### PR TITLE
feat: support @@schema (multiSchema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,13 @@ timescaledb({
 });
 ```
 
-> Multi-schema (`@@schema`) is not yet supported — see [Limitations](#limitations-v01).
+### Multiple schemas (`@@schema`)
+
+Multi-schema is supported too. Models annotated with `@@schema("metrics")` (with the
+`multiSchema` preview feature) have their hypertables and continuous aggregates created in,
+and queried from, the right schema — the generator and runtime schema-qualify every relation
+(`"metrics"."sensor_readings"`). No extra configuration needed beyond the standard Prisma
+multiSchema setup.
 
 ---
 
@@ -361,9 +367,6 @@ database) ships in this repo.
   `lte`, `gt`, `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null`
   checks, and `AND`/`OR`/`NOT`. **Relation filters** (`some`/`none`/`every`) and nested
   `not: { ... }` are not supported (they can't be a single-table query) and throw a clear error.
-- **`@@schema` (multiSchema)** is not yet handled — relations aren't schema-qualified, so
-  models must live in the default schema. (`@@map`/`@map` table & column renaming **is**
-  supported — see [Renamed tables/columns](#renamed-tablescolumns-map--map) below.)
 - **`timeBucket` numeric precision:** results come back as JS `number`s — `count` is cast to
   `int`, and `sum`/`avg` to `double precision` so integer-column aggregates aren't returned as
   `BigInt`/`Decimal`. Caveat: `sum`/`avg` are therefore float64, so a `sum` beyond 2^53 loses

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -41,7 +41,9 @@ export function timescaledb(config: TimescaleConfig = {}) {
   for (const h of config.hypertables ?? []) {
     hypertableByModel.set(h.model ?? h.table, {
       table: h.table,
-      ...(h.schema ? { schema: h.schema } : {}),
+      // !== undefined (not truthy): keep an explicitly-set schema so an invalid value like ""
+      // reaches identifier validation instead of being silently dropped to an unqualified target.
+      ...(h.schema !== undefined ? { schema: h.schema } : {}),
       column: h.column,
       columns: { ...(h.columns ?? {}) },
     });
@@ -49,7 +51,7 @@ export function timescaledb(config: TimescaleConfig = {}) {
   // Prisma view model name -> DB view name + schema, for refreshContinuousAggregate.
   const caggViewByModel = new Map<string, { name: string; schema?: string }>();
   for (const c of config.continuousAggregates ?? []) {
-    caggViewByModel.set(c.model ?? c.name, { name: c.name, ...(c.schema ? { schema: c.schema } : {}) });
+    caggViewByModel.set(c.model ?? c.name, { name: c.name, ...(c.schema !== undefined ? { schema: c.schema } : {}) });
   }
 
   const timeBucket = async function (this: unknown, args: TimeBucketRuntimeArgs) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -33,15 +33,23 @@ interface UnsafeRawClient extends RawClient {
  * const prisma = new PrismaClient().$extends(timescaledb(registry));
  */
 export function timescaledb(config: TimescaleConfig = {}) {
-  // Key by Prisma model name (ctx.$name); values hold the resolved DB table + column map.
-  const hypertableByModel = new Map<string, { table: string; column: string; columns: Record<string, string> }>();
+  // Key by Prisma model name (ctx.$name); values hold the resolved DB table + schema + column map.
+  const hypertableByModel = new Map<
+    string,
+    { table: string; schema?: string; column: string; columns: Record<string, string> }
+  >();
   for (const h of config.hypertables ?? []) {
-    hypertableByModel.set(h.model ?? h.table, { table: h.table, column: h.column, columns: { ...(h.columns ?? {}) } });
+    hypertableByModel.set(h.model ?? h.table, {
+      table: h.table,
+      ...(h.schema ? { schema: h.schema } : {}),
+      column: h.column,
+      columns: { ...(h.columns ?? {}) },
+    });
   }
-  // Prisma view model name -> DB view name, for refreshContinuousAggregate.
-  const caggViewByModel = new Map<string, string>();
+  // Prisma view model name -> DB view name + schema, for refreshContinuousAggregate.
+  const caggViewByModel = new Map<string, { name: string; schema?: string }>();
   for (const c of config.continuousAggregates ?? []) {
-    caggViewByModel.set(c.model ?? c.name, c.name);
+    caggViewByModel.set(c.model ?? c.name, { name: c.name, ...(c.schema ? { schema: c.schema } : {}) });
   }
 
   const timeBucket = async function (this: unknown, args: TimeBucketRuntimeArgs) {
@@ -57,7 +65,7 @@ export function timescaledb(config: TimescaleConfig = {}) {
       );
     }
     assertInterval(args.bucket);
-    const { sql, params } = buildTimeBucketQuery(ht.table, ht.column, args, ht.columns);
+    const { sql, params } = buildTimeBucketQuery(ht.table, ht.column, args, ht.columns, ht.schema);
     return (ctx.$parent as UnsafeRawClient).$queryRawUnsafe(sql, ...params);
   } as unknown as TimeBucketMethod;
 

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -1,5 +1,11 @@
 // The $timescale management namespace (SPEC §4.3).
-import { assertSafeIdent, quoteIdent } from "../core/sql.js";
+import { assertSafeIdent, qualifiedIdent } from "../core/sql.js";
+
+/** Resolved DB identity of a continuous aggregate (name + optional @@schema). */
+export interface CaggRef {
+  name: string;
+  schema?: string;
+}
 
 /** Minimal raw-capable client surface we rely on (PrismaClient provides these). */
 export interface RawClient {
@@ -22,12 +28,16 @@ export interface TimescaleManage {
   refreshContinuousAggregate(name: string, range?: RefreshRange): Promise<void>;
 }
 
-/** @param viewByModel Prisma view model name -> DB view name (for @@map resolution). */
-export function makeManage(client: RawClient, viewByModel: ReadonlyMap<string, string> = new Map()): TimescaleManage {
+/** @param viewByModel Prisma view model name -> { DB view name, schema } (for @@map/@@schema). */
+export function makeManage(
+  client: RawClient,
+  viewByModel: ReadonlyMap<string, CaggRef> = new Map(),
+): TimescaleManage {
   return {
     async refreshContinuousAggregate(name, range) {
-      const view = viewByModel.get(name) ?? name;
-      assertSafeIdent(view, "continuous aggregate name");
+      const ref = viewByModel.get(name) ?? { name };
+      assertSafeIdent(ref.name, "continuous aggregate name");
+      if (ref.schema !== undefined) assertSafeIdent(ref.schema, "continuous aggregate schema");
       // Open bounds (full refresh) must be a literal NULL, not a bound param: Postgres
       // can't infer the type of a NULL parameter for the function's "any" window args.
       const params: unknown[] = [];
@@ -36,7 +46,8 @@ export function makeManage(client: RawClient, viewByModel: ReadonlyMap<string, s
         params.push(value);
         return `$${params.length}`;
       };
-      const sql = `CALL refresh_continuous_aggregate('${quoteIdent(view)}', ${bound(range?.start)}, ${bound(range?.end)})`;
+      const target = qualifiedIdent(ref.name, ref.schema);
+      const sql = `CALL refresh_continuous_aggregate('${target}', ${bound(range?.start)}, ${bound(range?.end)})`;
       await client.$executeRawUnsafe(sql, ...params);
     },
   };

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -4,7 +4,7 @@
 import { Prisma } from "@prisma/client/extension";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
-import { assertSafeIdent, quoteIdent } from "../core/sql.js";
+import { assertSafeIdent, qualifiedIdent, quoteIdent } from "../core/sql.js";
 import { whereToSql } from "./where.js";
 
 // --- type machinery --------------------------------------------------------
@@ -88,9 +88,11 @@ export function buildTimeBucketQuery(
   timeColumn: string,
   args: TimeBucketRuntimeArgs,
   columns: Record<string, string> = {},
+  schema?: string,
 ): { sql: string; params: unknown[] } {
   assertSafeIdent(table, "model table");
   assertSafeIdent(timeColumn, "time column");
+  if (schema !== undefined) assertSafeIdent(schema, "model schema");
   assertInterval(args.bucket);
   if (!args.range || !(args.range.start instanceof Date) || !(args.range.end instanceof Date)) {
     throw new Error("timeBucket: `range.start` and `range.end` are required Dates.");
@@ -154,6 +156,6 @@ export function buildTimeBucketQuery(
   if (whereSql) where += ` AND (${whereSql})`;
 
   const groupBy = [`"bucket"`, ...groupCols.map((g) => quoteIdent(g))].join(", ");
-  const sql = `SELECT ${select.join(", ")} FROM ${quoteIdent(table)} WHERE ${where} GROUP BY ${groupBy} ORDER BY "bucket"`;
+  const sql = `SELECT ${select.join(", ")} FROM ${qualifiedIdent(table, schema)} WHERE ${where} GROUP BY ${groupBy} ORDER BY "bucket"`;
   return { sql, params };
 }

--- a/src/core/continuousAggregate.ts
+++ b/src/core/continuousAggregate.ts
@@ -1,7 +1,7 @@
 // Continuous aggregate SQL builder (SPEC §2.3 / CLAUDE.md constraints 3, 4).
 import type { CaggConfig, MigrationSql } from "./types.js";
 import { assertInterval } from "./interval.js";
-import { assertSafeIdent, quoteIdent, quoteLiteral, relationLiteral } from "./sql.js";
+import { assertSafeIdent, qualifiedIdent, quoteIdent, quoteLiteral, relationLiteral } from "./sql.js";
 
 const AGG_FNS = new Set(["avg", "sum", "min", "max", "count"]);
 
@@ -14,13 +14,15 @@ const AGG_FNS = new Set(["avg", "sum", "min", "max", "count"]);
  * - `down` uses `DROP MATERIALIZED VIEW IF EXISTS` — never plain `DROP VIEW` (constraint 4).
  */
 export function createContinuousAggregateSql(config: CaggConfig): MigrationSql {
-  const { name, source, bucket, timeColumn, bucketColumn, aggregates, refresh } = config;
+  const { name, source, schema, sourceSchema, bucket, timeColumn, bucketColumn, aggregates, refresh } = config;
   const groupBy = config.groupBy ?? [];
 
   assertSafeIdent(name, "continuous aggregate name");
   assertSafeIdent(source, "continuous aggregate source");
   assertSafeIdent(timeColumn, "time column");
   assertSafeIdent(bucketColumn, "bucket column");
+  if (schema !== undefined) assertSafeIdent(schema, "continuous aggregate schema");
+  if (sourceSchema !== undefined) assertSafeIdent(sourceSchema, "source schema");
   assertInterval(bucket);
   groupBy.forEach((g) => {
     assertSafeIdent(g.source, "groupBy source column");
@@ -49,11 +51,11 @@ export function createContinuousAggregateSql(config: CaggConfig): MigrationSql {
 
   const groupByCols = [bucketColumn, ...groupBy.map((g) => g.output)].map(quoteIdent).join(", ");
 
-  let up = `CREATE MATERIALIZED VIEW IF NOT EXISTS ${quoteIdent(name)}
+  let up = `CREATE MATERIALIZED VIEW IF NOT EXISTS ${qualifiedIdent(name, schema)}
   WITH (timescaledb.continuous) AS
 SELECT
   ${selectLines.join(",\n  ")}
-FROM ${quoteIdent(source)}
+FROM ${qualifiedIdent(source, sourceSchema)}
 GROUP BY ${groupByCols}
 WITH NO DATA;`;
 
@@ -63,7 +65,7 @@ WITH NO DATA;`;
     assertInterval(refresh.scheduleInterval);
     up += `
 
-SELECT add_continuous_aggregate_policy(${relationLiteral(name)},
+SELECT add_continuous_aggregate_policy(${relationLiteral(name, schema)},
   start_offset      => INTERVAL ${quoteLiteral(refresh.startOffset)},
   end_offset        => INTERVAL ${quoteLiteral(refresh.endOffset)},
   schedule_interval => INTERVAL ${quoteLiteral(refresh.scheduleInterval)},
@@ -72,7 +74,7 @@ SELECT add_continuous_aggregate_policy(${relationLiteral(name)},
   }
 
   // Constraint 4: a cagg appears in the views catalog but DROP VIEW errors on it.
-  const down = `DROP MATERIALIZED VIEW IF EXISTS ${quoteIdent(name)};`;
+  const down = `DROP MATERIALIZED VIEW IF EXISTS ${qualifiedIdent(name, schema)};`;
 
   return { up, down };
 }

--- a/src/core/hypertable.ts
+++ b/src/core/hypertable.ts
@@ -18,15 +18,16 @@ const DEFAULT_CHUNK_INTERVAL = "7 days";
  * separate "un-hypertable" step (SPEC §2.2).
  */
 export function createHypertableSql(config: HypertableConfig): MigrationSql {
-  const { table, column } = config;
+  const { table, column, schema } = config;
   const chunkInterval = config.chunkInterval ?? DEFAULT_CHUNK_INTERVAL;
 
   assertSafeIdent(table, "hypertable table");
   assertSafeIdent(column, "hypertable time column");
+  if (schema !== undefined) assertSafeIdent(schema, "hypertable schema");
   assertInterval(chunkInterval);
 
   const up = `SELECT create_hypertable(
-  ${relationLiteral(table)},
+  ${relationLiteral(table, schema)},
   by_range(${quoteLiteral(column)}, INTERVAL ${quoteLiteral(chunkInterval)}),
   if_not_exists => TRUE,
   migrate_data  => TRUE

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,4 +12,4 @@ export { assertInterval, isInterval } from "./interval.js";
 export { createExtensionSql } from "./extension.js";
 export { createHypertableSql } from "./hypertable.js";
 export { createContinuousAggregateSql } from "./continuousAggregate.js";
-export { quoteIdent, quoteLiteral, relationLiteral, assertSafeIdent } from "./sql.js";
+export { quoteIdent, quoteLiteral, qualifiedIdent, relationLiteral, assertSafeIdent } from "./sql.js";

--- a/src/core/sql.ts
+++ b/src/core/sql.ts
@@ -23,16 +23,26 @@ export function quoteLiteral(value: string): string {
 }
 
 /**
+ * Quote a (optionally schema-qualified) relation/identifier for use in DDL/queries.
+ * `qualifiedIdent("sensor_readings", "metrics")` -> `"metrics"."sensor_readings"`;
+ * with no schema -> `"sensor_readings"`.
+ */
+export function qualifiedIdent(name: string, schema?: string): string {
+  return schema ? `${quoteIdent(schema)}.${quoteIdent(name)}` : quoteIdent(name);
+}
+
+/**
  * Render a relation as a quoted *string literal* for TimescaleDB functions that take the
  * relation by name (e.g. create_hypertable, add_continuous_aggregate_policy,
- * refresh_continuous_aggregate). `SensorReading` -> `'"SensorReading"'`.
+ * refresh_continuous_aggregate). `SensorReading` -> `'"SensorReading"'`;
+ * with a schema -> `'"metrics"."sensor_readings"'`.
  *
  * CLAUDE.md constraint 2: NEVER cast (`::regclass` / `::name`) — pass the quoted string
  * literal. Mixed-case names must keep their inner quotes or Postgres case-folds them
  * (the `refresh_continuous_aggregate('sensorhourly')` failure surfaced in the spike).
  */
-export function relationLiteral(name: string): string {
-  return quoteLiteral(quoteIdent(name));
+export function relationLiteral(name: string, schema?: string): string {
+  return quoteLiteral(qualifiedIdent(name, schema));
 }
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -16,6 +16,8 @@ export interface HypertableConfig {
   model?: string;
   /** Table/relation name as it exists in the DB, unquoted (the @@map name, or model name). */
   table: string;
+  /** Database schema (the @@schema name) when using multiSchema; omitted for the default schema. */
+  schema?: string;
   /** Time partitioning column, as it exists in the DB (the @map name, or field name). */
   column: string;
   /** Chunk size; defaults to "7 days" when omitted. */
@@ -62,8 +64,12 @@ export interface CaggConfig {
   model?: string;
   /** View name as it exists in the DB (the @@map name, or model name). */
   name: string;
-  /** Source hypertable model name. */
+  /** The view's database schema (@@schema), when using multiSchema. */
+  schema?: string;
+  /** Source hypertable table name (DB name). */
   source: string;
+  /** The source hypertable's database schema (@@schema); may differ from the view's. */
+  sourceSchema?: string;
   /** time_bucket interval. */
   bucket: Interval;
   /** Source time column the bucket is computed from. */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -77,6 +77,7 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
   return {
     ...(model.name !== table ? { model: model.name } : {}),
     table,
+    ...(model.schema ? { schema: model.schema } : {}),
     column: dbCol(field),
     ...(chunkInterval !== undefined ? { chunkInterval: chunkInterval as Interval } : {}),
     ...(Object.keys(columns).length > 0 ? { columns } : {}),
@@ -164,7 +165,9 @@ function buildCagg(
   return {
     ...(view.name !== viewName ? { model: view.name } : {}),
     name: viewName,
+    ...(view.schema ? { schema: view.schema } : {}),
     source: dbTable(sourceModel),
+    ...(sourceModel.schema ? { sourceSchema: sourceModel.schema } : {}),
     bucket: bucket as Interval,
     timeColumn: dbCol(timeField),
     bucketColumn,

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -44,6 +44,10 @@ export interface HarnessOptions {
   models?: string;
   /** Override the Prisma CREATE TABLE migration SQL (must match the schema's DB names). */
   initSql?: string;
+  /** Extra generator preview features (merged with the default ["views"]). */
+  previewFeatures?: string[];
+  /** Datasource schemas (enables multiSchema); when set, adds `schemas = [...]`. */
+  schemas?: string[];
 }
 
 export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> {
@@ -108,7 +112,7 @@ export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> 
 
 function scaffoldProject(dir: string, opts: HarnessOptions): void {
   writeFileSync(join(dir, "prisma.config.ts"), PRISMA_CONFIG);
-  writeFileSync(join(dir, "schema.prisma"), schemaPrisma(opts.models ?? DEFAULT_MODELS));
+  writeFileSync(join(dir, "schema.prisma"), schemaPrisma(opts.models ?? DEFAULT_MODELS, opts));
 
   const migrations = join(dir, "migrations");
   mkdirSync(migrations, { recursive: true });
@@ -134,13 +138,15 @@ export default defineConfig({
 });
 `;
 
-function schemaPrisma(models: string): string {
+function schemaPrisma(models: string, opts: HarnessOptions): string {
   // provider is an absolute path to our built generator binary.
   const provider = GENERATOR_PROVIDER.replace(/\\/g, "/");
+  const previewFeatures = JSON.stringify(["views", ...(opts.previewFeatures ?? [])]);
+  const schemasLine = opts.schemas ? `\n  schemas  = ${JSON.stringify(opts.schemas)}` : "";
   return `generator client {
   provider        = "prisma-client"
   output          = "./client"
-  previewFeatures = ["views"]
+  previewFeatures = ${previewFeatures}
 }
 
 generator timescaledb {
@@ -149,7 +155,7 @@ generator timescaledb {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "postgresql"${schemasLine}
 }
 
 ${models}`;

--- a/test/integration/multi-schema.test.ts
+++ b/test/integration/multi-schema.test.ts
@@ -91,8 +91,9 @@ describe.skipIf(!DOCKER_OK)("@@schema / multiSchema (generated migrations + runt
     expect(await counts(h)).toEqual({ hypertables: 1, caggs: 1 });
   });
 
-  it("reproduces them after migrate reset", async () => {
+  it("reproduces them after migrate reset + deploy", async () => {
     h.prisma(["migrate", "reset", "--force"]);
+    h.prisma(["migrate", "deploy"]);
     expect(await counts(h)).toEqual({ hypertables: 1, caggs: 1 });
   });
 

--- a/test/integration/multi-schema.test.ts
+++ b/test/integration/multi-schema.test.ts
@@ -1,0 +1,147 @@
+// End-to-end proof of @@schema (multiSchema): the hypertable + cagg live in a non-default
+// schema ("metrics"). Proves the generator schema-qualifies its SQL and the runtime resolves
+// schema-qualified relations against real TimescaleDB.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED: Docker is not available. The @@schema (multiSchema) checks are NOT verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+  @@schema("metrics")
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time", refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" })
+view SensorHourly {
+  bucket   DateTime /// @timescale.bucket
+  deviceId Int      /// @timescale.groupBy
+  avgTemp  Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+
+  @@unique([deviceId, bucket])
+  @@schema("metrics")
+}
+`;
+
+const INIT_SQL = `-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "metrics";
+
+-- CreateTable
+CREATE TABLE "metrics"."SensorReading" (
+    "time" TIMESTAMP(3) NOT NULL,
+    "deviceId" INTEGER NOT NULL,
+    "temperature" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "SensorReading_pkey" PRIMARY KEY ("deviceId","time")
+);
+
+-- CreateIndex
+CREATE INDEX "SensorReading_deviceId_time_idx" ON "metrics"."SensorReading"("deviceId", "time");
+`;
+
+async function counts(h: Harness) {
+  const [hyper] = await h.query<{ n: number }>(
+    "SELECT count(*)::int AS n FROM timescaledb_information.hypertables WHERE hypertable_schema = 'metrics' AND hypertable_name = 'SensorReading'",
+  );
+  const [cagg] = await h.query<{ n: number }>(
+    "SELECT count(*)::int AS n FROM timescaledb_information.continuous_aggregates WHERE view_schema = 'metrics' AND view_name = 'SensorHourly'",
+  );
+  return { hypertables: hyper?.n ?? 0, caggs: cagg?.n ?? 0 };
+}
+
+describe.skipIf(!DOCKER_OK)("@@schema / multiSchema (generated migrations + runtime)", () => {
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await startHarness({
+      models: MODELS,
+      initSql: INIT_SQL,
+      previewFeatures: ["multiSchema"],
+      schemas: ["public", "metrics"],
+    });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+  });
+
+  afterAll(async () => {
+    await h?.stop();
+  });
+
+  it("creates the hypertable + cagg in the non-default schema", async () => {
+    expect(await counts(h)).toEqual({ hypertables: 1, caggs: 1 });
+  });
+
+  it("reproduces them after migrate reset", async () => {
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await counts(h)).toEqual({ hypertables: 1, caggs: 1 });
+  });
+
+  it("inserts + reads through schema-qualified relations (timeBucket, refresh, cagg view)", async () => {
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+
+    const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    const prisma = base.$extends(timescaledb(registry));
+
+    try {
+      await prisma.sensorReading.createMany({
+        data: [
+          { time: new Date("2026-06-15T10:05:00Z"), deviceId: 1, temperature: 20 },
+          { time: new Date("2026-06-15T10:25:00Z"), deviceId: 1, temperature: 22 },
+          { time: new Date("2026-06-15T10:45:00Z"), deviceId: 1, temperature: 24 },
+          { time: new Date("2026-06-15T11:10:00Z"), deviceId: 1, temperature: 30 },
+          { time: new Date("2026-06-15T10:15:00Z"), deviceId: 2, temperature: 15 },
+        ],
+      });
+
+      const rows = await prisma.sensorReading.timeBucket({
+        bucket: "1 hour",
+        range: { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") },
+        groupBy: ["deviceId"],
+        aggregate: { avgTemp: { avg: "temperature" } },
+      });
+      expect(
+        rows
+          .map((r: { bucket: Date; deviceId: number; avgTemp: number }) => ({
+            h: r.bucket.toISOString(),
+            d: r.deviceId,
+            avg: Number(r.avgTemp),
+          }))
+          .sort((a, b) => a.d - b.d || a.h.localeCompare(b.h)),
+      ).toEqual([
+        { h: "2026-06-15T10:00:00.000Z", d: 1, avg: 22 },
+        { h: "2026-06-15T11:00:00.000Z", d: 1, avg: 30 },
+        { h: "2026-06-15T10:00:00.000Z", d: 2, avg: 15 },
+      ]);
+
+      await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+      const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });
+      expect(
+        hourly.map((r: { deviceId: number; avgTemp: number }) => ({ d: r.deviceId, avg: Number(r.avgTemp) })),
+      ).toEqual([{ d: 1, avg: 22 }, { d: 1, avg: 30 }, { d: 2, avg: 15 }]);
+    } finally {
+      await base.$disconnect();
+    }
+  });
+});

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -49,6 +49,11 @@ describe("createHypertableSql", () => {
     expect(() => createHypertableSql({ table: "a-b", column: "time" })).toThrow(/Invalid/);
     expect(() => createHypertableSql({ table: "X", column: "t", chunkInterval: "1 fortnight" as never })).toThrow(/Invalid interval/);
   });
+
+  it("schema-qualifies the relation under multiSchema (@@schema)", () => {
+    const { up } = createHypertableSql({ table: "sensor_readings", column: "ts", chunkInterval: "1 day", schema: "metrics" });
+    expect(up).toContain(`'"metrics"."sensor_readings"'`);
+  });
 });
 
 describe("createContinuousAggregateSql", () => {
@@ -118,5 +123,13 @@ SELECT add_continuous_aggregate_policy('"SensorHourly"',
     expect(() =>
       createContinuousAggregateSql({ ...base, aggregates: [{ name: "x", fn: "median" as never, column: "temperature" }] }),
     ).toThrow(/Unsupported aggregate function/);
+  });
+
+  it("schema-qualifies view, source, policy and down under multiSchema (@@schema)", () => {
+    const sql = createContinuousAggregateSql({ ...base, schema: "metrics", sourceSchema: "metrics" });
+    expect(sql.up).toContain(`CREATE MATERIALIZED VIEW IF NOT EXISTS "metrics"."SensorHourly"`);
+    expect(sql.up).toContain(`FROM "metrics"."SensorReading"`);
+    expect(sql.up).toContain(`add_continuous_aggregate_policy('"metrics"."SensorHourly"'`);
+    expect(sql.down).toBe(`DROP MATERIALIZED VIEW IF EXISTS "metrics"."SensorHourly";`);
   });
 });

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -215,6 +215,49 @@ ${body}
   });
 });
 
+describe("extractTimescaleSchema — @@schema (multiSchema)", () => {
+  it("resolves @@schema to schema / sourceSchema on the configs", async () => {
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views", "multiSchema"]
+}
+datasource db {
+  provider = "postgresql"
+  schemas  = ["public", "metrics"]
+}
+
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+  @@schema("metrics")
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket  DateTime /// @timescale.bucket
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([bucket])
+  @@schema("metrics")
+}
+`,
+    });
+    const result = extractTimescaleSchema(dmmf);
+    expect(result.hypertables[0]).toMatchObject({ table: "SensorReading", schema: "metrics" });
+    expect(result.continuousAggregates[0]).toMatchObject({
+      name: "SensorHourly",
+      schema: "metrics",
+      source: "SensorReading",
+      sourceSchema: "metrics",
+    });
+  });
+});
+
 describe("extractTimescaleSchema — @@map / @map", () => {
   it("resolves table/column names to DB names and records the column map", async () => {
     const result = await extract(`

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -45,8 +45,15 @@ describe("makeManage.refreshContinuousAggregate", () => {
 
   it("resolves the Prisma view model name to its @@map DB view name", async () => {
     const { client, calls } = fakeClient();
-    const viewByModel = new Map([["SensorHourly", "sensor_hourly"]]);
+    const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly" }]]);
     await makeManage(client, viewByModel).refreshContinuousAggregate("SensorHourly");
     expect(calls[0]!.sql).toBe(`CALL refresh_continuous_aggregate('"sensor_hourly"', NULL, NULL)`);
+  });
+
+  it("schema-qualifies the cagg name when a @@schema is configured", async () => {
+    const { client, calls } = fakeClient();
+    const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly", schema: "metrics" }]]);
+    await makeManage(client, viewByModel).refreshContinuousAggregate("SensorHourly");
+    expect(calls[0]!.sql).toBe(`CALL refresh_continuous_aggregate('"metrics"."sensor_hourly"', NULL, NULL)`);
   });
 });

--- a/test/unit/sql.test.ts
+++ b/test/unit/sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assertSafeIdent, quoteIdent, quoteLiteral, relationLiteral } from "../../src/core/sql.js";
+import { assertSafeIdent, qualifiedIdent, quoteIdent, quoteLiteral, relationLiteral } from "../../src/core/sql.js";
 
 describe("sql helpers", () => {
   it("quotes identifiers and preserves case", () => {
@@ -18,6 +18,12 @@ describe("sql helpers", () => {
 
   it("renders a relation as a quoted string literal (no casts)", () => {
     expect(relationLiteral("SensorReading")).toBe(`'"SensorReading"'`);
+  });
+
+  it("qualifiedIdent / relationLiteral schema-qualify when a schema is given", () => {
+    expect(qualifiedIdent("sensor_readings")).toBe(`"sensor_readings"`);
+    expect(qualifiedIdent("sensor_readings", "metrics")).toBe(`"metrics"."sensor_readings"`);
+    expect(relationLiteral("sensor_hourly", "metrics")).toBe(`'"metrics"."sensor_hourly"'`);
   });
 
   it("rejects unsafe identifiers", () => {

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -78,6 +78,10 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`FROM "metrics"."sensor_readings"`);
   });
 
+  it("rejects an explicitly-set invalid (empty) schema rather than silently ignoring it", () => {
+    expect(() => buildTimeBucketQuery("sensor_readings", "ts", base, {}, "")).toThrow(/Invalid model schema/);
+  });
+
   it("throws when range bounds are missing", () => {
     expect(() =>
       buildTimeBucketQuery("SensorReading", "time", { bucket: "1 hour", aggregate: base.aggregate } as TimeBucketRuntimeArgs),

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -73,6 +73,11 @@ describe("buildTimeBucketQuery", () => {
     expect(params).toEqual(["1 hour", range.start, range.end, 1]);
   });
 
+  it("schema-qualifies the table under multiSchema (@@schema)", () => {
+    const { sql } = buildTimeBucketQuery("sensor_readings", "ts", base, {}, "metrics");
+    expect(sql).toContain(`FROM "metrics"."sensor_readings"`);
+  });
+
   it("throws when range bounds are missing", () => {
     expect(() =>
       buildTimeBucketQuery("SensorReading", "time", { bucket: "1 hour", aggregate: base.aggregate } as TimeBucketRuntimeArgs),


### PR DESCRIPTION
Resolves the last v0.1 limitation — models couldn't live in a non-default schema because relations weren't schema-qualified.

## What
Models annotated with `@@schema("metrics")` (with the `multiSchema` preview feature) now work end-to-end. Every relation reference is schema-qualified (`"metrics"."sensor_readings"`):
- **Generator**: `create_hypertable`, the continuous aggregate (view name + `FROM` source + policy), and the `DROP` in the down migration.
- **Runtime**: `timeBucket` qualifies the `FROM`; `$timescale.refreshContinuousAggregate` qualifies the cagg target. A cagg and its source may even be in different schemas (`schema` vs `sourceSchema`).

## How
- New `qualifiedIdent(name, schema?)` + schema-aware `relationLiteral` in `core/sql`.
- `HypertableConfig.schema`, `CaggConfig.schema` / `sourceSchema`; resolved from `model.schema` in the DMMF layer.

## Tests
- **Unit**: `qualifiedIdent`/`relationLiteral`, schema-qualified hypertable + cagg builders, DMMF `@@schema` resolution, `timeBucket` qualified `FROM`, schema-qualified refresh.
- **Integration**: a schema with models in a `metrics` schema — generate + deploy + `migrate reset` + insert + `timeBucket` + refresh + cagg read, all against real TimescaleDB.

## Docs
- New **Multiple schemas (`@@schema`)** section; removed from Limitations.

With this, all four fixable v0.1 limitations are addressed (`@@map`, `where` operators, integer aggregates, `@@schema`). The only remaining note is that continuous aggregates must use `@@unique` (a Prisma 7 constraint, not something this package can change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full end-to-end multi-schema support for hypertables and continuous aggregates when Prisma’s `multiSchema` preview feature is enabled, including schema-qualified SQL generation and refresh behavior.
* **Documentation**
  * Updated the README to remove the prior multi-schema limitation and describe `@@schema` support end-to-end.
* **Tests**
  * Added integration and unit test coverage validating schema-qualified hypertables, continuous aggregates, and time-bucket querying in non-default schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->