### PR TITLE
fix: retry refresh_continuous_aggregate on a concurrent policy refresh (55P03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ await prisma.$timescale.refreshContinuousAggregate("SensorHourly");             
 await prisma.$timescale.refreshContinuousAggregate("SensorHourly", { start, end }); // window
 ```
 
+If a scheduled refresh policy happens to be running on the same continuous aggregate, a manual
+refresh would otherwise fail with `SQLSTATE 55P03` (*"could not refresh … due to a concurrent
+refresh"*). `refreshContinuousAggregate` absorbs this transient case by briefly retrying with
+backoff, so an explicit refresh racing the policy job succeeds instead of throwing.
+
 ---
 
 ## Without the generator (manual config)

--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ await prisma.$timescale.refreshContinuousAggregate("SensorHourly", { start, end 
 
 If a scheduled refresh policy happens to be running on the same continuous aggregate, a manual
 refresh would otherwise fail with `SQLSTATE 55P03` (*"could not refresh … due to a concurrent
-refresh"*). `refreshContinuousAggregate` absorbs this transient case by briefly retrying with
-backoff, so an explicit refresh racing the policy job succeeds instead of throwing.
+refresh"*). `refreshContinuousAggregate` retries this transient case with bounded exponential
+backoff (default: up to 8 attempts); if the contention persists beyond that budget, the original
+`55P03` error is rethrown.
 
 ---
 

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -18,21 +18,57 @@ export interface RefreshRange {
   end?: Date | null;
 }
 
+/** Tuning for the concurrent-refresh retry. Defaults are sensible; mainly for tests. */
+export interface ManageOptions {
+  /**
+   * Max attempts for a refresh that collides with the cagg's background refresh policy
+   * (SQLSTATE 55P03). Default 8.
+   */
+  maxRefreshAttempts?: number;
+  /** Delay between retries (ms -> Promise). Injectable for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
 export interface TimescaleManage {
   /**
    * Refresh a continuous aggregate over an optional time window (SPEC §4.3).
    * Accepts the Prisma view model name; it is resolved to the DB view name (@@map) and passed
    * as a quoted identifier so mixed-case caggs resolve correctly (an unquoted name case-folds
    * and fails — surfaced in the spike).
+   *
+   * If a scheduled refresh policy is running on the same cagg, the manual refresh briefly
+   * retries (see SQLSTATE 55P03 below) instead of failing.
    */
   refreshContinuousAggregate(name: string, range?: RefreshRange): Promise<void>;
 }
+
+// SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
+// refresh_continuous_aggregate() overlaps the cagg's scheduled refresh-policy job
+// ("could not refresh continuous aggregate ... due to a concurrent refresh"). It is
+// transient — the policy job releases the lock when it finishes — so an explicit refresh
+// briefly retries rather than surfacing a spurious failure to the caller.
+const CONCURRENT_REFRESH_SQLSTATE = "55P03";
+
+function isConcurrentRefreshError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { meta?: { code?: unknown }; message?: unknown };
+  // Driver adapters expose the Postgres SQLSTATE on the error's `meta.code`.
+  if (e.meta?.code === CONCURRENT_REFRESH_SQLSTATE) return true;
+  // Fallback: the SQLSTATE is rendered into Prisma's raw-query error message
+  // (`Raw query failed. Code: \`55P03\`. ...`) across client/adapter versions.
+  return typeof e.message === "string" && e.message.includes(CONCURRENT_REFRESH_SQLSTATE);
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** @param viewByModel Prisma view model name -> { DB view name, schema } (for @@map/@@schema). */
 export function makeManage(
   client: RawClient,
   viewByModel: ReadonlyMap<string, CaggRef> = new Map(),
+  options: ManageOptions = {},
 ): TimescaleManage {
+  const maxAttempts = Math.max(1, options.maxRefreshAttempts ?? 8);
+  const sleep = options.sleep ?? defaultSleep;
   return {
     async refreshContinuousAggregate(name, range) {
       const ref = viewByModel.get(name) ?? { name };
@@ -48,7 +84,17 @@ export function makeManage(
       };
       const target = qualifiedIdent(ref.name, ref.schema);
       const sql = `CALL refresh_continuous_aggregate('${target}', ${bound(range?.start)}, ${bound(range?.end)})`;
-      await client.$executeRawUnsafe(sql, ...params);
+      // Retry only on a concurrent policy refresh (55P03), with bounded exponential backoff.
+      // Any other error — or exhausting the attempt budget — propagates unchanged.
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          await client.$executeRawUnsafe(sql, ...params);
+          return;
+        } catch (err) {
+          if (attempt >= maxAttempts || !isConcurrentRefreshError(err)) throw err;
+          await sleep(Math.min(50 * 2 ** (attempt - 1), 1000));
+        }
+      }
     },
   };
 }

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -67,7 +67,11 @@ export function makeManage(
   viewByModel: ReadonlyMap<string, CaggRef> = new Map(),
   options: ManageOptions = {},
 ): TimescaleManage {
-  const maxAttempts = Math.max(1, options.maxRefreshAttempts ?? 8);
+  // Coerce to a finite integer >= 1. A NaN here would make the retry loop's `attempt <=
+  // maxAttempts` guard false on the first iteration — a silent no-op that never runs the
+  // refresh — and Infinity would retry unboundedly on repeated 55P03; both fall back to 8.
+  const requestedAttempts = options.maxRefreshAttempts ?? 8;
+  const maxAttempts = Number.isFinite(requestedAttempts) ? Math.max(1, Math.floor(requestedAttempts)) : 8;
   const sleep = options.sleep ?? defaultSleep;
   return {
     async refreshContinuousAggregate(name, range) {

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -109,4 +109,15 @@ describe("makeManage.refreshContinuousAggregate", () => {
     ).rejects.toBe(otherError);
     expect(attempts()).toBe(1); // failed fast, no retry
   });
+
+  it("treats a non-finite or sub-1 maxRefreshAttempts as a safe default (never a silent no-op)", async () => {
+    // NaN/Infinity/0/negative must not skip the loop entirely — the refresh must still run.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 0, -3]) {
+      const { client, calls } = fakeClient();
+      await makeManage(client, new Map(), { maxRefreshAttempts: bad, sleep: noSleep }).refreshContinuousAggregate(
+        "SensorHourly",
+      );
+      expect(calls).toHaveLength(1); // executed exactly once
+    }
+  });
 });

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -12,6 +12,31 @@ function fakeClient() {
   return { client, calls };
 }
 
+/** A client whose $executeRawUnsafe throws `failWith` for the first `failTimes` calls. */
+function flakyClient(failWith: unknown, failTimes: number) {
+  let attempts = 0;
+  const client: RawClient = {
+    async $executeRawUnsafe() {
+      attempts++;
+      if (attempts <= failTimes) throw failWith;
+      return 0;
+    },
+  };
+  return { client, attempts: () => attempts };
+}
+
+// SQLSTATE 55P03 surfaced via the driver's `meta.code` only (message carries no code).
+const metaConcurrent = Object.assign(new Error("lock not available"), { meta: { code: "55P03" } });
+// SQLSTATE 55P03 surfaced only inside Prisma's rendered raw-query message (no `meta`).
+const messageConcurrent = new Error(
+  "Invalid `prisma.$executeRawUnsafe()` invocation:\n" +
+    "Raw query failed. Code: `55P03`. Message: `could not refresh continuous aggregate due to a concurrent refresh`",
+);
+const otherError = Object.assign(new Error("Raw query failed. Code: `42P01`. relation does not exist"), {
+  meta: { code: "42P01" },
+});
+const noSleep = async () => {};
+
 describe("makeManage.refreshContinuousAggregate", () => {
   it("full refresh uses literal NULL bounds and binds no params", async () => {
     const { client, calls } = fakeClient();
@@ -55,5 +80,33 @@ describe("makeManage.refreshContinuousAggregate", () => {
     const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly", schema: "metrics" }]]);
     await makeManage(client, viewByModel).refreshContinuousAggregate("SensorHourly");
     expect(calls[0]!.sql).toBe(`CALL refresh_continuous_aggregate('"metrics"."sensor_hourly"', NULL, NULL)`);
+  });
+
+  it("retries a concurrent-policy refresh (55P03 in the message) then succeeds", async () => {
+    const { client, attempts } = flakyClient(messageConcurrent, 2);
+    await makeManage(client, new Map(), { sleep: noSleep }).refreshContinuousAggregate("SensorHourly");
+    expect(attempts()).toBe(3); // two 55P03s, then success
+  });
+
+  it("detects a concurrent refresh via the driver's meta.code", async () => {
+    const { client, attempts } = flakyClient(metaConcurrent, 1);
+    await makeManage(client, new Map(), { sleep: noSleep }).refreshContinuousAggregate("SensorHourly");
+    expect(attempts()).toBe(2);
+  });
+
+  it("gives up after maxRefreshAttempts and rethrows the 55P03 error", async () => {
+    const { client, attempts } = flakyClient(messageConcurrent, Number.POSITIVE_INFINITY);
+    await expect(
+      makeManage(client, new Map(), { sleep: noSleep, maxRefreshAttempts: 3 }).refreshContinuousAggregate("SensorHourly"),
+    ).rejects.toBe(messageConcurrent);
+    expect(attempts()).toBe(3);
+  });
+
+  it("does not retry errors other than 55P03", async () => {
+    const { client, attempts } = flakyClient(otherError, Number.POSITIVE_INFINITY);
+    await expect(
+      makeManage(client, new Map(), { sleep: noSleep }).refreshContinuousAggregate("SensorHourly"),
+    ).rejects.toBe(otherError);
+    expect(attempts()).toBe(1); // failed fast, no retry
   });
 });


### PR DESCRIPTION
## What

A manual `$timescale.refreshContinuousAggregate(...)` can collide with the continuous
aggregate's **scheduled refresh-policy job**. TimescaleDB surfaces the collision as
`SQLSTATE 55P03` — *"could not refresh continuous aggregate … due to a concurrent refresh"*.

That lock is **transient** (the policy job releases it on completion), so the explicit
refresh now briefly retries with bounded exponential backoff instead of failing.

## Why

This is a real user-facing case: the README's documented pattern (bulk insert → manual
`refreshContinuousAggregate` → read) runs against a cagg that also has a refresh policy, so
a user can hit `55P03` whenever their manual call races the scheduled job.

It also removes an **intermittent CI failure** in `reset-safety.test.ts`, where the
post-deploy policy job occasionally raced the test's manual refresh. The unchanged-code CI
re-run of that flake passed green, confirming it was a race, not a regression.

## How

- Retry **only** on `55P03`; any other error (or exhausting the budget) propagates unchanged.
- Detect via the driver's `meta.code`, with a message-substring fallback across
  client/adapter versions.
- Defaults: 8 attempts, backoff `50ms → 1s` cap. Retry timing is injectable
  (`ManageOptions.sleep`) so unit tests stay deterministic — no real sleeps in CI.
- README management section documents the behavior.

## Testing

- **Unit:** 4 new `manage.test.ts` cases — retry-then-succeed (message + `meta.code` paths),
  give-up-and-rethrow after `maxRefreshAttempts`, and no-retry for non-55P03 errors. `89` unit/type tests pass.
- **Local gates:** `build`, `test`, `test:types`, `attw` all green.
- **Integration (real TimescaleDB):** full suite `9/9` green; `reset-safety.test.ts` run an
  additional 3× for stability — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous-aggregate manual refresh now automatically retries with bounded exponential backoff when concurrent refresh lock conflicts are detected.
  * Added optional tuning for retry behavior, including maximum attempts and a customizable sleep/delay mechanism.

* **Bug Fixes**
  * Concurrent-refresh conflicts now trigger retries using either structured error codes or message matching; all other errors are rethrown immediately.

* **Tests**
  * Added deterministic unit coverage for retry, backoff limits, and non-retryable errors.

* **Documentation**
  * Clarified the behavior and retry limits for SQLSTATE `55P03`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->