### PR TITLE
feat: data retention policies (`@timescale.retention` + `$timescale`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,11 @@ database) ships in this repo.
 | `@timescale.groupBy` | view field | — |
 | `@timescale.aggregate` | view field | `fn` (`avg`\|`sum`\|`min`\|`max`\|`count`), `column` |
 
-**Intervals** are `"<amount> <unit>"` where unit is `second(s)`, `minute(s)`, `hour(s)`,
-`day(s)`, `week(s)`, `month(s)`, or `year(s)` — validated at compile time (`"1 hour"`, `"7 days"`,
-`"2 years"`).
+**Intervals** are `"<amount> <unit>"` where unit is any PostgreSQL interval input unit —
+`microsecond(s)`, `millisecond(s)`, `second(s)`, `minute(s)`, `hour(s)`, `day(s)`, `week(s)`,
+`month(s)`, `year(s)`, `decade(s)`, or `centur(y|ies)` — validated at compile time *and* runtime
+(`"1 hour"`, `"7 days"`, `"2 years"`). (`quarter` is not an interval unit in PostgreSQL; combined
+forms like `"1 year 2 months"` aren't supported by this single-unit type.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ await prisma.$timescale.refreshContinuousAggregate("SensorHourly");             
 await prisma.$timescale.refreshContinuousAggregate("SensorHourly", { start, end }); // window
 ```
 
+> **Typo-safe.** The model/view names passed to every `$timescale` method (and
+> `addRetentionPolicy` / `removeRetentionPolicy`) are checked against your registered
+> hypertables and continuous aggregates — `refreshContinuousAggregate("SensorHrly")` is a
+> **compile error**, not a runtime surprise. This works automatically from the generated
+> `registry` (and from inline `timescaledb({ hypertables: [...] })` literals); only names built
+> from runtime `string` variables fall back to unchecked `string`.
+
 If a scheduled refresh policy happens to be running on the same continuous aggregate, a manual
 refresh would otherwise fail with `SQLSTATE 55P03` (*"could not refresh … due to a concurrent
 refresh"*). `refreshContinuousAggregate` retries this transient case with bounded exponential

--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ database) ships in this repo.
 | `@timescale.aggregate` | view field | `fn` (`avg`\|`sum`\|`min`\|`max`\|`count`), `column` |
 
 **Intervals** are `"<amount> <unit>"` where unit is `second(s)`, `minute(s)`, `hour(s)`,
-`day(s)`, `week(s)`, or `month(s)` — validated at compile time (`"1 hour"`, `"7 days"`).
+`day(s)`, `week(s)`, `month(s)`, or `year(s)` — validated at compile time (`"1 hour"`, `"7 days"`,
+`"2 years"`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 **breaks on `prisma migrate reset` / `migrate dev`**. This package fixes that with:
 
 - 🧱 **Hypertables & continuous aggregates** from `///` schema annotations
+- 🧹 **Retention policies** — drop old chunks automatically via `@timescale.retention` or `$timescale`
 - ♻️ **Reset-safe migrations** — survive `prisma migrate reset` (proven twice, on real TimescaleDB)
 - 🔎 **Typed `timeBucket(...)` queries** with result-row inference and compile-time column checks
 - 🛟 **Generator-optional** — the client extension works from a manual config too, so a Prisma
   internal-API change can't fully break you
 
-> **v0.1 scope:** hypertables, continuous aggregates, reset-safe migrations, typed query
-> helpers. Vector / BM25 / hypercore / retention are out of scope for now.
+> **Scope:** hypertables, continuous aggregates, retention policies, reset-safe migrations, typed
+> query helpers. Vector / BM25 / hypercore are out of scope for now.
 
 ---
 
@@ -28,6 +29,7 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 - [Quick start](#quick-start)
 - [Setup in detail](#setup-in-detail)
 - [Runtime usage](#runtime-usage)
+- [Data retention (`@timescale.retention`)](#data-retention-timescaleretention)
 - [Without the generator](#without-the-generator-manual-config)
 - [Renamed tables/columns (`@@map` / `@map`)](#renamed-tablescolumns-map--map)
 - [Shadow database](#shadow-database)
@@ -284,6 +286,42 @@ backoff (default: up to 8 attempts); if the contention persists beyond that budg
 
 ---
 
+## Data retention (`@timescale.retention`)
+
+Drop old chunks automatically with a retention policy. Annotate the hypertable model and the
+generator emits a **reset-safe** `add_retention_policy(...)` into the managed migration:
+
+```prisma
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "30 days")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+}
+```
+
+`dropAfter` is an [interval](#annotation-reference): chunks whose data is older than it are dropped
+on TimescaleDB's schedule. The policy survives `prisma migrate reset` like everything else this
+package emits.
+
+You can also manage policies at runtime — and this is the path to use with the
+[manual config](#without-the-generator-manual-config) (no annotation):
+
+```ts
+await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "30 days" });
+await prisma.$timescale.removeRetentionPolicy("SensorReading");
+```
+
+> **Changing `dropAfter`:** TimescaleDB won't *update* an existing policy whose interval differs —
+> `add_retention_policy(… if_not_exists => TRUE)` keeps the old one and warns. To change the window,
+> `removeRetentionPolicy(...)` first (or change the annotation and reset). This is a TimescaleDB
+> behavior, not a plugin limitation.
+
+---
+
 ## Without the generator (manual config)
 
 The client extension works **without** the generator — pass the config directly:
@@ -297,7 +335,8 @@ const prisma = new PrismaClient({ adapter }).$extends(
 ```
 
 The SQL builders are also exported from `prisma-extension-timescaledb/core` for hand-written
-migrations: `createExtensionSql`, `createHypertableSql`, `createContinuousAggregateSql`.
+migrations: `createExtensionSql`, `createHypertableSql`, `createContinuousAggregateSql`,
+`createRetentionPolicySql`.
 
 ---
 
@@ -374,6 +413,7 @@ database) ships in this repo.
 | Annotation | On | Arguments |
 | --- | --- | --- |
 | `@timescale.hypertable` | model | `column` (required), `chunkInterval` (default `"7 days"`) |
+| `@timescale.retention` | model (also a hypertable) | `dropAfter` (required) — drop chunks older than this interval |
 | `@timescale.continuousAggregate` | view | `source`, `bucket`, `timeColumn` (required); `refresh: { startOffset, endOffset, scheduleInterval }` (optional) |
 | `@timescale.bucket` | view field | — (exactly one per aggregate) |
 | `@timescale.groupBy` | view field | — |

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -22,6 +22,30 @@ export interface TimescaleConfig {
   continuousAggregates?: readonly CaggConfig[];
 }
 
+/**
+ * @internal Union of registered hypertable model names from a config (`model ?? table`), used to
+ * type the `$timescale` retention helpers so a typo is a compile error. `never` when none.
+ */
+export type HypertableModelNames<C> = C extends { hypertables: readonly (infer H)[] }
+  ? H extends { model: infer M extends string }
+    ? M
+    : H extends { table: infer T extends string }
+      ? T
+      : never
+  : never;
+
+/** @internal Union of registered continuous-aggregate model names (`model ?? name`), for refresh. */
+export type CaggModelNames<C> = C extends { continuousAggregates: readonly (infer X)[] }
+  ? X extends { model: infer M extends string }
+    ? M
+    : X extends { name: infer N extends string }
+      ? N
+      : never
+  : never;
+
+/** @internal `never` (nothing registered / non-literal names) widens back to `string` so the helper stays callable. */
+export type NamesOrString<T> = [T] extends [never] ? string : T;
+
 interface UnsafeRawClient extends RawClient {
   $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
 }
@@ -32,7 +56,7 @@ interface UnsafeRawClient extends RawClient {
  * @example
  * const prisma = new PrismaClient().$extends(timescaledb(registry));
  */
-export function timescaledb(config: TimescaleConfig = {}) {
+export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(config: C = {} as C) {
   // Key by Prisma model name (ctx.$name); values hold the resolved DB table + schema + column map.
   const hypertableByModel = new Map<
     string,
@@ -78,7 +102,11 @@ export function timescaledb(config: TimescaleConfig = {}) {
         $allModels: { timeBucket },
       },
       client: {
-        $timescale: makeManage(client as unknown as RawClient, caggViewByModel, { hypertableByModel }),
+        $timescale: makeManage<NamesOrString<HypertableModelNames<C>>, NamesOrString<CaggModelNames<C>>>(
+          client as unknown as RawClient,
+          caggViewByModel,
+          { hypertableByModel },
+        ),
       },
     }),
   );

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -78,7 +78,7 @@ export function timescaledb(config: TimescaleConfig = {}) {
         $allModels: { timeBucket },
       },
       client: {
-        $timescale: makeManage(client as unknown as RawClient, caggViewByModel),
+        $timescale: makeManage(client as unknown as RawClient, caggViewByModel, { hypertableByModel }),
       },
     }),
   );

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -44,7 +44,16 @@ export interface ManageOptions {
   sleep?: (ms: number) => Promise<void>;
 }
 
-export interface TimescaleManage {
+/**
+ * The `$timescale` management namespace. The type parameters are the registered model-name
+ * unions taken from the config/registry, so a name argument is checked at compile time — a
+ * typo like `"SensorRead"` is a type error. They default to `string` for the manual config
+ * path or when the names aren't string literals.
+ *
+ * @typeParam HModels - registered hypertable model names (retention helpers)
+ * @typeParam CModels - registered continuous-aggregate model names (refresh)
+ */
+export interface TimescaleManage<HModels extends string = string, CModels extends string = string> {
   /**
    * Refresh a continuous aggregate over an optional time window (SPEC §4.3).
    * Accepts the Prisma view model name; it is resolved to the DB view name (@@map) and passed
@@ -54,7 +63,7 @@ export interface TimescaleManage {
    * If a scheduled refresh policy is running on the same cagg, the manual refresh briefly
    * retries (see SQLSTATE 55P03 below) instead of failing.
    */
-  refreshContinuousAggregate(name: string, range?: RefreshRange): Promise<void>;
+  refreshContinuousAggregate(name: CModels, range?: RefreshRange): Promise<void>;
 
   /**
    * Add a data-retention policy to a hypertable — drops chunks whose data is older than
@@ -62,10 +71,10 @@ export interface TimescaleManage {
    * Idempotent: re-adding an identical policy is a no-op. NB: TimescaleDB will NOT update an
    * existing policy whose `dropAfter` differs — remove it first.
    */
-  addRetentionPolicy(model: string, options: RetentionOptions): Promise<void>;
+  addRetentionPolicy(model: HModels, options: RetentionOptions): Promise<void>;
 
   /** Remove the data-retention policy from a hypertable (no-op if there is none). */
-  removeRetentionPolicy(model: string): Promise<void>;
+  removeRetentionPolicy(model: HModels): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -88,11 +97,11 @@ function isConcurrentRefreshError(err: unknown): boolean {
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** @param viewByModel Prisma view model name -> { DB view name, schema } (for @@map/@@schema). */
-export function makeManage(
+export function makeManage<HModels extends string = string, CModels extends string = string>(
   client: RawClient,
   viewByModel: ReadonlyMap<string, CaggRef> = new Map(),
   options: ManageOptions = {},
-): TimescaleManage {
+): TimescaleManage<HModels, CModels> {
   // Coerce to a finite integer >= 1. A NaN here would make the retry loop's `attempt <=
   // maxAttempts` guard false on the first iteration — a silent no-op that never runs the
   // refresh — and Infinity would retry unboundedly on repeated 55P03; both fall back to 8.

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -1,10 +1,23 @@
 // The $timescale management namespace (SPEC §4.3).
-import { assertSafeIdent, qualifiedIdent } from "../core/sql.js";
+import { assertSafeIdent, qualifiedIdent, quoteLiteral, relationLiteral } from "../core/sql.js";
+import { assertInterval, type Interval } from "../core/interval.js";
 
 /** Resolved DB identity of a continuous aggregate (name + optional @@schema). */
 export interface CaggRef {
   name: string;
   schema?: string;
+}
+
+/** Resolved DB identity of a hypertable (relation + optional @@schema). */
+export interface HypertableRef {
+  table: string;
+  schema?: string;
+}
+
+/** Options for a data-retention policy. */
+export interface RetentionOptions {
+  /** Drop chunks whose data is older than this interval (TimescaleDB `drop_after`). */
+  dropAfter: Interval;
 }
 
 /** Minimal raw-capable client surface we rely on (PrismaClient provides these). */
@@ -18,8 +31,10 @@ export interface RefreshRange {
   end?: Date | null;
 }
 
-/** Tuning for the concurrent-refresh retry. Defaults are sensible; mainly for tests. */
+/** Registry refs + tuning for the `$timescale` namespace. */
 export interface ManageOptions {
+  /** Prisma model name -> hypertable DB relation, for the retention helpers (@@map/@@schema). */
+  hypertableByModel?: ReadonlyMap<string, HypertableRef>;
   /**
    * Max attempts for a refresh that collides with the cagg's background refresh policy
    * (SQLSTATE 55P03). Default 8.
@@ -40,6 +55,17 @@ export interface TimescaleManage {
    * retries (see SQLSTATE 55P03 below) instead of failing.
    */
   refreshContinuousAggregate(name: string, range?: RefreshRange): Promise<void>;
+
+  /**
+   * Add a data-retention policy to a hypertable — drops chunks whose data is older than
+   * `dropAfter`. Accepts the Prisma model name (resolved to the DB relation via @@map/@@schema).
+   * Idempotent: re-adding an identical policy is a no-op. NB: TimescaleDB will NOT update an
+   * existing policy whose `dropAfter` differs — remove it first.
+   */
+  addRetentionPolicy(model: string, options: RetentionOptions): Promise<void>;
+
+  /** Remove the data-retention policy from a hypertable (no-op if there is none). */
+  removeRetentionPolicy(model: string): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -73,6 +99,16 @@ export function makeManage(
   const requestedAttempts = options.maxRefreshAttempts ?? 8;
   const maxAttempts = Number.isFinite(requestedAttempts) ? Math.max(1, Math.floor(requestedAttempts)) : 8;
   const sleep = options.sleep ?? defaultSleep;
+  const hypertableByModel = options.hypertableByModel ?? new Map<string, HypertableRef>();
+
+  /** Resolve a Prisma model name to its hypertable DB relation (identity when unregistered). */
+  const resolveHypertable = (model: string): HypertableRef => {
+    const ref = hypertableByModel.get(model) ?? { table: model };
+    assertSafeIdent(ref.table, "hypertable table");
+    if (ref.schema !== undefined) assertSafeIdent(ref.schema, "hypertable schema");
+    return ref;
+  };
+
   return {
     async refreshContinuousAggregate(name, range) {
       const ref = viewByModel.get(name) ?? { name };
@@ -99,6 +135,22 @@ export function makeManage(
           await sleep(Math.min(50 * 2 ** (attempt - 1), 1000));
         }
       }
+    },
+
+    async addRetentionPolicy(model, opts) {
+      const ref = resolveHypertable(model);
+      assertInterval(opts.dropAfter);
+      const rel = relationLiteral(ref.table, ref.schema);
+      // drop_after is a strict-grammar Interval (assertInterval) quoted as a literal — no cast
+      // on the relation (constraint 2); if_not_exists keeps a re-add a no-op.
+      const sql = `SELECT add_retention_policy(${rel}, drop_after => INTERVAL ${quoteLiteral(opts.dropAfter)}, if_not_exists => TRUE)`;
+      await client.$executeRawUnsafe(sql);
+    },
+
+    async removeRetentionPolicy(model) {
+      const ref = resolveHypertable(model);
+      const rel = relationLiteral(ref.table, ref.schema);
+      await client.$executeRawUnsafe(`SELECT remove_retention_policy(${rel}, if_exists => TRUE)`);
     },
   };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,7 @@
 export type {
   MigrationSql,
   HypertableConfig,
+  RetentionConfig,
   CaggConfig,
   AggregateSpec,
   RefreshPolicy,
@@ -12,4 +13,5 @@ export { assertInterval, isInterval } from "./interval.js";
 export { createExtensionSql } from "./extension.js";
 export { createHypertableSql } from "./hypertable.js";
 export { createContinuousAggregateSql } from "./continuousAggregate.js";
+export { createRetentionPolicySql, type RetentionPolicyConfig } from "./retention.js";
 export { quoteIdent, quoteLiteral, qualifiedIdent, relationLiteral, assertSafeIdent } from "./sql.js";

--- a/src/core/interval.ts
+++ b/src/core/interval.ts
@@ -2,7 +2,15 @@
 // compile time; the runtime validator guards the string we interpolate into SQL (intervals
 // are interpolated, so validating their shape also closes the injection vector there).
 
+// The full set of PostgreSQL interval *input* units (datatype-datetime.html §8.5.4),
+// singular + plural. Note: `quarter` is NOT here — it is an EXTRACT field only, not a valid
+// interval input unit (`INTERVAL '1 quarter'` errors). Combined forms ("1 year 2 months"),
+// ISO 8601, and bare abbreviations are intentionally unsupported by this single-unit type.
 const UNITS = [
+  "microsecond",
+  "microseconds",
+  "millisecond",
+  "milliseconds",
   "second",
   "seconds",
   "minute",
@@ -17,6 +25,10 @@ const UNITS = [
   "months",
   "year",
   "years",
+  "decade",
+  "decades",
+  "century",
+  "centuries",
 ] as const;
 
 type Unit = (typeof UNITS)[number];

--- a/src/core/interval.ts
+++ b/src/core/interval.ts
@@ -15,13 +15,15 @@ const UNITS = [
   "weeks",
   "month",
   "months",
+  "year",
+  "years",
 ] as const;
 
 type Unit = (typeof UNITS)[number];
 
 /**
  * A Postgres/TimescaleDB interval literal, branded at the type level to catch typos at
- * compile time, e.g. `"1 hour"`, `"7 days"`, `"30 minutes"`.
+ * compile time, e.g. `"1 hour"`, `"7 days"`, `"30 minutes"`, `"2 years"`.
  */
 export type Interval = `${number} ${Unit}`;
 

--- a/src/core/retention.ts
+++ b/src/core/retention.ts
@@ -1,0 +1,41 @@
+// Retention policy SQL builder (BUILD_PLAN stretch; CLAUDE.md constraints 2, 3).
+import type { MigrationSql } from "./types.js";
+import type { Interval } from "./interval.js";
+import { assertInterval } from "./interval.js";
+import { assertSafeIdent, quoteLiteral, relationLiteral } from "./sql.js";
+
+/** Retention-policy builder input. All names are DB names (post-@@map / @@schema). */
+export interface RetentionPolicyConfig {
+  /** Hypertable relation name as it exists in the DB, unquoted. */
+  table: string;
+  /** Database schema (@@schema) when using multiSchema; omitted for the default schema. */
+  schema?: string;
+  /** Drop chunks whose data is older than this interval (TimescaleDB `drop_after`). */
+  dropAfter: Interval;
+}
+
+/**
+ * Build the reset-safe `add_retention_policy(...)` SQL — drops chunks older than `dropAfter`.
+ *
+ * - Relation passed as a quoted string literal `'"Table"'` — NO `::regclass` (constraint 2);
+ *   the cast form fails inside Prisma's migration engine (same lesson as `create_hypertable`).
+ * - `if_not_exists => TRUE` makes replay safe (constraint 3): on `migrate reset` an identical
+ *   policy is a NOTICE/no-op. NB: TimescaleDB will NOT update an existing policy whose
+ *   `drop_after` differs — it warns and keeps the old one — so changing `dropAfter` needs a
+ *   remove + re-add, not just a regenerate.
+ *
+ * Down: `remove_retention_policy(..., if_exists => TRUE)` (idempotent).
+ */
+export function createRetentionPolicySql(config: RetentionPolicyConfig): MigrationSql {
+  const { table, schema, dropAfter } = config;
+
+  assertSafeIdent(table, "retention table");
+  if (schema !== undefined) assertSafeIdent(schema, "retention schema");
+  assertInterval(dropAfter);
+
+  const rel = relationLiteral(table, schema);
+  const up = `SELECT add_retention_policy(${rel}, drop_after => INTERVAL ${quoteLiteral(dropAfter)}, if_not_exists => TRUE);`;
+  const down = `SELECT remove_retention_policy(${rel}, if_exists => TRUE);`;
+
+  return { up, down };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,12 @@ export interface MigrationSql {
   down: string;
 }
 
+/** Optional data-retention policy attached to a hypertable (drops chunks older than `dropAfter`). */
+export interface RetentionConfig {
+  /** Drop chunks whose data is older than this interval (TimescaleDB `drop_after`). */
+  dropAfter: Interval;
+}
+
 /** Hypertable conversion config (SPEC §1.1 / §2.2). All names are DB names (post-@@map). */
 export interface HypertableConfig {
   /**
@@ -28,6 +34,8 @@ export interface HypertableConfig {
    * there are no @map renames (callers fall back to identity).
    */
   columns?: Record<string, string>;
+  /** Optional data-retention policy (`@timescale.retention`); omitted means no policy. */
+  retention?: RetentionConfig;
 }
 
 /** A single aggregate column in a continuous aggregate (SPEC §1.2). DB names. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -84,10 +84,11 @@ export interface CaggConfig {
   timeColumn: string;
   /** Output column (view field DB name) for the time_bucket expression (`@timescale.bucket`). */
   bucketColumn: string;
-  /** Optional group-by passthroughs (besides the bucket). */
-  groupBy?: CaggGroupBy[];
-  /** One or more aggregate columns. */
-  aggregates: AggregateSpec[];
+  /** Optional group-by passthroughs (besides the bucket). `readonly` so a generated `as const`
+   * registry is assignable (the generator builds mutable arrays, which assign fine). */
+  groupBy?: readonly CaggGroupBy[];
+  /** One or more aggregate columns. `readonly` for the same `as const` registry reason. */
+  aggregates: readonly AggregateSpec[];
   /** Optional refresh policy; omitted means manual refresh only. */
   refresh?: RefreshPolicy;
 }

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -2,7 +2,7 @@
 // internal shapes (HypertableConfig / CaggConfig) and never touches `options.dmmf`. A Prisma
 // internal-API change should only require edits in this file.
 import type { DMMF } from "@prisma/generator-helper";
-import type { AggregateSpec, CaggConfig, CaggGroupBy, HypertableConfig, RefreshPolicy } from "../core/types.js";
+import type { AggregateSpec, CaggConfig, CaggGroupBy, HypertableConfig, RefreshPolicy, RetentionConfig } from "../core/types.js";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import {
@@ -34,6 +34,11 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
     const annotations = parseAnnotations(model.documentation);
     if (findAnnotation(annotations, "hypertable")) {
       hypertables.push(buildHypertable(model, annotations));
+    } else if (findAnnotation(annotations, "retention")) {
+      // Retention attaches to a hypertable's chunks; it is meaningless on a plain model.
+      throw new Error(
+        `@timescale.retention on model "${model.name}": only valid together with @timescale.hypertable.`,
+      );
     }
     if (findAnnotation(annotations, "continuousAggregate")) {
       continuousAggregates.push(buildCagg(model, annotations, byName));
@@ -73,6 +78,7 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
 
   const columns = columnMap(model);
   const table = dbTable(model);
+  const retention = buildRetention(annotations, model.name);
 
   return {
     ...(model.name !== table ? { model: model.name } : {}),
@@ -81,7 +87,20 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
     column: dbCol(field),
     ...(chunkInterval !== undefined ? { chunkInterval: chunkInterval as Interval } : {}),
     ...(Object.keys(columns).length > 0 ? { columns } : {}),
+    ...(retention ? { retention } : {}),
   };
+}
+
+function buildRetention(
+  annotations: ReturnType<typeof parseAnnotations>,
+  modelName: string,
+): RetentionConfig | undefined {
+  const ann = findAnnotation(annotations, "retention");
+  if (!ann) return undefined;
+  const ctx = `@timescale.retention on model "${modelName}"`;
+  const dropAfter = requireString(ann.args, "dropAfter", ctx);
+  assertInterval(dropAfter);
+  return { dropAfter: dropAfter as Interval };
 }
 
 function buildCagg(

--- a/src/generator/emit-migrations.ts
+++ b/src/generator/emit-migrations.ts
@@ -10,6 +10,7 @@ import type { TimescaleSchema } from "./dmmf.js";
 import { createExtensionSql } from "../core/extension.js";
 import { createHypertableSql } from "../core/hypertable.js";
 import { createContinuousAggregateSql } from "../core/continuousAggregate.js";
+import { createRetentionPolicySql } from "../core/retention.js";
 
 export const EXTENSION_MIGRATION = "00000000000000_timescaledb_extension";
 export const OBJECTS_MIGRATION = "99999999999999_timescaledb_objects";
@@ -36,6 +37,14 @@ ${createExtensionSql().up}
   const parts: string[] = [];
   for (const h of hypertables) {
     parts.push(`-- Hypertable: ${h.table}\n${createHypertableSql(h).up}`);
+    if (h.retention) {
+      const sql = createRetentionPolicySql({
+        table: h.table,
+        ...(h.schema !== undefined ? { schema: h.schema } : {}),
+        dropAfter: h.retention.dropAfter,
+      }).up;
+      parts.push(`-- Retention policy: ${h.table}\n${sql}`);
+    }
   }
   for (const c of caggs) {
     parts.push(`-- Continuous aggregate: ${c.name}\n${createContinuousAggregateSql(c).up}`);

--- a/test/integration/retention.test.ts
+++ b/test/integration/retention.test.ts
@@ -1,0 +1,81 @@
+// Retention policies end-to-end on a real TimescaleDB: the generator emits a reset-safe
+// add_retention_policy from @timescale.retention, and the $timescale runtime helpers
+// add/remove a policy. Verified against timescaledb_information.jobs.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+// Hypertable-only schema with a retention policy (matches the harness default CREATE TABLE).
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "30 days")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+async function retentionJobs(h: Harness): Promise<number> {
+  const [row] = await h.query<{ n: number }>(
+    "SELECT count(*)::int AS n FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention'",
+  );
+  return row?.n ?? 0;
+}
+
+describe.skipIf(!DOCKER_OK)("retention policies (generated + runtime)", () => {
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+  });
+
+  afterAll(async () => {
+    await h?.stop();
+  });
+
+  it("emits a reset-safe retention policy from @timescale.retention", async () => {
+    h.prisma(["migrate", "deploy"]);
+    expect(await retentionJobs(h)).toBe(1);
+
+    // Reproduced across `migrate reset` (idempotent replay, zero manual steps).
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await retentionJobs(h)).toBe(1);
+  });
+
+  it("$timescale.addRetentionPolicy / removeRetentionPolicy operate at runtime", async () => {
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+
+    const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    const prisma = base.$extends(timescaledb(registry));
+    try {
+      await prisma.$timescale.removeRetentionPolicy("SensorReading");
+      expect(await retentionJobs(h)).toBe(0);
+
+      await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      expect(await retentionJobs(h)).toBe(1);
+
+      // Idempotent: re-adding the identical policy is a no-op, not an error.
+      await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      expect(await retentionJobs(h)).toBe(1);
+    } finally {
+      await base.$disconnect();
+    }
+  });
+});

--- a/test/integration/retention.test.ts
+++ b/test/integration/retention.test.ts
@@ -17,6 +17,12 @@ const DOCKER_OK = (() => {
   }
 })();
 
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED retention.test.ts: Docker is not available. Retention policies are NOT verified.\n",
+  );
+}
+
 // Hypertable-only schema with a retention policy (matches the harness default CREATE TABLE).
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 /// @timescale.retention(dropAfter: "30 days")

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -1,0 +1,71 @@
+// Type-level tests for the $timescale model-name type-safety (checked by `npm run test:types`).
+// A name argument is constrained to the registered model names, so a typo fails to compile.
+import { timescaledb } from "../../src/index.js";
+import type { CaggModelNames, HypertableModelNames, NamesOrString } from "../../src/client/index.js";
+import type { TimescaleManage } from "../../src/client/manage.js";
+
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// --- 1) the generic namespace constrains the name arguments ---
+declare const m: TimescaleManage<"SensorReading" | "DeviceLog", "SensorHourly">;
+
+m.addRetentionPolicy("SensorReading", { dropAfter: "1 day" }); // ok
+m.addRetentionPolicy("DeviceLog", { dropAfter: "1 day" }); // ok
+m.removeRetentionPolicy("SensorReading"); // ok
+m.refreshContinuousAggregate("SensorHourly"); // ok
+
+// @ts-expect-error - "SensorRead" is not a registered hypertable
+m.addRetentionPolicy("SensorRead", { dropAfter: "1 day" });
+// @ts-expect-error - typo on remove
+m.removeRetentionPolicy("SensorRaeding");
+// @ts-expect-error - "SensorHrly" is not a registered continuous aggregate
+m.refreshContinuousAggregate("SensorHrly");
+
+// The default (no type args) stays `string` for the manual / non-literal path.
+declare const loose: TimescaleManage;
+loose.addRetentionPolicy("anything", { dropAfter: "1 day" }); // ok — string fallback
+loose.refreshContinuousAggregate("anything"); // ok
+
+// --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
+const mapped = {
+  hypertables: [{ model: "SensorReading", table: "sensor_readings" }],
+  continuousAggregates: [{ model: "SensorHourly", name: "sensor_hourly" }],
+} as const;
+type _mh = Expect<Equal<HypertableModelNames<typeof mapped>, "SensorReading">>;
+type _mc = Expect<Equal<CaggModelNames<typeof mapped>, "SensorHourly">>;
+
+// No @@map -> the model name is the table / view name.
+const plain = {
+  hypertables: [{ table: "SensorReading" }],
+  continuousAggregates: [{ name: "SensorHourly" }],
+} as const;
+type _ph = Expect<Equal<HypertableModelNames<typeof plain>, "SensorReading">>;
+type _pc = Expect<Equal<CaggModelNames<typeof plain>, "SensorHourly">>;
+
+// Multiple hypertables -> a union.
+const multi = { hypertables: [{ table: "A" }, { table: "B" }] } as const;
+type _multi = Expect<Equal<HypertableModelNames<typeof multi>, "A" | "B">>;
+
+// Nothing registered -> never -> widens back to string (helper stays callable).
+type _none = Expect<Equal<NamesOrString<HypertableModelNames<Record<string, never>>>, string>>;
+
+// --- 3) timescaledb() accepts the generated `as const` registry shape (end-to-end signature) ---
+const registry = {
+  hypertables: [{ model: "SensorReading", table: "sensor_readings", column: "ts", chunkInterval: "1 day" }],
+  continuousAggregates: [
+    {
+      model: "SensorHourly",
+      name: "sensor_hourly",
+      source: "sensor_readings",
+      bucket: "1 hour",
+      timeColumn: "ts",
+      bucketColumn: "bucket",
+      aggregates: [{ name: "avgTemp", fn: "avg", column: "temperature" }],
+    },
+  ],
+} as const;
+void timescaledb(registry);
+void timescaledb(); // no-arg path
+
+export {};

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createExtensionSql } from "../../src/core/extension.js";
 import { createHypertableSql } from "../../src/core/hypertable.js";
 import { createContinuousAggregateSql } from "../../src/core/continuousAggregate.js";
+import { createRetentionPolicySql } from "../../src/core/retention.js";
 import type { CaggConfig } from "../../src/core/types.js";
 
 describe("createExtensionSql", () => {
@@ -131,5 +132,39 @@ SELECT add_continuous_aggregate_policy('"SensorHourly"',
     expect(sql.up).toContain(`FROM "metrics"."SensorReading"`);
     expect(sql.up).toContain(`add_continuous_aggregate_policy('"metrics"."SensorHourly"'`);
     expect(sql.down).toBe(`DROP MATERIALIZED VIEW IF EXISTS "metrics"."SensorHourly";`);
+  });
+});
+
+describe("createRetentionPolicySql", () => {
+  const sql = createRetentionPolicySql({ table: "SensorReading", dropAfter: "30 days" });
+
+  it("matches the reset-safe add/remove retention SQL", () => {
+    expect(sql.up).toBe(
+      `SELECT add_retention_policy('"SensorReading"', drop_after => INTERVAL '30 days', if_not_exists => TRUE);`,
+    );
+    expect(sql.down).toBe(`SELECT remove_retention_policy('"SensorReading"', if_exists => TRUE);`);
+  });
+
+  it("contains NO ::regclass cast; passes the relation as a quoted string literal (constraint 2)", () => {
+    expect(sql.up).not.toContain("::regclass");
+    expect(sql.up).toContain(`'"SensorReading"'`);
+  });
+
+  it("is idempotent up and down (if_not_exists / if_exists)", () => {
+    expect(sql.up).toContain("if_not_exists => TRUE");
+    expect(sql.down).toContain("if_exists => TRUE");
+  });
+
+  it("schema-qualifies the relation under multiSchema (@@schema)", () => {
+    const q = createRetentionPolicySql({ table: "sensor_readings", schema: "metrics", dropAfter: "7 days" });
+    expect(q.up).toContain(`'"metrics"."sensor_readings"'`);
+    expect(q.down).toContain(`'"metrics"."sensor_readings"'`);
+  });
+
+  it("rejects bad identifiers and intervals", () => {
+    expect(() => createRetentionPolicySql({ table: "a-b", dropAfter: "30 days" })).toThrow(/Invalid/);
+    expect(() => createRetentionPolicySql({ table: "X", dropAfter: "1 fortnight" as never })).toThrow(
+      /Invalid interval/,
+    );
   });
 });

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -303,3 +303,60 @@ view SensorHourly {
     ]);
   });
 });
+
+describe("extractTimescaleSchema — retention", () => {
+  it("parses @timescale.retention(dropAfter) on a hypertable", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "30 days")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables).toEqual([
+      { table: "SensorReading", column: "time", chunkInterval: "1 day", retention: { dropAfter: "30 days" } },
+    ]);
+  });
+
+  it("rejects @timescale.retention without @timescale.hypertable", async () => {
+    await expect(
+      extract(`
+/// @timescale.retention(dropAfter: "30 days")
+model Plain {
+  id   Int      @id
+  time DateTime
+}
+`),
+    ).rejects.toThrow(/only valid together with @timescale.hypertable/);
+  });
+
+  it("requires the dropAfter argument", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+/// @timescale.retention
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/missing or non-string argument "dropAfter"/);
+  });
+
+  it("rejects an invalid dropAfter interval", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+/// @timescale.retention(dropAfter: "1 fortnight")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/Invalid interval/);
+  });
+});

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -123,6 +123,36 @@ describe("emitMigrations", () => {
       "
     `);
   });
+
+  it("emits the retention policy after its hypertable when @timescale.retention is set", async () => {
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views"]
+}
+datasource db {
+  provider = "postgresql"
+}
+
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "30 days")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`,
+    });
+    const objects = emitMigrations(extractTimescaleSchema(dmmf))[`${OBJECTS_MIGRATION}/migration.sql`]!;
+    expect(objects).toContain(
+      `SELECT add_retention_policy('"SensorReading"', drop_after => INTERVAL '30 days', if_not_exists => TRUE);`,
+    );
+    expect(objects).not.toContain("::regclass");
+    // Retention is emitted after the create_hypertable it depends on.
+    expect(objects.indexOf("create_hypertable")).toBeLessThan(objects.indexOf("add_retention_policy"));
+  });
 });
 
 describe("emitTypes", () => {

--- a/test/unit/interval.test.ts
+++ b/test/unit/interval.test.ts
@@ -2,15 +2,31 @@ import { describe, expect, it } from "vitest";
 import { assertInterval, isInterval } from "../../src/core/interval.js";
 
 describe("interval", () => {
-  it("accepts well-formed intervals", () => {
-    for (const v of ["1 hour", "7 days", "30 minutes", "1 second", "12 months", "2 weeks", "1.5 days", "1 year", "2 years"]) {
+  it("accepts well-formed intervals across the full PostgreSQL unit set", () => {
+    for (const v of [
+      "1 hour",
+      "7 days",
+      "30 minutes",
+      "1 second",
+      "12 months",
+      "2 weeks",
+      "1.5 days",
+      "1 year",
+      "2 years",
+      "500 microseconds",
+      "250 milliseconds",
+      "3 decades",
+      "1 century",
+      "2 centuries",
+    ]) {
       expect(isInterval(v)).toBe(true);
       expect(() => assertInterval(v)).not.toThrow();
     }
   });
 
-  it("rejects malformed intervals", () => {
-    for (const v of ["hour", "1hour", "1 fortnight", "1  hour", " 1 hour", "1 hour ", "-1 hours", ""]) {
+  it("rejects malformed intervals and non-input units (quarter, millennium)", () => {
+    // `quarter` / `millennium` are EXTRACT fields, not interval input units in PostgreSQL.
+    for (const v of ["hour", "1hour", "1 fortnight", "1 quarter", "1 millennium", "1  hour", " 1 hour", "1 hour ", "-1 hours", ""]) {
       expect(isInterval(v)).toBe(false);
       expect(() => assertInterval(v)).toThrow(/Invalid interval/);
     }

--- a/test/unit/interval.test.ts
+++ b/test/unit/interval.test.ts
@@ -3,7 +3,7 @@ import { assertInterval, isInterval } from "../../src/core/interval.js";
 
 describe("interval", () => {
   it("accepts well-formed intervals", () => {
-    for (const v of ["1 hour", "7 days", "30 minutes", "1 second", "12 months", "2 weeks", "1.5 days"]) {
+    for (const v of ["1 hour", "7 days", "30 minutes", "1 second", "12 months", "2 weeks", "1.5 days", "1 year", "2 years"]) {
       expect(isInterval(v)).toBe(true);
       expect(() => assertInterval(v)).not.toThrow();
     }

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -121,3 +121,44 @@ describe("makeManage.refreshContinuousAggregate", () => {
     }
   });
 });
+
+describe("makeManage retention policies", () => {
+  it("addRetentionPolicy emits add_retention_policy with the quoted relation literal", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).addRetentionPolicy("SensorReading", { dropAfter: "30 days" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toBe(
+      `SELECT add_retention_policy('"SensorReading"', drop_after => INTERVAL '30 days', if_not_exists => TRUE)`,
+    );
+    expect(calls[0]!.params).toEqual([]);
+  });
+
+  it("resolves the model to its @@map / @@schema relation", async () => {
+    const { client, calls } = fakeClient();
+    const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+    await makeManage(client, new Map(), { hypertableByModel }).addRetentionPolicy("SensorReading", {
+      dropAfter: "7 days",
+    });
+    expect(calls[0]!.sql).toBe(
+      `SELECT add_retention_policy('"metrics"."sensor_readings"', drop_after => INTERVAL '7 days', if_not_exists => TRUE)`,
+    );
+  });
+
+  it("removeRetentionPolicy emits an idempotent remove", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).removeRetentionPolicy("SensorReading");
+    expect(calls[0]!.sql).toBe(`SELECT remove_retention_policy('"SensorReading"', if_exists => TRUE)`);
+  });
+
+  it("rejects an invalid dropAfter interval", async () => {
+    const { client } = fakeClient();
+    await expect(
+      makeManage(client).addRetentionPolicy("SensorReading", { dropAfter: "1 fortnight" as never }),
+    ).rejects.toThrow(/Invalid interval/);
+  });
+
+  it("rejects an unsafe model/relation name", async () => {
+    const { client } = fakeClient();
+    await expect(makeManage(client).addRetentionPolicy("bad name", { dropAfter: "1 day" })).rejects.toThrow(/Invalid/);
+  });
+});


### PR DESCRIPTION
## What

Adds TimescaleDB **data retention** as a third managed object type alongside hypertables and
continuous aggregates — drop old chunks automatically. Both the generator path and a runtime path:

```prisma
/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
/// @timescale.retention(dropAfter: "30 days")
model SensorReading { ... }
```
```ts
await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "30 days" });
await prisma.$timescale.removeRetentionPolicy("SensorReading");
```

This was the BUILD_PLAN-flagged next step ("small, high-value, and absent from the official package").

## How

- **core** — `createRetentionPolicySql({ table, schema?, dropAfter })` → reset-safe
  `add_retention_policy` / `remove_retention_policy`. Cast-free quoted relation literal
  (`'"SensorReading"'`, **constraint 2**); `if_not_exists` / `if_exists` for idempotent replay.
- **generator** — parse `@timescale.retention(dropAfter)` on hypertable models; emit the policy into
  the objects migration **after** `create_hypertable`; reject the annotation on non-hypertables.
- **runtime** — `$timescale.addRetentionPolicy` / `removeRetentionPolicy`, resolving the Prisma model
  name to its `@@map`/`@@schema` relation.

## Research (before coding)

- Pulled the current `add_retention_policy` signature from TimescaleDB source (Context7):
  `(relation REGCLASS, drop_after "any", if_not_exists, schedule_interval, initial_start, timezone, drop_created_before)`.
- **Empirically verified** (throwaway probe, since deleted) that the cast-free string-literal
  relation form applies through **Prisma's migration engine** (the thing `create_hypertable` breaks
  on with `::regclass`), survives `migrate reset`, and that `remove_retention_policy(… if_exists)` is
  a safe down. The reset-safe shape is proven, not assumed.
- **Documented caveat:** `add_retention_policy(… if_not_exists => TRUE)` returns `-1` + a WARNING and
  does **not** update an existing policy whose `drop_after` differs — so changing `dropAfter` needs a
  remove + re-add. Surfaced in the README.

## Testing

- **Unit:** core SQL (up/down, no-cast, `@@schema`, interval validation), annotation parsing (valid +
  non-hypertable / missing-arg / bad-interval errors), generator emission (policy after its
  hypertable), and the runtime helpers (`@@map`/`@@schema` resolution, idempotent SQL, rejections).
- **Integration (real TimescaleDB):** `@timescale.retention` → migration → **reset-safe** (job
  reproduced after `migrate reset`); runtime add/remove round-trip incl. idempotent re-add.
- All gates green: **108** unit/type tests, `test:types`, `build`, `attw`, integration **11/11**.

README gains a "Data retention" section, an annotation-reference row, and the change-caveat; the
scope note now lists retention as supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TimescaleDB data retention policies via `@timescale.retention(dropAfter: ...)`, generating idempotent, reset-safe migration SQL.
  * Added runtime management: `addRetentionPolicy` / `removeRetentionPolicy` with model-name typing, plus `createRetentionPolicySql` for manual SQL generation.
  * Extended supported interval literals to include `year` / `years`.
* **Documentation**
  * Updated README with retention policy scope, usage, and management details.
* **Tests**
  * Added unit/integration coverage for SQL generation, DMMF parsing/validation, migration output ordering, and runtime idempotency/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->