### PR TITLE
feat: return timeBucket sum/avg as JS numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,10 @@ database) ships in this repo.
 - **`@@schema` (multiSchema)** is not yet handled — relations aren't schema-qualified, so
   models must live in the default schema. (`@@map`/`@map` table & column renaming **is**
   supported — see [Renamed tables/columns](#renamed-tablescolumns-map--map) below.)
-- **Integer-column aggregates:** `count` returns a JS `number`; `sum`/`avg` over integer
-  columns may return a Postgres `bigint`/`numeric` while typed as `number`. Float columns
-  behave as expected.
+- **`timeBucket` numeric precision:** results come back as JS `number`s — `count` is cast to
+  `int`, and `sum`/`avg` to `double precision` so integer-column aggregates aren't returned as
+  `BigInt`/`Decimal`. Caveat: `sum`/`avg` are therefore float64, so a `sum` beyond 2^53 loses
+  exactness. (Continuous-aggregate columns use the type you declare on the `view` model.)
 - Continuous aggregates must be declared as Prisma `view`s with `@@unique` (not `@@id`).
 
 ---

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -127,12 +127,20 @@ export function buildTimeBucketQuery(
       throw new Error(`timeBucket: unsupported aggregate function "${fn}" for "${resultName}".`);
     }
     const src = quoteIdent(col(column));
-    // count -> ::int so it returns a JS number (Postgres count is bigint otherwise).
-    select.push(
-      fn === "count"
-        ? `count(${src})::int AS ${quoteIdent(resultName)}`
-        : `${fn}(${src}) AS ${quoteIdent(resultName)}`,
-    );
+    const alias = quoteIdent(resultName);
+    // Cast so results come back as JS numbers (matching the typed `number` result), instead
+    // of Prisma's BigInt/Decimal for integer-column aggregates:
+    //   count -> ::int        (Postgres count is bigint)
+    //   sum/avg -> ::float8    (sum of int is bigint; avg of int is numeric)
+    // min/max already return the column's own (numeric) type. NB: float8 means sums beyond
+    // 2^53 lose exactness — acceptable for the `number` contract.
+    if (fn === "count") {
+      select.push(`count(${src})::int AS ${alias}`);
+    } else if (fn === "sum" || fn === "avg") {
+      select.push(`${fn}(${src})::double precision AS ${alias}`);
+    } else {
+      select.push(`${fn}(${src}) AS ${alias}`);
+    }
   }
 
   let where = `${time} >= $2 AND ${time} < $3`;

--- a/test/integration/reset-safety.test.ts
+++ b/test/integration/reset-safety.test.ts
@@ -123,6 +123,18 @@ describe.skipIf(!DOCKER_OK)("reset-safety (generated migrations)", () => {
         { h: "2026-06-15T11:00:00.000Z", n: 1 }, // 30
       ]);
 
+      // sum/avg over an INTEGER column (deviceId) must come back as JS numbers, not
+      // BigInt/Decimal. deviceId across all 5 rows = [1,1,1,1,2] -> sum 6, avg 1.2.
+      const [agg] = await prisma.sensorReading.timeBucket({
+        bucket: "1 day",
+        range: { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") },
+        aggregate: { sumDev: { sum: "deviceId" }, avgDev: { avg: "deviceId" } },
+      });
+      expect(typeof agg.sumDev).toBe("number");
+      expect(typeof agg.avgDev).toBe("number");
+      expect(agg.sumDev).toBe(6);
+      expect(agg.avgDev).toBeCloseTo(1.2);
+
       // Refresh the continuous aggregate, then read it as a normal typed Prisma view.
       await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -12,12 +12,22 @@ describe("buildTimeBucketQuery", () => {
   it("builds a parameterized query with quoted identifiers, count::int, and no relation cast", () => {
     const { sql, params } = buildTimeBucketQuery("SensorReading", "time", { ...base, groupBy: ["deviceId"] });
     expect(sql).toContain(`time_bucket($1, "time") AS "bucket"`);
-    expect(sql).toContain(`avg("temperature") AS "avgTemp"`);
+    expect(sql).toContain(`avg("temperature")::double precision AS "avgTemp"`);
     expect(sql).toContain(`count("temperature")::int AS "n"`);
     expect(sql).toContain(`FROM "SensorReading"`);
     expect(sql).toContain(`GROUP BY "bucket", "deviceId"`);
     expect(sql).not.toContain("::regclass");
     expect(params).toEqual(["1 hour", range.start, range.end]);
+  });
+
+  it("casts sum/avg to double precision (integer-column aggregates return JS numbers)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { total: { sum: "deviceId" }, mean: { avg: "deviceId" }, hi: { max: "deviceId" } },
+    });
+    expect(sql).toContain(`sum("deviceId")::double precision AS "total"`);
+    expect(sql).toContain(`avg("deviceId")::double precision AS "mean"`);
+    expect(sql).toContain(`max("deviceId") AS "hi"`); // min/max keep the column type
   });
 
   it("appends equality filters as bound params", () => {
@@ -57,7 +67,7 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`FROM "sensor_readings"`);
     expect(sql).toContain(`time_bucket($1, "ts") AS "bucket"`);
     expect(sql).toContain(`"device_id" AS "deviceId"`); // DB column selected, Prisma name aliased
-    expect(sql).toContain(`avg("temperature") AS "avgTemp"`); // unmapped column = identity
+    expect(sql).toContain(`avg("temperature")::double precision AS "avgTemp"`); // unmapped column = identity
     expect(sql).toContain(`AND ("device_id" = $4)`); // where key resolved to DB column
     expect(sql).toContain(`GROUP BY "bucket", "deviceId"`); // group by the output alias
     expect(params).toEqual(["1 hour", range.start, range.end, 1]);


### PR DESCRIPTION
Resolves the limitation that integer-column `sum`/`avg` in `timeBucket` came back as Postgres `bigint`/`numeric` (Prisma `BigInt`/`Decimal`) despite being typed as `number`.

## Fix
Cast in the generated SQL so results match the `number` type:
- `count` → `::int` (already)
- `sum` / `avg` → `::double precision`
- `min` / `max` → unchanged (keep the column's own type; for `number`-typed fields they already return numbers)

**Caveat (documented):** `sum`/`avg` are now float64, so a `sum` beyond 2^53 loses exactness — acceptable for the `number` contract.

## Tests
- Unit: asserts `sum`/`avg` emit `::double precision`, `min`/`max` don't.
- Integration: `sum`/`avg` over an integer column (`deviceId`) return JS `number`s (`sum = 6`, `avg = 1.2`) against real TimescaleDB.

Continuous-aggregate columns are unaffected — they use the type you declare on the `view` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated limitations to clarify numeric precision behavior for aggregates: `count` returns as integer, `sum`/`avg` as double precision, with precision caveats for large values beyond 2^53.

* **Bug Fixes**
  * Fixed aggregate function casting to properly handle numeric type conversions in query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->