### PR TITLE
feat: support Prisma where operators in timeBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ const hourly = await prisma.sensorHourly.findMany({ orderBy: { bucket: "desc" } 
 const rows = await prisma.sensorReading.timeBucket({
   bucket: "1 hour",
   range: { start, end },          // both bounds required
-  where: { deviceId: 1 },         // top-level equality (v0.1)
+  where: {                        // Prisma where operators + AND/OR/NOT
+    deviceId: { in: [1, 2] },
+    temperature: { gte: 20, lt: 35 },
+  },
   groupBy: ["deviceId"],
   aggregate: {
     avgTemp: { avg: "temperature" },
@@ -354,8 +357,10 @@ database) ships in this repo.
 
 ## Limitations (v0.1)
 
-- **`timeBucket` `where`** supports top-level equality only at runtime (typed with Prisma's
-  full where input; throws on operators / nested filters).
+- **`timeBucket` `where`** supports scalar operators (`equals`, `not`, `in`, `notIn`, `lt`,
+  `lte`, `gt`, `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null`
+  checks, and `AND`/`OR`/`NOT`. **Relation filters** (`some`/`none`/`every`) and nested
+  `not: { ... }` are not supported (they can't be a single-table query) and throw a clear error.
 - **`@@schema` (multiSchema)** is not yet handled — relations aren't schema-qualified, so
   models must live in the default schema. (`@@map`/`@map` table & column renaming **is**
   supported — see [Renamed tables/columns](#renamed-tablescolumns-map--map) below.)

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@prisma/client/extension";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import { assertSafeIdent, quoteIdent } from "../core/sql.js";
+import { whereToSql } from "./where.js";
 
 // --- type machinery --------------------------------------------------------
 
@@ -135,15 +136,14 @@ export function buildTimeBucketQuery(
   }
 
   let where = `${time} >= $2 AND ${time} < $3`;
-  for (const [key, value] of Object.entries(args.where ?? {})) {
-    if (value === undefined) continue; // unset key — treat as "no filter" (Prisma semantics)
-    if (value === null || typeof value === "object") {
-      throw new Error(`timeBucket: \`where\` supports top-level equality only in v0.1 (got non-primitive for "${key}").`);
-    }
-    assertSafeIdent(key, "where column");
-    params.push(value);
-    where += ` AND ${quoteIdent(col(key))} = $${params.length}`;
-  }
+  const whereSql = whereToSql(args.where, {
+    col: (name) => quoteIdent(col(name)),
+    push: (value) => {
+      params.push(value);
+      return `$${params.length}`;
+    },
+  });
+  if (whereSql) where += ` AND (${whereSql})`;
 
   const groupBy = [`"bucket"`, ...groupCols.map((g) => quoteIdent(g))].join(", ");
   const sql = `SELECT ${select.join(", ")} FROM ${quoteIdent(table)} WHERE ${where} GROUP BY ${groupBy} ORDER BY "bucket"`;

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -1,0 +1,145 @@
+// Translate a Prisma `where` input into a parameterized SQL boolean expression for the
+// single-table timeBucket query. Values are always bound as parameters; column names are
+// resolved + identifier-checked by the caller, so the result is injection-safe.
+//
+// Supported: equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith
+// (+ mode: "insensitive"), null checks, shorthand equality, and AND / OR / NOT.
+// Unsupported (throws): relation filters (some/none/every), nested `not: {...}`, and any
+// operator not in the list above.
+
+export interface WhereCtx {
+  /** Resolve a Prisma field name to a quoted DB column (e.g. `deviceId` -> `"device_id"`). */
+  col: (field: string) => string;
+  /** Bind a value as a parameter and return its placeholder (e.g. `$4`). */
+  push: (value: unknown) => string;
+}
+
+const SUPPORTED = "equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith";
+
+/** Build a SQL boolean expression from a Prisma where input. Returns "" when there is no filter. */
+export function whereToSql(where: Record<string, unknown> | undefined, ctx: WhereCtx): string {
+  if (!where) return "";
+  const clauses: string[] = [];
+  for (const [key, value] of Object.entries(where)) {
+    if (value === undefined) continue;
+    if (key === "AND") {
+      const s = combine(asArray(value), ctx, "AND");
+      if (s) clauses.push(s);
+    } else if (key === "OR") {
+      const s = combine(asArray(value), ctx, "OR");
+      if (s) clauses.push(s);
+    } else if (key === "NOT") {
+      const s = combine(asArray(value), ctx, "AND");
+      if (s) clauses.push(`NOT (${s})`);
+    } else {
+      const s = fieldClause(key, value, ctx);
+      if (s) clauses.push(s);
+    }
+  }
+  return clauses.join(" AND ");
+}
+
+function combine(wheres: unknown[], ctx: WhereCtx, op: "AND" | "OR"): string {
+  const parts = wheres.map((w) => whereToSql(w as Record<string, unknown>, ctx)).filter(Boolean);
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return parts[0]!;
+  return `(${parts.join(` ${op} `)})`;
+}
+
+function fieldClause(field: string, value: unknown, ctx: WhereCtx): string {
+  const c = ctx.col(field);
+  if (value === null) return `${c} IS NULL`;
+  if (isScalar(value)) return `${c} = ${ctx.push(value)}`;
+  if (Array.isArray(value)) {
+    throw new Error(`timeBucket: unsupported array filter on "${field}".`);
+  }
+
+  const filter = value as Record<string, unknown>;
+  const mode = filter["mode"] === "insensitive" ? "insensitive" : undefined;
+  const parts: string[] = [];
+  for (const [op, v] of Object.entries(filter)) {
+    if (v === undefined || op === "mode") continue;
+    parts.push(operatorClause(c, field, op, v, mode, ctx));
+  }
+  return parts.join(" AND ");
+}
+
+function operatorClause(
+  col: string,
+  field: string,
+  op: string,
+  v: unknown,
+  mode: "insensitive" | undefined,
+  ctx: WhereCtx,
+): string {
+  switch (op) {
+    case "equals":
+      return v === null ? `${col} IS NULL` : `${col} = ${ctx.push(scalar(v, field, op))}`;
+    case "not":
+      if (v === null) return `${col} IS NOT NULL`;
+      if (isScalar(v)) return `${col} <> ${ctx.push(v)}`;
+      throw new Error(`timeBucket: nested "not" filter on "${field}" is not supported.`);
+    case "in":
+      return inClause(col, v, false, field, ctx);
+    case "notIn":
+      return inClause(col, v, true, field, ctx);
+    case "lt":
+      return `${col} < ${ctx.push(scalar(v, field, op))}`;
+    case "lte":
+      return `${col} <= ${ctx.push(scalar(v, field, op))}`;
+    case "gt":
+      return `${col} > ${ctx.push(scalar(v, field, op))}`;
+    case "gte":
+      return `${col} >= ${ctx.push(scalar(v, field, op))}`;
+    case "contains":
+    case "startsWith":
+    case "endsWith":
+      return likeClause(col, op, v, mode, field, ctx);
+    default:
+      throw new Error(
+        `timeBucket: unsupported where operator "${op}" on "${field}" (supported: ${SUPPORTED}; relation filters are not supported).`,
+      );
+  }
+}
+
+function inClause(col: string, v: unknown, negate: boolean, field: string, ctx: WhereCtx): string {
+  if (!Array.isArray(v)) {
+    throw new Error(`timeBucket: "${negate ? "notIn" : "in"}" on "${field}" requires an array.`);
+  }
+  if (v.length === 0) return negate ? "true" : "false";
+  const list = v.map((x) => ctx.push(x)).join(", ");
+  return `${col} ${negate ? "NOT IN" : "IN"} (${list})`;
+}
+
+function likeClause(
+  col: string,
+  kind: "contains" | "startsWith" | "endsWith",
+  v: unknown,
+  mode: "insensitive" | undefined,
+  field: string,
+  ctx: WhereCtx,
+): string {
+  if (typeof v !== "string") {
+    throw new Error(`timeBucket: "${kind}" on "${field}" requires a string.`);
+  }
+  // Escape LIKE wildcards/escape char in the user value; the pattern is bound as a param.
+  const escaped = v.replace(/([\\%_])/g, "\\$1");
+  const pattern = kind === "contains" ? `%${escaped}%` : kind === "startsWith" ? `${escaped}%` : `%${escaped}`;
+  const operator = mode === "insensitive" ? "ILIKE" : "LIKE";
+  return `${col} ${operator} ${ctx.push(pattern)} ESCAPE '\\'`;
+}
+
+function isScalar(v: unknown): boolean {
+  return v instanceof Date || typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "bigint";
+}
+
+function scalar(v: unknown, field: string, op: string): unknown {
+  if (v === null || !isScalar(v)) {
+    throw new Error(`timeBucket: "${op}" on "${field}" requires a scalar value.`);
+  }
+  return v;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -41,7 +41,9 @@ export function whereToSql(where: Record<string, unknown> | undefined, ctx: Wher
 
 function combine(wheres: unknown[], ctx: WhereCtx, op: "AND" | "OR"): string {
   const parts = wheres.map((w) => whereToSql(w as Record<string, unknown>, ctx)).filter(Boolean);
-  if (parts.length === 0) return "";
+  // Prisma semantics: an empty OR matches nothing; an empty AND (also used for NOT) imposes
+  // no constraint.
+  if (parts.length === 0) return op === "OR" ? "false" : "";
   if (parts.length === 1) return parts[0]!;
   return `(${parts.join(` ${op} `)})`;
 }

--- a/test/integration/reset-safety.test.ts
+++ b/test/integration/reset-safety.test.ts
@@ -106,6 +106,23 @@ describe.skipIf(!DOCKER_OK)("reset-safety (generated migrations)", () => {
         { h: "2026-06-15T10:00:00.000Z", d: 2, avg: 15, n: 1 },
       ]);
 
+      // where operators: device 1 AND temperature >= 21 (excludes the 20.0 reading).
+      const filtered = await prisma.sensorReading.timeBucket({
+        bucket: "1 hour",
+        range: { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") },
+        where: { AND: [{ deviceId: { in: [1] } }, { temperature: { gte: 21 } }] },
+        groupBy: ["deviceId"],
+        aggregate: { n: { count: "temperature" } },
+      });
+      expect(
+        filtered
+          .map((r: { bucket: Date; n: number }) => ({ h: r.bucket.toISOString(), n: Number(r.n) }))
+          .sort((a, b) => a.h.localeCompare(b.h)),
+      ).toEqual([
+        { h: "2026-06-15T10:00:00.000Z", n: 2 }, // 22 + 24 (20 excluded by >= 21)
+        { h: "2026-06-15T11:00:00.000Z", n: 1 }, // 30
+      ]);
+
       // Refresh the continuous aggregate, then read it as a normal typed Prisma view.
       await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -22,7 +22,7 @@ describe("buildTimeBucketQuery", () => {
 
   it("appends equality filters as bound params", () => {
     const { sql, params } = buildTimeBucketQuery("SensorReading", "time", { ...base, where: { deviceId: 1 } });
-    expect(sql).toContain(`AND "deviceId" = $4`);
+    expect(sql).toContain(`AND ("deviceId" = $4)`);
     expect(params).toEqual(["1 hour", range.start, range.end, 1]);
   });
 
@@ -32,10 +32,19 @@ describe("buildTimeBucketQuery", () => {
     expect(params).toEqual(["1 hour", range.start, range.end]);
   });
 
-  it("throws on non-primitive where values (operators not supported in v0.1)", () => {
-    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, where: { deviceId: { gte: 1 } } })).toThrow(
-      /equality only/,
-    );
+  it("supports comparison operators in where (parameterized)", () => {
+    const { sql, params } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      where: { deviceId: { in: [1, 2] }, temperature: { gte: 20 } },
+    });
+    expect(sql).toContain(`AND ("deviceId" IN ($4, $5) AND "temperature" >= $6)`);
+    expect(params).toEqual(["1 hour", range.start, range.end, 1, 2, 20]);
+  });
+
+  it("throws on an unsupported where operator", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, where: { deviceId: { foo: 1 } } }),
+    ).toThrow(/unsupported where operator/);
   });
 
   it("resolves @map columns to DB names while aliasing results to Prisma field names", () => {
@@ -49,7 +58,7 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`time_bucket($1, "ts") AS "bucket"`);
     expect(sql).toContain(`"device_id" AS "deviceId"`); // DB column selected, Prisma name aliased
     expect(sql).toContain(`avg("temperature") AS "avgTemp"`); // unmapped column = identity
-    expect(sql).toContain(`AND "device_id" = $4`); // where key resolved to DB column
+    expect(sql).toContain(`AND ("device_id" = $4)`); // where key resolved to DB column
     expect(sql).toContain(`GROUP BY "bucket", "deviceId"`); // group by the output alias
     expect(params).toEqual(["1 hour", range.start, range.end, 1]);
   });

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { whereToSql, type WhereCtx } from "../../src/client/where.js";
+
+function harness() {
+  const params: unknown[] = [];
+  const ctx: WhereCtx = {
+    col: (f) => `"${f}"`,
+    push: (v) => {
+      params.push(v);
+      return `$${params.length}`;
+    },
+  };
+  return { ctx, params };
+}
+
+describe("whereToSql", () => {
+  it("returns empty for undefined / {}", () => {
+    expect(whereToSql(undefined, harness().ctx)).toBe("");
+    expect(whereToSql({}, harness().ctx)).toBe("");
+  });
+
+  it("shorthand equality binds the value", () => {
+    const { ctx, params } = harness();
+    expect(whereToSql({ deviceId: 1 }, ctx)).toBe(`"deviceId" = $1`);
+    expect(params).toEqual([1]);
+  });
+
+  it("null -> IS NULL", () => {
+    expect(whereToSql({ label: null }, harness().ctx)).toBe(`"label" IS NULL`);
+  });
+
+  it("comparison operators on one field AND together", () => {
+    const { ctx, params } = harness();
+    expect(whereToSql({ temperature: { gte: 20, lt: 30 } }, ctx)).toBe(`"temperature" >= $1 AND "temperature" < $2`);
+    expect(params).toEqual([20, 30]);
+  });
+
+  it("in / notIn", () => {
+    const a = harness();
+    expect(whereToSql({ deviceId: { in: [1, 2, 3] } }, a.ctx)).toBe(`"deviceId" IN ($1, $2, $3)`);
+    expect(a.params).toEqual([1, 2, 3]);
+    expect(whereToSql({ deviceId: { notIn: [9] } }, harness().ctx)).toBe(`"deviceId" NOT IN ($1)`);
+  });
+
+  it("empty in -> false, empty notIn -> true", () => {
+    expect(whereToSql({ deviceId: { in: [] } }, harness().ctx)).toBe("false");
+    expect(whereToSql({ deviceId: { notIn: [] } }, harness().ctx)).toBe("true");
+  });
+
+  it("not value / not null", () => {
+    expect(whereToSql({ deviceId: { not: 5 } }, harness().ctx)).toBe(`"deviceId" <> $1`);
+    expect(whereToSql({ label: { not: null } }, harness().ctx)).toBe(`"label" IS NOT NULL`);
+  });
+
+  it("string contains/startsWith/endsWith escape wildcards; mode -> ILIKE", () => {
+    const a = harness();
+    expect(whereToSql({ label: { contains: "a%b" } }, a.ctx)).toBe(`"label" LIKE $1 ESCAPE '\\'`);
+    expect(a.params).toEqual(["%a\\%b%"]);
+    const b = harness();
+    expect(whereToSql({ label: { startsWith: "x", mode: "insensitive" } }, b.ctx)).toBe(`"label" ILIKE $1 ESCAPE '\\'`);
+    expect(b.params).toEqual(["x%"]);
+    expect(whereToSql({ label: { endsWith: "z" } }, harness().ctx)).toBe(`"label" LIKE $1 ESCAPE '\\'`);
+  });
+
+  it("AND / OR / NOT", () => {
+    expect(whereToSql({ AND: [{ deviceId: 1 }, { temperature: { gte: 20 } }] }, harness().ctx)).toBe(
+      `("deviceId" = $1 AND "temperature" >= $2)`,
+    );
+    expect(whereToSql({ OR: [{ deviceId: 1 }, { deviceId: 2 }] }, harness().ctx)).toBe(
+      `("deviceId" = $1 OR "deviceId" = $2)`,
+    );
+    expect(whereToSql({ NOT: { deviceId: 1 } }, harness().ctx)).toBe(`NOT ("deviceId" = $1)`);
+  });
+
+  it("multiple top-level fields AND together", () => {
+    expect(whereToSql({ deviceId: 1, temperature: { gt: 0 } }, harness().ctx)).toBe(
+      `"deviceId" = $1 AND "temperature" > $2`,
+    );
+  });
+
+  it("throws on unsupported operator, relation filter, and nested not", () => {
+    expect(() => whereToSql({ deviceId: { foo: 1 } }, harness().ctx)).toThrow(/unsupported where operator "foo"/);
+    expect(() => whereToSql({ author: { some: {} } }, harness().ctx)).toThrow(/unsupported where operator "some"/);
+    expect(() => whereToSql({ deviceId: { not: { gt: 1 } } }, harness().ctx)).toThrow(/nested "not"/);
+  });
+});

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -72,6 +72,12 @@ describe("whereToSql", () => {
     expect(whereToSql({ NOT: { deviceId: 1 } }, harness().ctx)).toBe(`NOT ("deviceId" = $1)`);
   });
 
+  it("empty OR matches nothing (false); empty AND / NOT impose no constraint", () => {
+    expect(whereToSql({ OR: [] }, harness().ctx)).toBe("false");
+    expect(whereToSql({ AND: [] }, harness().ctx)).toBe("");
+    expect(whereToSql({ NOT: [] }, harness().ctx)).toBe("");
+  });
+
   it("multiple top-level fields AND together", () => {
     expect(whereToSql({ deviceId: 1, temperature: { gt: 0 } }, harness().ctx)).toBe(
       `"deviceId" = $1 AND "temperature" > $2`,


### PR DESCRIPTION
Resolves the v0.1 limitation that `timeBucket`'s `where` only supported top-level equality.

## What
`timeBucket({ where })` now accepts the common Prisma `where` operators and translates them
to **parameterized** SQL:
- Comparison: `equals`, `not`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`
- String: `contains`, `startsWith`, `endsWith` (+ `mode: "insensitive"` → `ILIKE`), with wildcard escaping
- `null` checks (`IS NULL` / `IS NOT NULL`), shorthand equality, and logical `AND` / `OR` / `NOT`

**Unsupported → clear error:** relation filters (`some`/`none`/`every`), nested `not: {...}`,
and any unknown operator (they can't be a single-table raw query).

## Safety
Values are always bound as `$n` parameters; column names resolve through the `@map` column
map and are identifier-checked; `LIKE` patterns escape `%`/`_`/`\` with an `ESCAPE` clause.

## Tests
- **Unit** (`where.test.ts`): every operator, `AND`/`OR`/`NOT`, `null`, empty `in`/`notIn`, wildcard escaping, and the error cases.
- **Integration**: a real `timeBucket` query with `deviceId IN [1] AND temperature >= 21` against TimescaleDB, asserting the filtered counts.

## Docs
- `timeBucket` example now shows operators.
- Limitations updated: `where` documents the supported operator set; relation filters noted as unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `timeBucket` filtering: `where` now supports scalar operators (`in`, `lt/lte/gt/gte`), null checks, and logical composition (`AND`/`OR`/`NOT`) for more flexible queries.

* **Documentation**
  * Updated `timeBucket` examples and limitations to reflect the expanded `where` capabilities and clearly state unsupported options (relation filters and nested `not`), with a clear error.

* **Tests**
  * Expanded unit and integration coverage to validate SQL generation and correct filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->