### PR TITLE
feat: support nested `not: { ... }` in timeBucket where

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ const rows = await prisma.sensorReading.timeBucket({
   range: { start, end },          // both bounds required
   where: {                        // Prisma where operators + AND/OR/NOT
     deviceId: { in: [1, 2] },
-    temperature: { gte: 20, lt: 35 },
+    temperature: { gte: 20, lt: 35, not: { equals: 25 } }, // nested `not` is supported
   },
   groupBy: ["deviceId"],
   aggregate: {
@@ -449,10 +449,12 @@ forms like `"1 year 2 months"` aren't supported by this single-unit type.)
 
 ## Limitations (v0.1)
 
-- **`timeBucket` `where`** supports scalar operators (`equals`, `not`, `in`, `notIn`, `lt`,
-  `lte`, `gt`, `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null`
-  checks, and `AND`/`OR`/`NOT`. **Relation filters** (`some`/`none`/`every`) and nested
-  `not: { ... }` are not supported (they can't be a single-table query) and throw a clear error.
+- **`timeBucket` `where`** supports scalar operators (`equals`, `not` — including nested
+  `not: { ... }`, e.g. `{ deviceId: { not: { in: [1, 2] } } }` — `in`, `notIn`, `lt`, `lte`, `gt`,
+  `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null` checks, and
+  `AND`/`OR`/`NOT`. Negation matches Prisma's `findMany` semantics, including **NULL exclusion**
+  under `not` (SQL three-valued logic). **Relation filters** (`some`/`none`/`every`/`is`) are not
+  supported — they can't be a single-table query — and throw a clear error.
 - **`timeBucket` numeric precision:** aggregates **default** to JS `number` (`count` → `int`,
   `sum`/`avg` → `double precision`), so a default `sum` beyond 2^53 is float64-rounded. For exact
   results, opt an aggregate into [`as: "bigint"`](#exact-aggregate-results-as-bigint--string)

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -2,10 +2,9 @@
 // single-table timeBucket query. Values are always bound as parameters; column names are
 // resolved + identifier-checked by the caller, so the result is injection-safe.
 //
-// Supported: equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith
-// (+ mode: "insensitive"), null checks, shorthand equality, and AND / OR / NOT.
-// Unsupported (throws): relation filters (some/none/every), nested `not: {...}`, and any
-// operator not in the list above.
+// Supported: equals, not (incl. nested `not: { ... }`), in, notIn, lt, lte, gt, gte, contains,
+// startsWith, endsWith (+ mode: "insensitive"), null checks, shorthand equality, and AND / OR / NOT.
+// Unsupported (throws): relation filters (some/none/every) and any operator not in the list above.
 
 export interface WhereCtx {
   /** Resolve a Prisma field name to a quoted DB column (e.g. `deviceId` -> `"device_id"`). */
@@ -55,13 +54,16 @@ function fieldClause(field: string, value: unknown, ctx: WhereCtx): string {
   if (Array.isArray(value)) {
     throw new Error(`timeBucket: unsupported array filter on "${field}".`);
   }
+  return operatorMapToSql(c, field, value as Record<string, unknown>, ctx);
+}
 
-  const filter = value as Record<string, unknown>;
+/** AND together every operator clause in a filter object (e.g. `{ gte, lt }`). `mode` applies to LIKE ops. */
+function operatorMapToSql(col: string, field: string, filter: Record<string, unknown>, ctx: WhereCtx): string {
   const mode = filter["mode"] === "insensitive" ? "insensitive" : undefined;
   const parts: string[] = [];
   for (const [op, v] of Object.entries(filter)) {
     if (v === undefined || op === "mode") continue;
-    parts.push(operatorClause(c, field, op, v, mode, ctx));
+    parts.push(operatorClause(col, field, op, v, mode, ctx));
   }
   return parts.join(" AND ");
 }
@@ -80,7 +82,13 @@ function operatorClause(
     case "not":
       if (v === null) return `${col} IS NOT NULL`;
       if (isScalar(v)) return `${col} <> ${ctx.push(v)}`;
-      throw new Error(`timeBucket: nested "not" filter on "${field}" is not supported.`);
+      if (Array.isArray(v)) {
+        throw new Error(`timeBucket: "not" on "${field}" cannot be an array — use { not: { in: [...] } } or notIn.`);
+      }
+      // Negate a nested filter object. NOT (...) reproduces Prisma's findMany semantics exactly,
+      // including NULL handling: under negation NULL rows are excluded (SQL three-valued logic —
+      // NOT(unknown) is unknown — verified against Prisma). Recurses for deeper nesting.
+      return `NOT (${operatorMapToSql(col, field, v as Record<string, unknown>, ctx)})`;
     case "in":
       return inClause(col, v, false, field, ctx);
     case "notIn":

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -63,7 +63,8 @@ function operatorMapToSql(col: string, field: string, filter: Record<string, unk
   const parts: string[] = [];
   for (const [op, v] of Object.entries(filter)) {
     if (v === undefined || op === "mode") continue;
-    parts.push(operatorClause(col, field, op, v, mode, ctx));
+    const clause = operatorClause(col, field, op, v, mode, ctx);
+    if (clause) parts.push(clause); // skip empties (e.g. an empty nested `not`) so the AND join stays valid
   }
   return parts.join(" AND ");
 }
@@ -87,8 +88,12 @@ function operatorClause(
       }
       // Negate a nested filter object. NOT (...) reproduces Prisma's findMany semantics exactly,
       // including NULL handling: under negation NULL rows are excluded (SQL three-valued logic —
-      // NOT(unknown) is unknown — verified against Prisma). Recurses for deeper nesting.
-      return `NOT (${operatorMapToSql(col, field, v as Record<string, unknown>, ctx)})`;
+      // NOT(unknown) is unknown — verified against Prisma). Recurses for deeper nesting. An empty
+      // inner filter (`not: {}` / only `mode`) is a no-op (like an empty top-level NOT), not `NOT ()`.
+      {
+        const inner = operatorMapToSql(col, field, v as Record<string, unknown>, ctx);
+        return inner ? `NOT (${inner})` : "";
+      }
     case "in":
       return inClause(col, v, false, field, ctx);
     case "notIn":

--- a/test/integration/where-not.test.ts
+++ b/test/integration/where-not.test.ts
@@ -1,0 +1,94 @@
+// Nested `not: { ... }` in timeBucket where, end-to-end on real TimescaleDB. Proves the SQL
+// executes and that negation excludes NULL rows — matching Prisma's findMany (verified by the
+// research probe). Uses a nullable column so the NULL-exclusion is observable.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED where-not.test.ts: Docker is not available. Nested not is NOT verified.\n",
+  );
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time   DateTime
+  id     Int
+  device Int?
+
+  @@id([id, time])
+}`;
+
+const INIT_SQL = `CREATE TABLE "Reading" (
+    "time" TIMESTAMP(3) NOT NULL,
+    "id" INTEGER NOT NULL,
+    "device" INTEGER,
+
+    CONSTRAINT "Reading_pkey" PRIMARY KEY ("id","time")
+);`;
+
+describe.skipIf(!DOCKER_OK)("timeBucket nested not (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    await prisma.reading.createMany({
+      data: [
+        { time: new Date("2026-06-15T10:05:00Z"), id: 1, device: 1 },
+        { time: new Date("2026-06-15T10:15:00Z"), id: 2, device: 1 },
+        { time: new Date("2026-06-15T10:25:00Z"), id: 3, device: 2 },
+        { time: new Date("2026-06-15T10:35:00Z"), id: 4, device: null }, // NULL device
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") };
+  const count = async (where?: unknown): Promise<number> => {
+    const [row] = await prisma.reading.timeBucket({ bucket: "1 hour", range, where, aggregate: { n: { count: "id" } } });
+    return Number(row?.n ?? 0);
+  };
+
+  it("counts all rows with no filter (control)", async () => {
+    expect(await count()).toBe(4);
+  });
+
+  it("not: { in } negates and excludes NULL", async () => {
+    // device <> 1 → only device=2 (id 3); device=1 rows and the NULL row are excluded.
+    expect(await count({ device: { not: { in: [1] } } })).toBe(1);
+  });
+
+  it("not: { gte } negates the comparison and excludes NULL", async () => {
+    // NOT(device >= 2) → device < 2 → device=1 (ids 1,2); device=2 and the NULL row excluded.
+    expect(await count({ device: { not: { gte: 2 } } })).toBe(2);
+  });
+});

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -84,9 +84,37 @@ describe("whereToSql", () => {
     );
   });
 
-  it("throws on unsupported operator, relation filter, and nested not", () => {
+  it("nested not negates the inner filter as NOT (...) (matches Prisma; NULLs excluded)", () => {
+    const a = harness();
+    expect(whereToSql({ deviceId: { not: { in: [1, 2] } } }, a.ctx)).toBe(`NOT ("deviceId" IN ($1, $2))`);
+    expect(a.params).toEqual([1, 2]);
+
+    const b = harness();
+    expect(whereToSql({ temperature: { not: { gte: 30 } } }, b.ctx)).toBe(`NOT ("temperature" >= $1)`);
+    expect(b.params).toEqual([30]);
+
+    // multiple inner operators are ANDed inside the negation
+    const c = harness();
+    expect(whereToSql({ temperature: { not: { gte: 20, lt: 30 } } }, c.ctx)).toBe(
+      `NOT ("temperature" >= $1 AND "temperature" < $2)`,
+    );
+    expect(c.params).toEqual([20, 30]);
+
+    // a LIKE op + mode inside not
+    const d = harness();
+    expect(whereToSql({ label: { not: { contains: "x", mode: "insensitive" } } }, d.ctx)).toBe(
+      `NOT ("label" ILIKE $1 ESCAPE '\\')`,
+    );
+    expect(d.params).toEqual(["%x%"]);
+  });
+
+  it("throws on unsupported operators, relation filters (incl. inside not), and not: [array]", () => {
     expect(() => whereToSql({ deviceId: { foo: 1 } }, harness().ctx)).toThrow(/unsupported where operator "foo"/);
     expect(() => whereToSql({ author: { some: {} } }, harness().ctx)).toThrow(/unsupported where operator "some"/);
-    expect(() => whereToSql({ deviceId: { not: { gt: 1 } } }, harness().ctx)).toThrow(/nested "not"/);
+    // relation filters nested inside not still throw clearly
+    expect(() => whereToSql({ author: { not: { some: {} } } }, harness().ctx)).toThrow(
+      /unsupported where operator "some"/,
+    );
+    expect(() => whereToSql({ deviceId: { not: [1, 2] } }, harness().ctx)).toThrow(/cannot be an array/);
   });
 });

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -108,6 +108,15 @@ describe("whereToSql", () => {
     expect(d.params).toEqual(["%x%"]);
   });
 
+  it("empty nested not (not: {} or only mode) is a no-op, never NOT ()", () => {
+    expect(whereToSql({ deviceId: { not: {} } }, harness().ctx)).toBe("");
+    expect(whereToSql({ label: { not: { mode: "insensitive" } } }, harness().ctx)).toBe("");
+    // combined with a real operator on the same field, the empty not simply drops out
+    const a = harness();
+    expect(whereToSql({ temperature: { not: {}, gte: 5 } }, a.ctx)).toBe(`"temperature" >= $1`);
+    expect(a.params).toEqual([5]);
+  });
+
   it("throws on unsupported operators, relation filters (incl. inside not), and not: [array]", () => {
     expect(() => whereToSql({ deviceId: { foo: 1 } }, harness().ctx)).toThrow(/unsupported where operator "foo"/);
     expect(() => whereToSql({ author: { some: {} } }, harness().ctx)).toThrow(/unsupported where operator "some"/);


### PR DESCRIPTION
## What

Closes the addable half of the `timeBucket` `where` limitation: **nested `not: { ... }`** now works.

```ts
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  where: {
    deviceId: { not: { in: [1, 2] } },   // NOT ("deviceId" IN ($1, $2))
    temperature: { not: { gte: 30 } },   // NOT ("temperature" >= $1)
  },
  aggregate: { n: { count: "deviceId" } },
});
```

Previously this threw `nested "not" filter ... is not supported`. (Relation filters `some`/`none`/`every`/`is` remain unsupported — they genuinely can't be a single-table query.)

## How — and the research behind it

I captured Prisma's **actual** `findMany` SQL + results for `not` on a NULLABLE column (throwaway probe, since deleted). Two findings drove the design:

| `not` form (data `device [1,2,NULL]`) | Prisma returns | Prisma SQL |
| --- | --- | --- |
| `not: { equals: 1 }` | `[2]` | `device <> $1` |
| `not: { in: [1] }` | `[2]` | `device NOT IN ($1)` |
| `not: { gte: 2 }` | `[1]` | `device < $1` |

1. **Prisma excludes NULLs under negation** (no `OR … IS NULL` added) — so our existing `not: scalar` → `col <> v` already matched.
2. **`NOT (inner)` is result-equivalent to Prisma's per-operator inversion**, because SQL three-valued logic makes `NOT(NULL)` → excluded, exactly like `device < 2` excludes NULL. So I negate the whole inner filter as `NOT (...)` — matching Prisma's result set for every operator, with far less code than inverting each operator. It also recurses for deeper nesting, and `not: [array]` / relation filters inside `not` throw a clear error.

## Testing

- **Unit** (`where.test.ts`): `NOT (...)` SQL for `not: { in }`, `not: { gte }`, multi-op `not: { gte, lt }`, `not: { contains, mode }`; plus error cases (relation filter inside `not`, `not: [array]`).
- **Integration** (real TimescaleDB, nullable column): negation **and** NULL-exclusion proven end-to-end — `not: { in: [1] }` → 1 row, `not: { gte: 2 }` → 2 rows, NULL row excluded in both.
- All gates green: 109 unit/type, `test:types`, `build`, `attw`, integration 14/14.

README updated: limitation reworded, nested `not` documented + added to the `where` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for nested `not` filters in `timeBucket.where`, enabling recursive negation of scalar conditions for more expressive queries.

* **Bug Fixes**
  * Improved behavior for “empty” nested `not` inputs so they act as a no-op (avoiding invalid `NOT ()` output), and enhanced `not` validation/error messages.

* **Documentation**
  * Updated `timeBucket.where` docs to clarify nested `not` support while keeping relation filters (`some`/`none`/`every`/`is`) unsupported and erroring.

* **Tests**
  * Expanded unit and integration coverage for nested `not`, parameter handling, no-op behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->