### PR TITLE
feat: support @@map and @map (table & column renaming)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 coverage/
 *.tgz
 .DS_Store
+.vscode/
 
 # integration test temp projects
 .tmp-int-*/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 - [Setup in detail](#setup-in-detail)
 - [Runtime usage](#runtime-usage)
 - [Without the generator](#without-the-generator-manual-config)
+- [Renamed tables/columns (`@@map` / `@map`)](#renamed-tablescolumns-map--map)
 - [Shadow database](#shadow-database)
 - [Annotation reference](#annotation-reference)
 - [Troubleshooting](#troubleshooting)
@@ -174,6 +175,35 @@ All emitted SQL is idempotent (`IF NOT EXISTS`, `if_not_exists => TRUE`), so
 
 ## Runtime usage
 
+### Adding data
+
+A hypertable is an ordinary Prisma model, so you insert with the normal Prisma API — no
+special calls needed. TimescaleDB routes rows into the right time chunks automatically.
+
+```ts
+// single row
+await prisma.sensorReading.create({
+  data: { time: new Date(), deviceId: 1, temperature: 21.5 },
+});
+
+// bulk insert
+await prisma.sensorReading.createMany({
+  data: [
+    { time: new Date("2026-06-15T10:05:00Z"), deviceId: 1, temperature: 20 },
+    { time: new Date("2026-06-15T10:25:00Z"), deviceId: 1, temperature: 22 },
+    { time: new Date("2026-06-15T11:10:00Z"), deviceId: 1, temperature: 30 },
+  ],
+});
+```
+
+Continuous aggregates are populated by their refresh policy on a schedule; to materialize new
+rows immediately (e.g. right after a bulk insert, or in a test), refresh on demand:
+
+```ts
+await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+const hourly = await prisma.sensorHourly.findMany({ orderBy: { bucket: "desc" } });
+```
+
 ### Ad-hoc `time_bucket` queries
 
 ```ts
@@ -232,6 +262,52 @@ migrations: `createExtensionSql`, `createHypertableSql`, `createContinuousAggreg
 
 ---
 
+## Renamed tables/columns (`@@map` / `@map`)
+
+`@@map` (table) and `@map` (column) are fully supported. The generator reads the real
+database names from the DMMF and emits all SQL against them, while the runtime keeps
+accepting and returning **Prisma** field names — so nothing in your application code changes.
+
+```prisma
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime @map("ts")
+  deviceId    Int      @map("device_id")
+  temperature Float
+
+  @@id([deviceId, time])
+  @@map("sensor_readings")
+}
+```
+
+```ts
+// You still write Prisma field names; the runtime maps them to ts / device_id:
+await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  where: { deviceId: 1 },
+  groupBy: ["deviceId"],
+  aggregate: { avgTemp: { avg: "temperature" } },
+});
+```
+
+If you use the **manual config** (no generator), provide the DB names yourself:
+
+```ts
+timescaledb({
+  hypertables: [{
+    model: "SensorReading",                 // Prisma model name (drives prisma.sensorReading.*)
+    table: "sensor_readings",               // @@map table
+    column: "ts",                           // @map time column
+    columns: { deviceId: "device_id" },     // Prisma field -> DB column (where/groupBy/aggregate)
+  }],
+});
+```
+
+> Multi-schema (`@@schema`) is not yet supported — see [Limitations](#limitations-v01).
+
+---
+
 ## Shadow database
 
 `prisma migrate dev` / `migrate reset` validate migrations against a temporary **shadow
@@ -280,7 +356,9 @@ database) ships in this repo.
 
 - **`timeBucket` `where`** supports top-level equality only at runtime (typed with Prisma's
   full where input; throws on operators / nested filters).
-- **Table name must equal the model name** — `@@map` is not yet handled.
+- **`@@schema` (multiSchema)** is not yet handled — relations aren't schema-qualified, so
+  models must live in the default schema. (`@@map`/`@map` table & column renaming **is**
+  supported — see [Renamed tables/columns](#renamed-tablescolumns-map--map) below.)
 - **Integer-column aggregates:** `count` returns a JS `number`; `sum`/`avg` over integer
   columns may return a Postgres `bigint`/`numeric` while typed as `number`. Float columns
   behave as expected.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -33,9 +33,16 @@ interface UnsafeRawClient extends RawClient {
  * const prisma = new PrismaClient().$extends(timescaledb(registry));
  */
 export function timescaledb(config: TimescaleConfig = {}) {
-  const timeColumnByModel = new Map<string, string>(
-    (config.hypertables ?? []).map((h) => [h.table, h.column]),
-  );
+  // Key by Prisma model name (ctx.$name); values hold the resolved DB table + column map.
+  const hypertableByModel = new Map<string, { table: string; column: string; columns: Record<string, string> }>();
+  for (const h of config.hypertables ?? []) {
+    hypertableByModel.set(h.model ?? h.table, { table: h.table, column: h.column, columns: { ...(h.columns ?? {}) } });
+  }
+  // Prisma view model name -> DB view name, for refreshContinuousAggregate.
+  const caggViewByModel = new Map<string, string>();
+  for (const c of config.continuousAggregates ?? []) {
+    caggViewByModel.set(c.model ?? c.name, c.name);
+  }
 
   const timeBucket = async function (this: unknown, args: TimeBucketRuntimeArgs) {
     const ctx = Prisma.getExtensionContext(this);
@@ -43,15 +50,14 @@ export function timescaledb(config: TimescaleConfig = {}) {
     if (typeof model !== "string") {
       throw new Error("timeBucket: could not resolve the model name from the extension context.");
     }
-    const timeColumn = timeColumnByModel.get(model);
-    if (!timeColumn) {
+    const ht = hypertableByModel.get(model);
+    if (!ht) {
       throw new Error(
         `timeBucket: "${model}" is not a registered hypertable. Pass it via timescaledb({ hypertables: [...] }) or run the generator.`,
       );
     }
     assertInterval(args.bucket);
-    // v0.1 assumes table name == model name (no @@map handling yet).
-    const { sql, params } = buildTimeBucketQuery(model, timeColumn, args);
+    const { sql, params } = buildTimeBucketQuery(ht.table, ht.column, args, ht.columns);
     return (ctx.$parent as UnsafeRawClient).$queryRawUnsafe(sql, ...params);
   } as unknown as TimeBucketMethod;
 
@@ -62,7 +68,7 @@ export function timescaledb(config: TimescaleConfig = {}) {
         $allModels: { timeBucket },
       },
       client: {
-        $timescale: makeManage(client as unknown as RawClient),
+        $timescale: makeManage(client as unknown as RawClient, caggViewByModel),
       },
     }),
   );

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -15,16 +15,19 @@ export interface RefreshRange {
 export interface TimescaleManage {
   /**
    * Refresh a continuous aggregate over an optional time window (SPEC §4.3).
-   * The name is passed as a quoted identifier so mixed-case caggs resolve correctly
-   * (an unquoted name case-folds and fails — surfaced in the spike).
+   * Accepts the Prisma view model name; it is resolved to the DB view name (@@map) and passed
+   * as a quoted identifier so mixed-case caggs resolve correctly (an unquoted name case-folds
+   * and fails — surfaced in the spike).
    */
   refreshContinuousAggregate(name: string, range?: RefreshRange): Promise<void>;
 }
 
-export function makeManage(client: RawClient): TimescaleManage {
+/** @param viewByModel Prisma view model name -> DB view name (for @@map resolution). */
+export function makeManage(client: RawClient, viewByModel: ReadonlyMap<string, string> = new Map()): TimescaleManage {
   return {
     async refreshContinuousAggregate(name, range) {
-      assertSafeIdent(name, "continuous aggregate name");
+      const view = viewByModel.get(name) ?? name;
+      assertSafeIdent(view, "continuous aggregate name");
       // Open bounds (full refresh) must be a literal NULL, not a bound param: Postgres
       // can't infer the type of a NULL parameter for the function's "any" window args.
       const params: unknown[] = [];
@@ -33,7 +36,7 @@ export function makeManage(client: RawClient): TimescaleManage {
         params.push(value);
         return `$${params.length}`;
       };
-      const sql = `CALL refresh_continuous_aggregate('${quoteIdent(name)}', ${bound(range?.start)}, ${bound(range?.end)})`;
+      const sql = `CALL refresh_continuous_aggregate('${quoteIdent(view)}', ${bound(range?.start)}, ${bound(range?.end)})`;
       await client.$executeRawUnsafe(sql, ...params);
     },
   };

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -77,11 +77,16 @@ export interface TimeBucketRuntimeArgs {
   aggregate: Record<string, Record<string, string>>;
 }
 
-/** Build the parameterized time_bucket query. Identifiers are quoted; values are $-params. */
+/**
+ * Build the parameterized time_bucket query. Identifiers are quoted; values are $-params.
+ * `columns` maps Prisma field names (used in args) to DB column names (@map); output columns
+ * keep the Prisma field names so the inferred result row shape is unchanged.
+ */
 export function buildTimeBucketQuery(
   table: string,
   timeColumn: string,
   args: TimeBucketRuntimeArgs,
+  columns: Record<string, string> = {},
 ): { sql: string; params: unknown[] } {
   assertSafeIdent(table, "model table");
   assertSafeIdent(timeColumn, "time column");
@@ -89,6 +94,13 @@ export function buildTimeBucketQuery(
   if (!args.range || !(args.range.start instanceof Date) || !(args.range.end instanceof Date)) {
     throw new Error("timeBucket: `range.start` and `range.end` are required Dates.");
   }
+
+  // Resolve a Prisma field name to its DB column name (identity when not @map-renamed).
+  const col = (name: string): string => {
+    const dbName = columns[name] ?? name;
+    assertSafeIdent(dbName, "column");
+    return dbName;
+  };
 
   const params: unknown[] = [args.bucket, args.range.start, args.range.end];
   const time = quoteIdent(timeColumn);
@@ -98,7 +110,7 @@ export function buildTimeBucketQuery(
   const groupCols = args.groupBy ?? [];
   for (const g of groupCols) {
     assertSafeIdent(g, "groupBy column");
-    select.push(`${quoteIdent(g)} AS ${quoteIdent(g)}`);
+    select.push(`${quoteIdent(col(g))} AS ${quoteIdent(g)}`);
   }
 
   const aggregateEntries = Object.entries(args.aggregate ?? {});
@@ -113,12 +125,12 @@ export function buildTimeBucketQuery(
     if (!AGG_FNS.has(fn)) {
       throw new Error(`timeBucket: unsupported aggregate function "${fn}" for "${resultName}".`);
     }
-    assertSafeIdent(column, "aggregate source column");
+    const src = quoteIdent(col(column));
     // count -> ::int so it returns a JS number (Postgres count is bigint otherwise).
     select.push(
       fn === "count"
-        ? `count(${quoteIdent(column)})::int AS ${quoteIdent(resultName)}`
-        : `${fn}(${quoteIdent(column)}) AS ${quoteIdent(resultName)}`,
+        ? `count(${src})::int AS ${quoteIdent(resultName)}`
+        : `${fn}(${src}) AS ${quoteIdent(resultName)}`,
     );
   }
 
@@ -130,7 +142,7 @@ export function buildTimeBucketQuery(
     }
     assertSafeIdent(key, "where column");
     params.push(value);
-    where += ` AND ${quoteIdent(key)} = $${params.length}`;
+    where += ` AND ${quoteIdent(col(key))} = $${params.length}`;
   }
 
   const groupBy = [`"bucket"`, ...groupCols.map((g) => quoteIdent(g))].join(", ");

--- a/src/core/continuousAggregate.ts
+++ b/src/core/continuousAggregate.ts
@@ -22,7 +22,10 @@ export function createContinuousAggregateSql(config: CaggConfig): MigrationSql {
   assertSafeIdent(timeColumn, "time column");
   assertSafeIdent(bucketColumn, "bucket column");
   assertInterval(bucket);
-  groupBy.forEach((col) => assertSafeIdent(col, "groupBy column"));
+  groupBy.forEach((g) => {
+    assertSafeIdent(g.source, "groupBy source column");
+    assertSafeIdent(g.output, "groupBy output column");
+  });
 
   if (aggregates.length === 0) {
     throw new Error(`Continuous aggregate "${name}" must declare at least one aggregate.`);
@@ -40,11 +43,11 @@ export function createContinuousAggregateSql(config: CaggConfig): MigrationSql {
   // SELECT: time_bucket first, then group-by passthroughs, then the aggregates.
   const selectLines = [
     `time_bucket(${quoteLiteral(bucket)}, ${quoteIdent(timeColumn)}) AS ${quoteIdent(bucketColumn)}`,
-    ...groupBy.map((col) => `${quoteIdent(col)} AS ${quoteIdent(col)}`),
+    ...groupBy.map((g) => `${quoteIdent(g.source)} AS ${quoteIdent(g.output)}`),
     ...aggregates.map((a) => `${a.fn}(${quoteIdent(a.column)}) AS ${quoteIdent(a.name)}`),
   ];
 
-  const groupByCols = [bucketColumn, ...groupBy].map(quoteIdent).join(", ");
+  const groupByCols = [bucketColumn, ...groupBy.map((g) => g.output)].map(quoteIdent).join(", ");
 
   let up = `CREATE MATERIALIZED VIEW IF NOT EXISTS ${quoteIdent(name)}
   WITH (timescaledb.continuous) AS

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,24 +7,43 @@ export interface MigrationSql {
   down: string;
 }
 
-/** Hypertable conversion config (SPEC §1.1 / §2.2). */
+/** Hypertable conversion config (SPEC §1.1 / §2.2). All names are DB names (post-@@map). */
 export interface HypertableConfig {
-  /** Table/relation name as it exists in the DB, unquoted (e.g. "SensorReading"). */
+  /**
+   * Prisma model name, used by runtime helpers to resolve `prisma.<model>.timeBucket(...)`
+   * back to this config. Omitted when it equals `table` (no @@map); callers fall back to `table`.
+   */
+  model?: string;
+  /** Table/relation name as it exists in the DB, unquoted (the @@map name, or model name). */
   table: string;
-  /** Time partitioning column (e.g. "time"). */
+  /** Time partitioning column, as it exists in the DB (the @map name, or field name). */
   column: string;
   /** Chunk size; defaults to "7 days" when omitted. */
   chunkInterval?: Interval;
+  /**
+   * Map of Prisma field name -> DB column name, for runtime helpers that take Prisma field
+   * names (timeBucket where/groupBy/aggregate) and must emit DB column names. Omitted when
+   * there are no @map renames (callers fall back to identity).
+   */
+  columns?: Record<string, string>;
 }
 
-/** A single aggregate column in a continuous aggregate (SPEC §1.2). */
+/** A single aggregate column in a continuous aggregate (SPEC §1.2). DB names. */
 export interface AggregateSpec {
-  /** Result column name in the cagg view. */
+  /** Result column name in the cagg view, as Prisma reads it (the view field's DB name). */
   name: string;
   /** Aggregate function (v0.1 supported set). */
   fn: "avg" | "sum" | "min" | "max" | "count";
-  /** Source column the function is applied to. */
+  /** Source column the function is applied to, as it exists in the DB. */
   column: string;
+}
+
+/** A group-by passthrough: select the source DB column, alias it to the view's DB column. */
+export interface CaggGroupBy {
+  /** Source table column (DB name) to group by. */
+  source: string;
+  /** Output column in the view (the view field's DB name). */
+  output: string;
 }
 
 /** Continuous-aggregate refresh policy offsets (SPEC §1.2). */
@@ -36,7 +55,12 @@ export interface RefreshPolicy {
 
 /** Continuous aggregate config (SPEC §1.2 / §2.3). */
 export interface CaggConfig {
-  /** View name (e.g. "SensorHourly"). */
+  /**
+   * Prisma view model name, used by `$timescale.refreshContinuousAggregate(...)` to resolve
+   * the caller's name to the DB view. Omitted when it equals `name` (no @@map).
+   */
+  model?: string;
+  /** View name as it exists in the DB (the @@map name, or model name). */
   name: string;
   /** Source hypertable model name. */
   source: string;
@@ -44,10 +68,10 @@ export interface CaggConfig {
   bucket: Interval;
   /** Source time column the bucket is computed from. */
   timeColumn: string;
-  /** Output column name for the time_bucket expression (the view's `@timescale.bucket` field). */
+  /** Output column (view field DB name) for the time_bucket expression (`@timescale.bucket`). */
   bucketColumn: string;
-  /** Optional group-by columns (besides the bucket). */
-  groupBy?: string[];
+  /** Optional group-by passthroughs (besides the bucket). */
+  groupBy?: CaggGroupBy[];
   /** One or more aggregate columns. */
   aggregates: AggregateSpec[];
   /** Optional refresh policy; omitted means manual refresh only. */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -2,7 +2,7 @@
 // internal shapes (HypertableConfig / CaggConfig) and never touches `options.dmmf`. A Prisma
 // internal-API change should only require edits in this file.
 import type { DMMF } from "@prisma/generator-helper";
-import type { AggregateSpec, CaggConfig, HypertableConfig, RefreshPolicy } from "../core/types.js";
+import type { AggregateSpec, CaggConfig, CaggGroupBy, HypertableConfig, RefreshPolicy } from "../core/types.js";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import {
@@ -71,10 +71,15 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
   }
   if (chunkInterval !== undefined) assertInterval(chunkInterval);
 
+  const columns = columnMap(model);
+  const table = dbTable(model);
+
   return {
-    table: model.name,
-    column,
+    ...(model.name !== table ? { model: model.name } : {}),
+    table,
+    column: dbCol(field),
     ...(chunkInterval !== undefined ? { chunkInterval: chunkInterval as Interval } : {}),
+    ...(Object.keys(columns).length > 0 ? { columns } : {}),
   };
 }
 
@@ -105,9 +110,12 @@ function buildCagg(
     );
   }
 
-  // Field-level annotations on the view.
-  let bucketColumn: string | undefined;
-  const groupBy: string[] = [];
+  // Field-level annotations on the view. All names below are resolved to DB names: the
+  // view's output columns use the view fields' @map names; source refs use the source
+  // fields' @map names.
+  let bucketColumn: string | undefined; // view bucket field's DB name
+  let sawBucket = false;
+  const groupBy: CaggGroupBy[] = [];
   const aggregates: AggregateSpec[] = [];
 
   for (const field of view.fields) {
@@ -115,16 +123,18 @@ function buildCagg(
     const fctx = `@timescale field on "${view.name}.${field.name}"`;
 
     if (findAnnotation(fieldAnns, "bucket")) {
-      if (bucketColumn !== undefined) {
-        throw new Error(`${ctx}: more than one @timescale.bucket field ("${bucketColumn}" and "${field.name}").`);
+      if (sawBucket) {
+        throw new Error(`${ctx}: more than one @timescale.bucket field (second on "${field.name}").`);
       }
-      bucketColumn = field.name;
+      sawBucket = true;
+      bucketColumn = dbCol(field);
     }
     if (findAnnotation(fieldAnns, "groupBy")) {
-      if (!findScalarField(sourceModel, field.name)) {
+      const srcField = findScalarField(sourceModel, field.name);
+      if (!srcField) {
         throw new Error(`${fctx}: groupBy column "${field.name}" does not exist on source "${source}".`);
       }
-      groupBy.push(field.name);
+      groupBy.push({ source: dbCol(srcField), output: dbCol(field) });
     }
     const aggAnn = findAnnotation(fieldAnns, "aggregate");
     if (aggAnn) {
@@ -133,10 +143,11 @@ function buildCagg(
       if (!AGG_FNS.has(fn)) {
         throw new Error(`${fctx}: unsupported aggregate function "${fn}" (expected ${[...AGG_FNS].join(", ")}).`);
       }
-      if (!findScalarField(sourceModel, column)) {
+      const srcField = findScalarField(sourceModel, column);
+      if (!srcField) {
         throw new Error(`${fctx}: aggregate column "${column}" does not exist on source "${source}".`);
       }
-      aggregates.push({ name: field.name, fn, column });
+      aggregates.push({ name: dbCol(field), fn, column: dbCol(srcField) });
     }
   }
 
@@ -148,12 +159,14 @@ function buildCagg(
   }
 
   const refresh = buildRefresh(ann, ctx);
+  const viewName = dbTable(view);
 
   return {
-    name: view.name,
-    source,
+    ...(view.name !== viewName ? { model: view.name } : {}),
+    name: viewName,
+    source: dbTable(sourceModel),
     bucket: bucket as Interval,
-    timeColumn,
+    timeColumn: dbCol(timeField),
     bucketColumn,
     groupBy,
     aggregates,
@@ -180,4 +193,23 @@ function buildRefresh(ann: ReturnType<typeof parseAnnotations>[number], ctx: str
 
 function findScalarField(model: DMMF.Model, name: string): DMMF.Field | undefined {
   return model.fields.find((f) => f.name === name && f.kind === "scalar");
+}
+
+/** DB table name: the @@map value, or the model name. */
+function dbTable(model: DMMF.Model): string {
+  return model.dbName ?? model.name;
+}
+
+/** DB column name: the @map value, or the field name. */
+function dbCol(field: DMMF.Field): string {
+  return field.dbName ?? field.name;
+}
+
+/** Map of Prisma field name -> DB column name, for fields that were renamed via @map. */
+function columnMap(model: DMMF.Model): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const f of model.fields) {
+    if (f.kind === "scalar" && f.dbName) map[f.name] = f.dbName;
+  }
+  return map;
 }

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -39,7 +39,14 @@ export function ensureBuilt(): void {
   }
 }
 
-export async function startHarness(): Promise<Harness> {
+export interface HarnessOptions {
+  /** Override the model/view definitions (the generator/datasource header is always added). */
+  models?: string;
+  /** Override the Prisma CREATE TABLE migration SQL (must match the schema's DB names). */
+  initSql?: string;
+}
+
+export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> {
   ensureBuilt();
 
   const container = await new GenericContainer(IMAGE)
@@ -59,7 +66,7 @@ export async function startHarness(): Promise<Harness> {
   await runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow");
 
   const projectDir = mkdtempSync(join(REPO_ROOT, ".tmp-int-"));
-  scaffoldProject(projectDir);
+  scaffoldProject(projectDir, opts);
 
   const env = {
     ...process.env,
@@ -99,9 +106,9 @@ export async function startHarness(): Promise<Harness> {
 
 // --- scaffolding -----------------------------------------------------------
 
-function scaffoldProject(dir: string): void {
+function scaffoldProject(dir: string, opts: HarnessOptions): void {
   writeFileSync(join(dir, "prisma.config.ts"), PRISMA_CONFIG);
-  writeFileSync(join(dir, "schema.prisma"), schemaPrisma());
+  writeFileSync(join(dir, "schema.prisma"), schemaPrisma(opts.models ?? DEFAULT_MODELS));
 
   const migrations = join(dir, "migrations");
   mkdirSync(migrations, { recursive: true });
@@ -111,7 +118,7 @@ function scaffoldProject(dir: string): void {
   // extension (sorts first) and the hypertable+cagg objects (sorts last) at generate time.
   const init = join(migrations, "20260101000000_init");
   mkdirSync(init, { recursive: true });
-  writeFileSync(join(init, "migration.sql"), INIT_TABLE_SQL);
+  writeFileSync(join(init, "migration.sql"), opts.initSql ?? INIT_TABLE_SQL);
 }
 
 const PRISMA_CONFIG = `import "dotenv/config";
@@ -127,7 +134,7 @@ export default defineConfig({
 });
 `;
 
-function schemaPrisma(): string {
+function schemaPrisma(models: string): string {
   // provider is an absolute path to our built generator binary.
   const provider = GENERATOR_PROVIDER.replace(/\\/g, "/");
   return `generator client {
@@ -145,7 +152,10 @@ datasource db {
   provider = "postgresql"
 }
 
-/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+${models}`;
+}
+
+const DEFAULT_MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {
   time        DateTime
   deviceId    Int
@@ -164,7 +174,6 @@ view SensorHourly {
   @@unique([deviceId, bucket])
 }
 `;
-}
 
 const INIT_TABLE_SQL = `-- CreateTable
 CREATE TABLE "SensorReading" (

--- a/test/integration/mapped.test.ts
+++ b/test/integration/mapped.test.ts
@@ -1,0 +1,128 @@
+// End-to-end proof that @@map / @map work: a fully renamed schema (table "sensor_readings",
+// columns "ts"/"device_id", view "sensor_hourly", "avg_temp"). Proves the generator emits
+// DB-mapped SQL and the runtime resolves Prisma names -> DB names against real TimescaleDB.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime @map("ts")
+  deviceId    Int      @map("device_id")
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+  @@map("sensor_readings")
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time", refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" })
+view SensorHourly {
+  bucket   DateTime /// @timescale.bucket
+  deviceId Int      @map("device_id") /// @timescale.groupBy
+  avgTemp  Float    @map("avg_temp")  /// @timescale.aggregate(fn: "avg", column: "temperature")
+
+  @@unique([deviceId, bucket])
+  @@map("sensor_hourly")
+}
+`;
+
+const INIT_SQL = `-- CreateTable
+CREATE TABLE "sensor_readings" (
+    "ts" TIMESTAMP(3) NOT NULL,
+    "device_id" INTEGER NOT NULL,
+    "temperature" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "sensor_readings_pkey" PRIMARY KEY ("device_id","ts")
+);
+
+-- CreateIndex
+CREATE INDEX "sensor_readings_device_id_ts_idx" ON "sensor_readings"("device_id", "ts");
+`;
+
+describe.skipIf(!DOCKER_OK)("@@map / @map (generated migrations + runtime)", () => {
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+  });
+
+  afterAll(async () => {
+    await h?.stop();
+  });
+
+  it("creates the hypertable + cagg under their mapped DB names", async () => {
+    const [hyper] = await h.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM timescaledb_information.hypertables WHERE hypertable_name = 'sensor_readings'",
+    );
+    const [cagg] = await h.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM timescaledb_information.continuous_aggregates WHERE view_name = 'sensor_hourly'",
+    );
+    expect({ hypertables: hyper?.n, caggs: cagg?.n }).toEqual({ hypertables: 1, caggs: 1 });
+  });
+
+  it("inserts + reads through the mapped names via timeBucket, refresh and the cagg view", async () => {
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+
+    const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    const prisma = base.$extends(timescaledb(registry));
+
+    try {
+      await prisma.sensorReading.createMany({
+        data: [
+          { time: new Date("2026-06-15T10:05:00Z"), deviceId: 1, temperature: 20 },
+          { time: new Date("2026-06-15T10:25:00Z"), deviceId: 1, temperature: 22 },
+          { time: new Date("2026-06-15T10:45:00Z"), deviceId: 1, temperature: 24 },
+          { time: new Date("2026-06-15T11:10:00Z"), deviceId: 1, temperature: 30 },
+          { time: new Date("2026-06-15T10:15:00Z"), deviceId: 2, temperature: 15 },
+        ],
+      });
+
+      // Prisma field names in -> Prisma field names out, even though the DB uses ts/device_id.
+      const rows = await prisma.sensorReading.timeBucket({
+        bucket: "1 hour",
+        range: { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") },
+        where: { deviceId: 1 },
+        groupBy: ["deviceId"],
+        aggregate: { avgTemp: { avg: "temperature" } },
+      });
+      expect(
+        rows
+          .map((r: { bucket: Date; deviceId: number; avgTemp: number }) => ({
+            h: r.bucket.toISOString(),
+            d: r.deviceId,
+            avg: Number(r.avgTemp),
+          }))
+          .sort((a, b) => a.h.localeCompare(b.h)),
+      ).toEqual([
+        { h: "2026-06-15T10:00:00.000Z", d: 1, avg: 22 },
+        { h: "2026-06-15T11:00:00.000Z", d: 1, avg: 30 },
+      ]);
+
+      // Model name "SensorHourly" resolves to the DB view "sensor_hourly".
+      await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+      const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });
+      expect(
+        hourly.map((r: { deviceId: number; avgTemp: number }) => ({ d: r.deviceId, avg: Number(r.avgTemp) })),
+      ).toEqual([{ d: 1, avg: 22 }, { d: 1, avg: 30 }, { d: 2, avg: 15 }]);
+    } finally {
+      await base.$disconnect();
+    }
+  });
+});

--- a/test/integration/mapped.test.ts
+++ b/test/integration/mapped.test.ts
@@ -17,6 +17,12 @@ const DOCKER_OK = (() => {
   }
 })();
 
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED: Docker is not available. The @@map/@map reset-safety + runtime checks are NOT verified.\n",
+  );
+}
+
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {
   time        DateTime @map("ts")
@@ -66,6 +72,18 @@ describe.skipIf(!DOCKER_OK)("@@map / @map (generated migrations + runtime)", () 
   });
 
   it("creates the hypertable + cagg under their mapped DB names", async () => {
+    const [hyper] = await h.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM timescaledb_information.hypertables WHERE hypertable_name = 'sensor_readings'",
+    );
+    const [cagg] = await h.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM timescaledb_information.continuous_aggregates WHERE view_name = 'sensor_hourly'",
+    );
+    expect({ hypertables: hyper?.n, caggs: cagg?.n }).toEqual({ hypertables: 1, caggs: 1 });
+  });
+
+  it("reproduces the mapped hypertable + cagg after migrate reset", async () => {
+    // reset drops the DB and replays all migrations (re-running our deterministic generator).
+    h.prisma(["migrate", "reset", "--force"]);
     const [hyper] = await h.query<{ n: number }>(
       "SELECT count(*)::int AS n FROM timescaledb_information.hypertables WHERE hypertable_name = 'sensor_readings'",
     );

--- a/test/types/readme-examples.test-d.ts
+++ b/test/types/readme-examples.test-d.ts
@@ -15,6 +15,14 @@ const extension = timescaledb({
 });
 void extension;
 
+// Manual config with @@map / @map renaming — must type-check.
+const mapped = timescaledb({
+  hypertables: [
+    { model: "SensorReading", table: "sensor_readings", column: "ts", columns: { deviceId: "device_id" } },
+  ],
+});
+void mapped;
+
 // Core SQL builders exported from "prisma-extension-timescaledb/core".
 const ext: MigrationSql = createExtensionSql();
 const hyper: MigrationSql = createHypertableSql({ table: "SensorReading", column: "time", chunkInterval: "1 day" });
@@ -24,7 +32,7 @@ const cagg: MigrationSql = createContinuousAggregateSql({
   bucket: "1 hour",
   timeColumn: "time",
   bucketColumn: "bucket",
-  groupBy: ["deviceId"],
+  groupBy: [{ source: "deviceId", output: "deviceId" }],
   aggregates: [{ name: "avgTemp", fn: "avg", column: "temperature" }],
   refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" },
 });

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -58,7 +58,7 @@ describe("createContinuousAggregateSql", () => {
     bucket: "1 hour",
     timeColumn: "time",
     bucketColumn: "bucket",
-    groupBy: ["deviceId"],
+    groupBy: [{ source: "deviceId", output: "deviceId" }],
     aggregates: [
       { name: "avgTemp", fn: "avg", column: "temperature" },
       { name: "maxTemp", fn: "max", column: "temperature" },

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -58,7 +58,7 @@ view SensorHourly {
         bucket: "1 hour",
         timeColumn: "time",
         bucketColumn: "bucket",
-        groupBy: ["deviceId"],
+        groupBy: [{ source: "deviceId", output: "deviceId" }],
         aggregates: [
           { name: "avgTemp", fn: "avg", column: "temperature" },
           { name: "maxTemp", fn: "max", column: "temperature" },
@@ -212,5 +212,51 @@ ${body}
           `  bucket  DateTime /// @timescale.bucket\n  avgTemp Float /// @timescale.aggregate(fn: "avg", column: "temperature")\n  @@unique([bucket])`),
       ),
     ).rejects.toThrow(/source "SensorReading" must also be annotated with @timescale.hypertable/);
+  });
+});
+
+describe("extractTimescaleSchema — @@map / @map", () => {
+  it("resolves table/column names to DB names and records the column map", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime @map("ts")
+  deviceId    Int      @map("device_id")
+  temperature Float
+  @@id([deviceId, time])
+  @@map("sensor_readings")
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket   DateTime /// @timescale.bucket
+  deviceId Int      @map("device_id") /// @timescale.groupBy
+  avgTemp  Float    @map("avg_temp")  /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([deviceId, bucket])
+  @@map("sensor_hourly")
+}
+`);
+
+    expect(result.hypertables).toEqual([
+      {
+        model: "SensorReading",
+        table: "sensor_readings",
+        column: "ts",
+        chunkInterval: "1 day",
+        columns: { time: "ts", deviceId: "device_id" },
+      },
+    ]);
+    expect(result.continuousAggregates).toEqual([
+      {
+        model: "SensorHourly",
+        name: "sensor_hourly",
+        source: "sensor_readings",
+        bucket: "1 hour",
+        timeColumn: "ts",
+        bucketColumn: "bucket",
+        groupBy: [{ source: "device_id", output: "device_id" }],
+        aggregates: [{ name: "avg_temp", fn: "avg", column: "temperature" }],
+      },
+    ]);
   });
 });

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -159,7 +159,10 @@ describe("emitTypes", () => {
             "timeColumn": "time",
             "bucketColumn": "bucket",
             "groupBy": [
-              "deviceId"
+              {
+                "source": "deviceId",
+                "output": "deviceId"
+              }
             ],
             "aggregates": [
               {

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -42,4 +42,11 @@ describe("makeManage.refreshContinuousAggregate", () => {
     const { client } = fakeClient();
     await expect(makeManage(client).refreshContinuousAggregate("bad name")).rejects.toThrow(/Invalid/);
   });
+
+  it("resolves the Prisma view model name to its @@map DB view name", async () => {
+    const { client, calls } = fakeClient();
+    const viewByModel = new Map([["SensorHourly", "sensor_hourly"]]);
+    await makeManage(client, viewByModel).refreshContinuousAggregate("SensorHourly");
+    expect(calls[0]!.sql).toBe(`CALL refresh_continuous_aggregate('"sensor_hourly"', NULL, NULL)`);
+  });
 });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -38,6 +38,22 @@ describe("buildTimeBucketQuery", () => {
     );
   });
 
+  it("resolves @map columns to DB names while aliasing results to Prisma field names", () => {
+    const { sql, params } = buildTimeBucketQuery(
+      "sensor_readings",
+      "ts",
+      { ...base, groupBy: ["deviceId"], where: { deviceId: 1 } },
+      { deviceId: "device_id", time: "ts" },
+    );
+    expect(sql).toContain(`FROM "sensor_readings"`);
+    expect(sql).toContain(`time_bucket($1, "ts") AS "bucket"`);
+    expect(sql).toContain(`"device_id" AS "deviceId"`); // DB column selected, Prisma name aliased
+    expect(sql).toContain(`avg("temperature") AS "avgTemp"`); // unmapped column = identity
+    expect(sql).toContain(`AND "device_id" = $4`); // where key resolved to DB column
+    expect(sql).toContain(`GROUP BY "bucket", "deviceId"`); // group by the output alias
+    expect(params).toEqual(["1 hour", range.start, range.end, 1]);
+  });
+
   it("throws when range bounds are missing", () => {
     expect(() =>
       buildTimeBucketQuery("SensorReading", "time", { bucket: "1 hour", aggregate: base.aggregate } as TimeBucketRuntimeArgs),


### PR DESCRIPTION
Fixes the v0.1 limitation *"table name must equal the model name — `@@map` is not yet handled."*

## What
`@@map` (table) and `@map` (column) are now fully supported across the generator and the
runtime. You keep writing **Prisma** field names everywhere in app code; the package
resolves them to the real DB names.

## How
- **Generator** (`dmmf.ts`) resolves every reference to `dbName ?? name`: hypertable table +
  time column, and the cagg's view name, source table, time column, group-by passthroughs,
  and aggregate columns. `CaggConfig.groupBy` now carries `{source, output}` (select the
  source DB column, alias it to the view's DB column). The registry gains a per-hypertable
  `columns` map (Prisma field → DB column) and a `model` field for runtime lookup.
- **Runtime** — `timeBucket` looks up the hypertable by Prisma model name, emits DB column
  names, and aliases results back to Prisma field names (so the inferred result row is
  unchanged). `$timescale.refreshContinuousAggregate("SensorHourly")` resolves the model
  name → DB view name.

## Tests
- Unit: DMMF resolution, builder `{source, output}` group-by, `timeBucket` column resolution, `refresh` name resolution.
- **Integration**: a fully renamed schema (`sensor_readings` / `ts` / `device_id` / `sensor_hourly` / `avg_temp`) — migrate + `timeBucket` + refresh + cagg read end-to-end on real TimescaleDB.

## Docs
- New **Adding data** section (insert + refresh + read).
- New **Renamed tables/columns** section.
- `@@schema` (multiSchema) documented as the remaining mapping limitation (the `model.schema` hook is ready for a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for renamed hypertables/columns using `@@map` and `@map`, including correct runtime mapping for `timeBucket` queries and continuous aggregate refresh.
  * Improved continuous aggregate SQL generation to support explicit group-by input/output column mappings.

* **Documentation**
  * Expanded guide for `@@map` / `@map`, including “Adding data” examples, on-demand continuous aggregate refresh, and clarified limitations (multi-schema not supported).

* **Bug Fixes**
  * Fixed continuous aggregate refresh to correctly resolve and quote mapped view identifiers.

* **Tests**
  * Added end-to-end and unit coverage for mapped renaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->