### PR TITLE
feat: exact timeBucket aggregates via `as: "bigint" | "string"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,36 @@ Aggregate columns are checked against the model's scalar fields **at compile tim
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`.
 
+#### Exact aggregate results (`as: "bigint" | "string"`)
+
+By default every aggregate comes back as a JS `number` — `sum`/`avg` are computed as
+`double precision`, so a magnitude past `2^53` loses precision. Opt an individual aggregate
+into an exact type with `as`:
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: {
+    total:   { sum: "deviceId", as: "bigint" },    // → bigint  (exact integer)
+    samples: { count: "deviceId", as: "bigint" },  // → bigint  (no overflow past ~2.1B rows)
+    exact:   { avg: "temperature", as: "string" }, // → string  (exact decimal, e.g. "22.5000…")
+    fast:    { sum: "temperature" },               // → number  (default, unchanged)
+  },
+});
+// rows: Array<{ bucket: Date; total: bigint; samples: bigint; exact: string; fast: number }>
+```
+
+- `as: "bigint"` → Postgres `::bigint`, a native JS `bigint`. Exact for integer sums/counts, and
+  avoids the overflow the default `count` (`::int`) hits past ~2.1B rows in a single bucket. Not
+  available on `avg` (it's fractional).
+- `as: "string"` → Postgres `::text`, an exact decimal `string` (JSON-safe). Use for `avg` or
+  large fractional sums. Not available on `count`.
+- `as: "number"` (default) → JS `number`.
+
+The result-row type follows `as` per aggregate, and the disallowed combinations (`avg` + `bigint`,
+`count` + `string`) are compile errors.
+
 ### Reading a continuous aggregate
 
 A continuous aggregate is a Prisma `view`, so reads are ordinary, fully-typed Prisma:
@@ -373,10 +403,11 @@ database) ships in this repo.
   `lte`, `gt`, `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null`
   checks, and `AND`/`OR`/`NOT`. **Relation filters** (`some`/`none`/`every`) and nested
   `not: { ... }` are not supported (they can't be a single-table query) and throw a clear error.
-- **`timeBucket` numeric precision:** results come back as JS `number`s — `count` is cast to
-  `int`, and `sum`/`avg` to `double precision` so integer-column aggregates aren't returned as
-  `BigInt`/`Decimal`. Caveat: `sum`/`avg` are therefore float64, so a `sum` beyond 2^53 loses
-  exactness. (Continuous-aggregate columns use the type you declare on the `view` model.)
+- **`timeBucket` numeric precision:** aggregates **default** to JS `number` (`count` → `int`,
+  `sum`/`avg` → `double precision`), so a default `sum` beyond 2^53 is float64-rounded. For exact
+  results, opt an aggregate into [`as: "bigint"`](#exact-aggregate-results-as-bigint--string)
+  (native `bigint`) or `as: "string"` (exact decimal text). (Continuous-aggregate columns use the
+  type you declare on the `view` model.)
 - Continuous aggregates must be declared as Prisma `view`s with `@@unique` (not `@@id`).
 
 ---

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -89,8 +89,17 @@ export interface TimeBucketMethod {
 
 // --- runtime SQL builder ---------------------------------------------------
 
-const AGG_FNS = new Set(["avg", "sum", "min", "max", "count"]);
-const OUTPUT_AS = new Set(["number", "bigint", "string"]);
+// Valid `as` output per aggregate function — mirrors the per-function TS unions, and doubles
+// as the set of valid function names. The runtime checks against this so a TypeScript bypass
+// (an `any` cast or dynamically-built args) can't slip through a combination the types forbid
+// — e.g. `avg` + `bigint` (which would silently round) or `count` + `string`.
+const AGG_AS: Record<string, ReadonlySet<string>> = {
+  sum: new Set(["number", "bigint", "string"]),
+  avg: new Set(["number", "string"]),
+  min: new Set(["number"]),
+  max: new Set(["number"]),
+  count: new Set(["number", "bigint"]),
+};
 
 /**
  * SQL cast that controls the JS type Prisma returns for an aggregate — the cast IS the type
@@ -98,7 +107,7 @@ const OUTPUT_AS = new Set(["number", "bigint", "string"]);
  *   `::bigint` -> JS `bigint` (exact integers)   `::text` -> JS `string` (exact decimal)
  * Default (`"number"` / unset): `count` -> `::int`, `sum`/`avg` -> `::double precision`
  * (JS `number`, loses precision past 2^53), `min`/`max` -> native (already a number for the
- * numeric column types those accept).
+ * numeric column types those accept). Callers are validated against AGG_AS first.
  */
 function castFor(fn: string, outputAs: string | undefined): string {
   if (outputAs === "bigint") return "::bigint";
@@ -163,16 +172,17 @@ export function buildTimeBucketQuery(
     assertSafeIdent(resultName, "aggregate result column");
     // Split the optional `as` selector from the single function entry ({ sum: "x", as: "bigint" }).
     const { as: outputAs, ...fnPart } = op;
-    if (outputAs !== undefined && !OUTPUT_AS.has(outputAs)) {
-      throw new Error(
-        `timeBucket: invalid "as" ${JSON.stringify(outputAs)} for "${resultName}" (expected ${[...OUTPUT_AS].join(", ")}).`,
-      );
-    }
     const entry = Object.entries(fnPart)[0];
     if (!entry) throw new Error(`timeBucket: aggregate "${resultName}" must specify a function.`);
     const [fn, column] = entry;
-    if (!AGG_FNS.has(fn)) {
+    const allowedAs = AGG_AS[fn];
+    if (!allowedAs) {
       throw new Error(`timeBucket: unsupported aggregate function "${fn}" for "${resultName}".`);
+    }
+    if (outputAs !== undefined && !allowedAs.has(outputAs)) {
+      throw new Error(
+        `timeBucket: as: ${JSON.stringify(outputAs)} is not valid for "${fn}" on "${resultName}" (allowed: ${[...allowedAs].join(", ")}).`,
+      );
     }
     const src = quoteIdent(col(column));
     const alias = quoteIdent(resultName);

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -22,16 +22,38 @@ type NumericColumn<R> = { [K in keyof R]-?: NonNullable<R[K]> extends number ? K
 /** Any scalar column name of `R` (valid target for count / groupBy). */
 type AnyColumn<R> = Extract<keyof R, string>;
 
-/** A single aggregate operation: one function applied to one column of `R`. */
+/**
+ * Exact-output selector for an aggregate result column. By default results come back as a JS
+ * `number` (sum/avg are cast to `double precision`, so magnitudes past 2^53 lose precision).
+ * Opt into an exact type per aggregate:
+ *  - `"bigint"` -> a native JS `bigint` (Postgres `::bigint`): exact integers, and avoids the
+ *    `count` overflow that the default `::int` hits past ~2.1B rows in a single bucket.
+ *  - `"string"` -> the exact decimal as a JS `string` (Postgres `::text`): exact for `avg` and
+ *    large fractional sums, JSON-safe, and free of any Prisma-internal type coupling.
+ * Restricted per function: `avg` can't be `"bigint"` (it is fractional); `count` can't be
+ * `"string"` (it is an integer count).
+ */
+export type SumAs = "number" | "bigint" | "string";
+export type AvgAs = "number" | "string";
+export type CountAs = "number" | "bigint";
+
+/** A single aggregate operation: one function applied to one column of `R` (+ optional `as`). */
 export type AggregateOp<R> =
-  | { avg: NumericColumn<R> }
-  | { sum: NumericColumn<R> }
+  | { sum: NumericColumn<R>; as?: SumAs }
+  | { avg: NumericColumn<R>; as?: AvgAs }
   | { min: NumericColumn<R> }
   | { max: NumericColumn<R> }
-  | { count: AnyColumn<R> };
+  | { count: AnyColumn<R>; as?: CountAs };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
+
+/** Map an aggregate op's `as` selector to its result-row TS type (default `number`). */
+export type AggOutput<Op> = Op extends { as: "bigint" }
+  ? bigint
+  : Op extends { as: "string" }
+    ? string
+    : number;
 
 /** Arguments to `timeBucket`. `R` is the model's scalar row, `W` its where input. */
 export interface TimeBucketArgs<R, W = unknown> {
@@ -49,11 +71,11 @@ export interface TimeBucketArgs<R, W = unknown> {
 
 type GroupByOf<A> = A extends { groupBy: ReadonlyArray<infer G> } ? G : never;
 
-/** The inferred result row: bucket + selected group-by columns + each aggregate (as number). */
+/** The inferred result row: bucket + selected group-by columns + each aggregate (typed by `as`). */
 export type TimeBucketRow<R, A extends TimeBucketArgs<R, unknown>> = Prettify<
   { bucket: Date } & { [K in Extract<GroupByOf<A>, keyof R>]: R[K] } & {
     // -readonly: `const A` marks the aggregate keys readonly; the result row shouldn't be.
-    -readonly [K in keyof A["aggregate"]]: number;
+    -readonly [K in keyof A["aggregate"]]: AggOutput<A["aggregate"][K]>;
   }
 >;
 
@@ -68,6 +90,23 @@ export interface TimeBucketMethod {
 // --- runtime SQL builder ---------------------------------------------------
 
 const AGG_FNS = new Set(["avg", "sum", "min", "max", "count"]);
+const OUTPUT_AS = new Set(["number", "bigint", "string"]);
+
+/**
+ * SQL cast that controls the JS type Prisma returns for an aggregate — the cast IS the type
+ * selector (verified against Prisma 7 + @prisma/adapter-pg):
+ *   `::bigint` -> JS `bigint` (exact integers)   `::text` -> JS `string` (exact decimal)
+ * Default (`"number"` / unset): `count` -> `::int`, `sum`/`avg` -> `::double precision`
+ * (JS `number`, loses precision past 2^53), `min`/`max` -> native (already a number for the
+ * numeric column types those accept).
+ */
+function castFor(fn: string, outputAs: string | undefined): string {
+  if (outputAs === "bigint") return "::bigint";
+  if (outputAs === "string") return "::text";
+  if (fn === "count") return "::int";
+  if (fn === "sum" || fn === "avg") return "::double precision";
+  return ""; // min/max keep the column type
+}
 
 /** Loose runtime view of the args (the precise types live in TimeBucketMethod). */
 export interface TimeBucketRuntimeArgs {
@@ -122,7 +161,14 @@ export function buildTimeBucketQuery(
   }
   for (const [resultName, op] of aggregateEntries) {
     assertSafeIdent(resultName, "aggregate result column");
-    const entry = Object.entries(op)[0];
+    // Split the optional `as` selector from the single function entry ({ sum: "x", as: "bigint" }).
+    const { as: outputAs, ...fnPart } = op;
+    if (outputAs !== undefined && !OUTPUT_AS.has(outputAs)) {
+      throw new Error(
+        `timeBucket: invalid "as" ${JSON.stringify(outputAs)} for "${resultName}" (expected ${[...OUTPUT_AS].join(", ")}).`,
+      );
+    }
+    const entry = Object.entries(fnPart)[0];
     if (!entry) throw new Error(`timeBucket: aggregate "${resultName}" must specify a function.`);
     const [fn, column] = entry;
     if (!AGG_FNS.has(fn)) {
@@ -130,19 +176,8 @@ export function buildTimeBucketQuery(
     }
     const src = quoteIdent(col(column));
     const alias = quoteIdent(resultName);
-    // Cast so results come back as JS numbers (matching the typed `number` result), instead
-    // of Prisma's BigInt/Decimal for integer-column aggregates:
-    //   count -> ::int        (Postgres count is bigint)
-    //   sum/avg -> ::float8    (sum of int is bigint; avg of int is numeric)
-    // min/max already return the column's own (numeric) type. NB: float8 means sums beyond
-    // 2^53 lose exactness — acceptable for the `number` contract.
-    if (fn === "count") {
-      select.push(`count(${src})::int AS ${alias}`);
-    } else if (fn === "sum" || fn === "avg") {
-      select.push(`${fn}(${src})::double precision AS ${alias}`);
-    } else {
-      select.push(`${fn}(${src}) AS ${alias}`);
-    }
+    // The cast picks the JS return type: default `number`, or exact `bigint`/`string` via `as`.
+    select.push(`${fn}(${src})${castFor(fn, outputAs)} AS ${alias}`);
   }
 
   let where = `${time} >= $2 AND ${time} < $3`;

--- a/test/integration/reset-safety.test.ts
+++ b/test/integration/reset-safety.test.ts
@@ -135,6 +135,27 @@ describe.skipIf(!DOCKER_OK)("reset-safety (generated migrations)", () => {
       expect(agg.sumDev).toBe(6);
       expect(agg.avgDev).toBeCloseTo(1.2);
 
+      // Exact-output `as` selector (README limitation #2): integer aggregates as a native
+      // `bigint` (exact past 2^53), fractional as an exact decimal `string`, default `number`.
+      const [exact] = await prisma.sensorReading.timeBucket({
+        bucket: "1 day",
+        range: { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") },
+        aggregate: {
+          sumBig: { sum: "deviceId", as: "bigint" },
+          rowsBig: { count: "deviceId", as: "bigint" },
+          avgStr: { avg: "deviceId", as: "string" },
+          sumNum: { sum: "deviceId" },
+        },
+      });
+      expect(typeof exact.sumBig).toBe("bigint");
+      expect(exact.sumBig).toBe(6n);
+      expect(typeof exact.rowsBig).toBe("bigint");
+      expect(exact.rowsBig).toBe(5n); // count of all 5 rows
+      expect(typeof exact.avgStr).toBe("string");
+      expect(Number(exact.avgStr)).toBeCloseTo(1.2); // exact decimal text, e.g. "1.2000000000000000"
+      expect(typeof exact.sumNum).toBe("number");
+      expect(exact.sumNum).toBe(6);
+
       // Refresh the continuous aggregate, then read it as a normal typed Prisma view.
       await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -50,7 +50,61 @@ const rows2 = timeBucket({
 });
 type _inferred2 = Expect<Equal<(typeof rows2)[number], { bucket: Date; total: number }>>;
 
+// --- `as` selector: each aggregate's result type follows its exact-output kind ---
+const exact = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  groupBy: ["deviceId"],
+  aggregate: {
+    bytes: { sum: "temperature", as: "bigint" }, // -> bigint
+    rows: { count: "label", as: "bigint" }, // -> bigint
+    avgStr: { avg: "temperature", as: "string" }, // -> string
+    sumStr: { sum: "temperature", as: "string" }, // -> string
+    plain: { sum: "temperature" }, // -> number (default)
+    explicit: { avg: "temperature", as: "number" }, // -> number
+  },
+});
+type _exact = Expect<
+  Equal<
+    (typeof exact)[number],
+    {
+      bucket: Date;
+      deviceId: number;
+      bytes: bigint;
+      rows: bigint;
+      avgStr: string;
+      sumStr: string;
+      plain: number;
+      explicit: number;
+    }
+  >
+>;
+
 // --- negatives: each must fail to compile ---
+
+// avg cannot be "bigint" (it is fractional)
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - avg does not accept as: "bigint"
+  aggregate: { x: { avg: "temperature", as: "bigint" } },
+});
+
+// count cannot be "string" (it is an integer count)
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - count does not accept as: "string"
+  aggregate: { x: { count: "label", as: "string" } },
+});
+
+// an unknown `as` value
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "float" is not a valid `as`
+  aggregate: { x: { sum: "temperature", as: "float" } },
+});
 
 // avg on a column that doesn't exist
 timeBucket({

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -58,13 +58,13 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`sum("device_id")::bigint AS "total"`);
   });
 
-  it("rejects an invalid `as` value", () => {
-    expect(() =>
-      buildTimeBucketQuery("SensorReading", "time", {
-        ...base,
-        aggregate: { x: { sum: "deviceId", as: "float" } },
-      }),
-    ).toThrow(/invalid "as"/);
+  it("rejects fn + as combinations the types forbid (defensive, for non-TS callers)", () => {
+    const make = (agg: Record<string, Record<string, string>>) => () =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: agg });
+    expect(make({ x: { avg: "deviceId", as: "bigint" } })).toThrow(/not valid for "avg"/); // avg is fractional
+    expect(make({ x: { count: "deviceId", as: "string" } })).toThrow(/not valid for "count"/); // count is an integer
+    expect(make({ x: { min: "deviceId", as: "bigint" } })).toThrow(/not valid for "min"/); // min/max have no `as`
+    expect(make({ x: { sum: "deviceId", as: "float" } })).toThrow(/not valid for "sum"/); // unknown `as` value
   });
 
   it("appends equality filters as bound params", () => {

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -30,6 +30,43 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`max("deviceId") AS "hi"`); // min/max keep the column type
   });
 
+  it("emits exact casts per the `as` selector (bigint -> ::bigint, string -> ::text)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: {
+        total: { sum: "deviceId", as: "bigint" },
+        rows: { count: "deviceId", as: "bigint" },
+        avgStr: { avg: "deviceId", as: "string" },
+        sumStr: { sum: "deviceId", as: "string" },
+        plain: { sum: "deviceId" }, // default -> double precision
+      },
+    });
+    expect(sql).toContain(`sum("deviceId")::bigint AS "total"`);
+    expect(sql).toContain(`count("deviceId")::bigint AS "rows"`); // no ::int overflow past 2^31 rows
+    expect(sql).toContain(`avg("deviceId")::text AS "avgStr"`);
+    expect(sql).toContain(`sum("deviceId")::text AS "sumStr"`);
+    expect(sql).toContain(`sum("deviceId")::double precision AS "plain"`);
+  });
+
+  it("resolves @map columns under an `as` cast", () => {
+    const { sql } = buildTimeBucketQuery(
+      "sensor_readings",
+      "ts",
+      { ...base, aggregate: { total: { sum: "deviceId", as: "bigint" } } },
+      { deviceId: "device_id", time: "ts" },
+    );
+    expect(sql).toContain(`sum("device_id")::bigint AS "total"`);
+  });
+
+  it("rejects an invalid `as` value", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        aggregate: { x: { sum: "deviceId", as: "float" } },
+      }),
+    ).toThrow(/invalid "as"/);
+  });
+
   it("appends equality filters as bound params", () => {
     const { sql, params } = buildTimeBucketQuery("SensorReading", "time", { ...base, where: { deviceId: 1 } });
     expect(sql).toContain(`AND ("deviceId" = $4)`);


### PR DESCRIPTION
## What

Resolves README **limitation #2** (`timeBucket` numeric precision). Aggregates default to a JS
`number` — `sum`/`avg` are cast to `double precision`, so a sum past `2^53` is float64-rounded.
This adds an opt-in **exact** output per aggregate:

```ts
aggregate: {
  total:   { sum: "deviceId", as: "bigint" },    // → bigint  (exact integer)
  samples: { count: "deviceId", as: "bigint" },  // → bigint  (no overflow past ~2.1B rows)
  exact:   { avg: "temperature", as: "string" }, // → string  (exact decimal, e.g. "22.5000…")
  fast:    { sum: "temperature" },               // → number  (default, unchanged)
}
```

- `as: "bigint"` → Postgres `::bigint`, a **native JS `bigint`**. Exact integer sums/counts; also
  fixes the overflow the default `count` (`::int`) hits past ~2.1B rows in one bucket.
- `as: "string"` → Postgres `::text`, an **exact decimal `string`** (JSON-safe). For `avg` and large
  fractional sums.
- `as: "number"` (default) → JS `number`. **Fully backward compatible.**

## How it works

The research (Context7 + an empirical probe against Prisma 7 + `@prisma/adapter-pg` + TimescaleDB)
confirmed the SQL cast alone selects the JS type Prisma returns:

| cast | JS type | exact? |
| --- | --- | --- |
| `::bigint` | `bigint` | ✅ |
| `::numeric` | `Prisma.Decimal` | ✅ |
| `::double precision` | `number` | ❌ loses precision past 2^53 |

So there's **no JS result post-processing** — `castFor(fn, as)` picks the cast, and the runtime
returns the matching native type. Result-row types follow `as` per aggregate; the disallowed combos
(`avg`+`bigint`, `count`+`string`) are **compile errors**.

### Why `string` and not `Prisma.Decimal`

`Prisma.Decimal` *as a type* isn't cleanly importable in a generic package on Prisma 7.8 — it's not
exported from `@prisma/client/extension`, `@prisma/client/runtime/library` isn't in the exports map,
and `decimal.js` isn't a dependency. Typing the result as `Prisma.Decimal` would force a fragile deep
import into Prisma internals, against CLAUDE.md's resilience rule. A `string` is exact, JSON-safe, and
coupling-free.

## Testing

- **Type-level** (`timeBucket.test-d.ts`): `bigint`/`string`/`number` inference per `as`, plus
  `@ts-expect-error` for `avg`+`bigint`, `count`+`string`, and an unknown `as`.
- **Unit** (`timeBucket.test.ts`): `::bigint` / `::text` / default casts, `@map` resolution under a
  cast, invalid-`as` rejection.
- **Integration** (real TimescaleDB): exact `bigint` (`6n`), `count` `bigint` (`5n`), exact `string`
  avg, and default `number` — end-to-end through the generated client + extension.
- All local gates green: 93 unit/type tests, `test:types`, `build`, `attw`, integration `9/9`.

README documents the `as` selector and limitation #2 is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `as` option for time bucket aggregates to control output types: `bigint` for sum/count, `string` for exact decimal values, or default `number`.
  * Updated documentation with supported `as` values and corresponding result types per aggregate function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->