### PR TITLE
feat: relation filters (some/none/every/is/isNot) in timeBucket where

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,31 @@ Aggregate columns are checked against the model's scalar fields **at compile tim
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`.
 
+#### Relation filters (`some` / `none` / `every` / `is` / `isNot`)
+
+Filter a hypertable by a **related** model's fields. The generator reads your schema's relations
+and the runtime compiles them to `EXISTS` subqueries:
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  where: {
+    device: { is: { active: true } },     // to-one: the related device is active
+    tags:   { some: { label: "prod" } },  // to-many: has ≥1 matching tag
+    alerts: { every: { resolved: true } },// to-many: all resolved (vacuously true if none)
+    owner:  { isNot: null },              // relation exists
+  },
+  aggregate: { n: { count: "deviceId" } },
+});
+```
+
+Results match Prisma's `findMany` exactly, including `every`'s vacuous truth and NULL handling
+(`is`/`isNot: null` test relation existence). Composite foreign keys are supported. Limitations:
+relations must be visible to the generator (or supplied via the
+[manual config](#without-the-generator-manual-config)), and a relation filter **nested inside
+another relation's** filter is one level only (deeper nesting throws).
+
 #### Exact aggregate results (`as: "bigint" | "string"`)
 
 By default every aggregate comes back as a JS `number` — `sum`/`avg` are computed as
@@ -449,12 +474,12 @@ forms like `"1 year 2 months"` aren't supported by this single-unit type.)
 
 ## Limitations (v0.1)
 
-- **`timeBucket` `where`** supports scalar operators (`equals`, `not` — including nested
-  `not: { ... }`, e.g. `{ deviceId: { not: { in: [1, 2] } } }` — `in`, `notIn`, `lt`, `lte`, `gt`,
-  `gte`, `contains`, `startsWith`, `endsWith` + `mode: "insensitive"`), `null` checks, and
-  `AND`/`OR`/`NOT`. Negation matches Prisma's `findMany` semantics, including **NULL exclusion**
-  under `not` (SQL three-valued logic). **Relation filters** (`some`/`none`/`every`/`is`) are not
-  supported — they can't be a single-table query — and throw a clear error.
+- **`timeBucket` `where`** mirrors Prisma's `findMany` where: scalar operators (`equals`, `not`
+  incl. nested `not: { ... }`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `contains`, `startsWith`,
+  `endsWith` + `mode: "insensitive"`), `null` checks, `AND`/`OR`/`NOT`, and **relation filters**
+  (`some`/`none`/`every`/`is`/`isNot`) via `EXISTS` subqueries — including `every`'s vacuous truth
+  and NULL semantics (verified against Prisma). The one gap: a relation filter **nested inside
+  another relation's** inner where (one level is supported) throws a clear error.
 - **`timeBucket` numeric precision:** aggregates **default** to JS `number` (`count` → `int`,
   `sum`/`avg` → `double precision`), so a default `sum` beyond 2^53 is float64-rounded. For exact
   results, opt an aggregate into [`as: "bigint"`](#exact-aggregate-results-as-bigint--string)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -79,6 +79,10 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
     caggViewByModel.set(c.model ?? c.name, { name: c.name, ...(c.schema !== undefined ? { schema: c.schema } : {}) });
   }
 
+  /**
+   * The `model.timeBucket(...)` method: resolve the model to its hypertable config, build the
+   * parameterized query (incl. where / relation filters), and run it via `$queryRawUnsafe`.
+   */
   const timeBucket = async function (this: unknown, args: TimeBucketRuntimeArgs) {
     const ctx = Prisma.getExtensionContext(this);
     const model = ctx.$name;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,7 +4,7 @@
 // works WITHOUT the generator. The generator's emitted `registry` is assignable to this
 // config shape, so `timescaledb(registry)` is just the generated path.
 import { Prisma } from "@prisma/client/extension";
-import type { CaggConfig, HypertableConfig } from "../core/types.js";
+import type { CaggConfig, HypertableConfig, RelationConfig } from "../core/types.js";
 import { assertInterval } from "../core/interval.js";
 import {
   buildTimeBucketQuery,
@@ -60,7 +60,7 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
   // Key by Prisma model name (ctx.$name); values hold the resolved DB table + schema + column map.
   const hypertableByModel = new Map<
     string,
-    { table: string; schema?: string; column: string; columns: Record<string, string> }
+    { table: string; schema?: string; column: string; columns: Record<string, string>; relations: readonly RelationConfig[] }
   >();
   for (const h of config.hypertables ?? []) {
     hypertableByModel.set(h.model ?? h.table, {
@@ -70,6 +70,7 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
       ...(h.schema !== undefined ? { schema: h.schema } : {}),
       column: h.column,
       columns: { ...(h.columns ?? {}) },
+      relations: h.relations ?? [],
     });
   }
   // Prisma view model name -> DB view name + schema, for refreshContinuousAggregate.
@@ -91,7 +92,7 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
       );
     }
     assertInterval(args.bucket);
-    const { sql, params } = buildTimeBucketQuery(ht.table, ht.column, args, ht.columns, ht.schema);
+    const { sql, params } = buildTimeBucketQuery(ht.table, ht.column, args, ht.columns, ht.schema, ht.relations);
     return (ctx.$parent as UnsafeRawClient).$queryRawUnsafe(sql, ...params);
   } as unknown as TimeBucketMethod;
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -4,8 +4,9 @@
 import { Prisma } from "@prisma/client/extension";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
+import type { RelationConfig } from "../core/types.js";
 import { assertSafeIdent, qualifiedIdent, quoteIdent } from "../core/sql.js";
-import { whereToSql } from "./where.js";
+import { whereToSql, type RuntimeRelation } from "./where.js";
 
 // --- type machinery --------------------------------------------------------
 
@@ -137,6 +138,7 @@ export function buildTimeBucketQuery(
   args: TimeBucketRuntimeArgs,
   columns: Record<string, string> = {},
   schema?: string,
+  relations: readonly RelationConfig[] = [],
 ): { sql: string; params: unknown[] } {
   assertSafeIdent(table, "model table");
   assertSafeIdent(timeColumn, "time column");
@@ -190,6 +192,19 @@ export function buildTimeBucketQuery(
     select.push(`${fn}(${src})${castFor(fn, outputAs)} AS ${alias}`);
   }
 
+  // Relation-filter lookup (some/none/every/is/isNot -> EXISTS). The related table is
+  // quoted/qualified here; join keys + column maps come from the generated registry.
+  const relByField = new Map<string, RuntimeRelation>();
+  for (const r of relations) {
+    relByField.set(r.field, {
+      table: qualifiedIdent(r.table, r.schema),
+      list: r.list,
+      on: r.on,
+      ...(r.columns ? { columns: r.columns } : {}),
+      ...(r.fk ? { fk: r.fk } : {}),
+    });
+  }
+
   let where = `${time} >= $2 AND ${time} < $3`;
   const whereSql = whereToSql(args.where, {
     col: (name) => quoteIdent(col(name)),
@@ -197,6 +212,9 @@ export function buildTimeBucketQuery(
       params.push(value);
       return `$${params.length}`;
     },
+    ...(relByField.size > 0
+      ? { rel: { outerTable: qualifiedIdent(table, schema), get: (f: string) => relByField.get(f) } }
+      : {}),
   });
   if (whereSql) where += ` AND (${whereSql})`;
 

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -132,6 +132,7 @@ function relationClause(field: string, value: unknown, rel: RuntimeRelation, ctx
   return parts.length > 1 ? `(${parts.join(" AND ")})` : (parts[0] ?? "");
 }
 
+/** Combine an AND/OR/NOT array of sub-`where`s into one parenthesized clause (Prisma's logical operators). */
 function combine(wheres: unknown[], ctx: WhereCtx, op: "AND" | "OR"): string {
   const parts = wheres.map((w) => whereToSql(w as Record<string, unknown>, ctx)).filter(Boolean);
   // Prisma semantics: an empty OR matches nothing; an empty AND (also used for NOT) imposes
@@ -141,6 +142,7 @@ function combine(wheres: unknown[], ctx: WhereCtx, op: "AND" | "OR"): string {
   return `(${parts.join(` ${op} `)})`;
 }
 
+/** Build the clause for one scalar field: `null` -> IS NULL, a scalar -> `=`, else an operator map. */
 function fieldClause(field: string, value: unknown, ctx: WhereCtx): string {
   const c = ctx.col(field);
   if (value === null) return `${c} IS NULL`;
@@ -163,6 +165,7 @@ function operatorMapToSql(col: string, field: string, filter: Record<string, unk
   return parts.join(" AND ");
 }
 
+/** Translate one Prisma operator (`gte`, `in`, `contains`, `not`, …) on a column into SQL. */
 function operatorClause(
   col: string,
   field: string,
@@ -211,6 +214,7 @@ function operatorClause(
   }
 }
 
+/** Build an `IN` / `NOT IN` clause; an empty list short-circuits to `false` / `true` (Prisma semantics). */
 function inClause(col: string, v: unknown, negate: boolean, field: string, ctx: WhereCtx): string {
   if (!Array.isArray(v)) {
     throw new Error(`timeBucket: "${negate ? "notIn" : "in"}" on "${field}" requires an array.`);
@@ -220,6 +224,7 @@ function inClause(col: string, v: unknown, negate: boolean, field: string, ctx: 
   return `${col} ${negate ? "NOT IN" : "IN"} (${list})`;
 }
 
+/** Build a `LIKE` / `ILIKE` clause for contains/startsWith/endsWith, escaping the user value's wildcards. */
 function likeClause(
   col: string,
   kind: "contains" | "startsWith" | "endsWith",
@@ -238,10 +243,12 @@ function likeClause(
   return `${col} ${operator} ${ctx.push(pattern)} ESCAPE '\\'`;
 }
 
+/** True for the JS values bindable as a single SQL scalar parameter (Date/string/number/boolean/bigint). */
 function isScalar(v: unknown): boolean {
   return v instanceof Date || typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "bigint";
 }
 
+/** Assert a value is a non-null scalar (for operators that require one), or throw a clear error. */
 function scalar(v: unknown, field: string, op: string): unknown {
   if (v === null || !isScalar(v)) {
     throw new Error(`timeBucket: "${op}" on "${field}" requires a scalar value.`);
@@ -249,6 +256,7 @@ function scalar(v: unknown, field: string, op: string): unknown {
   return v;
 }
 
+/** Normalize a value to an array (Prisma's AND/OR/NOT accept either a single object or an array). */
 function asArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [value];
 }

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -1,16 +1,40 @@
 // Translate a Prisma `where` input into a parameterized SQL boolean expression for the
-// single-table timeBucket query. Values are always bound as parameters; column names are
-// resolved + identifier-checked by the caller, so the result is injection-safe.
+// timeBucket query. Values are always bound as parameters; column names are resolved +
+// identifier-checked, so the result is injection-safe.
 //
 // Supported: equals, not (incl. nested `not: { ... }`), in, notIn, lt, lte, gt, gte, contains,
-// startsWith, endsWith (+ mode: "insensitive"), null checks, shorthand equality, and AND / OR / NOT.
-// Unsupported (throws): relation filters (some/none/every) and any operator not in the list above.
+// startsWith, endsWith (+ mode: "insensitive"), null checks, shorthand equality, AND / OR / NOT,
+// and relation filters (some/none/every/is/isNot) via EXISTS subqueries when relation metadata
+// is provided. Unsupported (throws): any operator not in the list above, and nested relation
+// filters (a relation filter inside another relation's inner where).
+import { assertSafeIdent, quoteIdent } from "../core/sql.js";
 
 export interface WhereCtx {
   /** Resolve a Prisma field name to a quoted DB column (e.g. `deviceId` -> `"device_id"`). */
   col: (field: string) => string;
   /** Bind a value as a parameter and return its placeholder (e.g. `$4`). */
   push: (value: unknown) => string;
+  /** Relation-filter support; absent => relation keys fall through to the unsupported-operator error. */
+  rel?: {
+    /** The current (outer) table, already quoted/qualified, for the EXISTS join (e.g. `"public"."Reading"`). */
+    outerTable: string;
+    /** Look up a relation by Prisma field name; undefined if `field` is not a relation. */
+    get: (field: string) => RuntimeRelation | undefined;
+  };
+}
+
+/** Runtime view of a relation, for building EXISTS subqueries. Names are DB names. */
+export interface RuntimeRelation {
+  /** Related table, quoted/qualified (e.g. `"public"."Device"`). */
+  table: string;
+  /** true => to-many (some/none/every); false => to-one (is/isNot). */
+  list: boolean;
+  /** Join pairs: `related.<related> = outer.<outer>` (unquoted DB column names). */
+  on: readonly { related: string; outer: string }[];
+  /** Related Prisma field name -> DB column, for the inner where (@map). */
+  columns?: Record<string, string>;
+  /** Outer FK column(s) (DB names) for `is`/`isNot: null` (optional to-one only). */
+  fk?: readonly string[];
 }
 
 const SUPPORTED = "equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith";
@@ -31,11 +55,81 @@ export function whereToSql(where: Record<string, unknown> | undefined, ctx: Wher
       const s = combine(asArray(value), ctx, "AND");
       if (s) clauses.push(`NOT (${s})`);
     } else {
-      const s = fieldClause(key, value, ctx);
+      const relation = ctx.rel?.get(key);
+      const s = relation ? relationClause(key, value, relation, ctx) : fieldClause(key, value, ctx);
       if (s) clauses.push(s);
     }
   }
   return clauses.join(" AND ");
+}
+
+/**
+ * Build the EXISTS / NOT EXISTS clause for a relation filter (some/none/every/is/isNot or a
+ * to-one shorthand). The inner filter is resolved against the related table (aliased `_rel`) by
+ * recursing through whereToSql with a related-column context — so all scalar operators (incl.
+ * nested not) work inside it. Mirrors Prisma's findMany results, including `every`'s vacuous
+ * truth and `isNot`/`none` including the no-related-record case (verified against Prisma).
+ */
+function relationClause(field: string, value: unknown, rel: RuntimeRelation, ctx: WhereCtx): string {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`timeBucket: relation filter on "${field}" must be an object (some/none/every/is/isNot).`);
+  }
+  const filter = value as Record<string, unknown>;
+  const alias = quoteIdent("_rel");
+  const outer = ctx.rel!.outerTable;
+
+  // Inner where resolves against the related table; params are shared; no nested relation filters.
+  const innerCtx: WhereCtx = {
+    push: ctx.push,
+    col: (f) => {
+      const c = rel.columns?.[f] ?? f;
+      assertSafeIdent(c, "relation column");
+      return `${alias}.${quoteIdent(c)}`;
+    },
+  };
+  const join = rel.on.map((p) => `${alias}.${quoteIdent(p.related)} = ${outer}.${quoteIdent(p.outer)}`).join(" AND ");
+  const from = `${rel.table} AS ${alias}`;
+
+  // EXISTS (SELECT 1 FROM related AS _rel WHERE join AND (inner)); inner "" -> TRUE. `every` negates
+  // the inner (NOT EXISTS where a related row fails it). `negate` wraps the whole thing in NOT.
+  const exists = (negate: boolean, negateInner: boolean, inner: unknown): string => {
+    let innerSql = whereToSql(inner as Record<string, unknown> | undefined, innerCtx) || "TRUE";
+    if (negateInner) innerSql = `NOT (${innerSql})`;
+    const sub = `EXISTS (SELECT 1 FROM ${from} WHERE ${join} AND (${innerSql}))`;
+    return negate ? `NOT ${sub}` : sub;
+  };
+  // `is`/`isNot: null` — optional to-one uses the FK column; a relation with no local FK falls
+  // back to existence (is: null => no related row).
+  const nullCheck = (negate: boolean): string => {
+    if (rel.fk && rel.fk.length > 0) {
+      const cond = rel.fk.map((c) => `${outer}.${quoteIdent(c)} IS ${negate ? "NOT NULL" : "NULL"}`).join(" AND ");
+      return rel.fk.length > 1 ? `(${cond})` : cond;
+    }
+    const sub = `EXISTS (SELECT 1 FROM ${from} WHERE ${join})`;
+    return negate ? sub : `NOT ${sub}`;
+  };
+
+  const parts: string[] = [];
+  if (rel.list) {
+    for (const [op, inner] of Object.entries(filter)) {
+      if (inner === undefined) continue;
+      if (op === "some") parts.push(exists(false, false, inner));
+      else if (op === "none") parts.push(exists(true, false, inner));
+      else if (op === "every") parts.push(exists(true, true, inner));
+      else throw new Error(`timeBucket: unsupported list relation filter "${op}" on "${field}" (use some / none / every).`);
+    }
+  } else if ("is" in filter || "isNot" in filter) {
+    for (const [op, inner] of Object.entries(filter)) {
+      if (inner === undefined) continue;
+      if (op === "is") parts.push(inner === null ? nullCheck(false) : exists(false, false, inner));
+      else if (op === "isNot") parts.push(inner === null ? nullCheck(true) : exists(true, false, inner));
+      else throw new Error(`timeBucket: unsupported to-one relation filter "${op}" on "${field}" (use is / isNot).`);
+    }
+  } else {
+    // to-one shorthand: the whole object is the related where (equivalent to `is`).
+    parts.push(exists(false, false, filter));
+  }
+  return parts.length > 1 ? `(${parts.join(" AND ")})` : (parts[0] ?? "");
 }
 
 function combine(wheres: unknown[], ctx: WhereCtx, op: "AND" | "OR"): string {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,7 @@ export type {
   MigrationSql,
   HypertableConfig,
   RetentionConfig,
+  RelationConfig,
   CaggConfig,
   AggregateSpec,
   RefreshPolicy,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,28 @@ export interface RetentionConfig {
   dropAfter: Interval;
 }
 
+/**
+ * A relation from a hypertable to another model, used to support relation filters
+ * (`some`/`none`/`every`/`is`/`isNot`) in `timeBucket` where via EXISTS subqueries. All names
+ * are DB names (post-@@map / @@schema).
+ */
+export interface RelationConfig {
+  /** Prisma relation field name on the hypertable (the `where` key), e.g. "device". */
+  field: string;
+  /** Related model's DB table name. */
+  table: string;
+  /** Related model's `@@schema` (multiSchema); omitted for the default schema. */
+  schema?: string;
+  /** `true` for a to-many relation (`some`/`none`/`every`); `false` for to-one (`is`/`isNot`). */
+  list: boolean;
+  /** Join condition pairs — `related.<related> = hypertable.<outer>` (DB column names). */
+  on: readonly { related: string; outer: string }[];
+  /** Related Prisma field name -> DB column, for resolving the inner filter (@map). */
+  columns?: Record<string, string>;
+  /** For an optional to-one relation: the hypertable's FK column(s) (DB names), for `is`/`isNot: null`. */
+  fk?: readonly string[];
+}
+
 /** Hypertable conversion config (SPEC §1.1 / §2.2). All names are DB names (post-@@map). */
 export interface HypertableConfig {
   /**
@@ -36,6 +58,8 @@ export interface HypertableConfig {
   columns?: Record<string, string>;
   /** Optional data-retention policy (`@timescale.retention`); omitted means no policy. */
   retention?: RetentionConfig;
+  /** Relations to other models, for relation filters in `timeBucket` where (EXISTS subqueries). */
+  relations?: readonly RelationConfig[];
 }
 
 /** A single aggregate column in a continuous aggregate (SPEC §1.2). DB names. */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -2,7 +2,15 @@
 // internal shapes (HypertableConfig / CaggConfig) and never touches `options.dmmf`. A Prisma
 // internal-API change should only require edits in this file.
 import type { DMMF } from "@prisma/generator-helper";
-import type { AggregateSpec, CaggConfig, CaggGroupBy, HypertableConfig, RefreshPolicy, RetentionConfig } from "../core/types.js";
+import type {
+  AggregateSpec,
+  CaggConfig,
+  CaggGroupBy,
+  HypertableConfig,
+  RefreshPolicy,
+  RelationConfig,
+  RetentionConfig,
+} from "../core/types.js";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import {
@@ -33,7 +41,7 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   for (const model of models) {
     const annotations = parseAnnotations(model.documentation);
     if (findAnnotation(annotations, "hypertable")) {
-      hypertables.push(buildHypertable(model, annotations));
+      hypertables.push(buildHypertable(model, annotations, byName));
     } else if (findAnnotation(annotations, "retention")) {
       // Retention attaches to a hypertable's chunks; it is meaningless on a plain model.
       throw new Error(
@@ -59,7 +67,11 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   return { hypertables, continuousAggregates };
 }
 
-function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parseAnnotations>): HypertableConfig {
+function buildHypertable(
+  model: DMMF.Model,
+  annotations: ReturnType<typeof parseAnnotations>,
+  byName: Map<string, DMMF.Model>,
+): HypertableConfig {
   const ctx = `@timescale.hypertable on model "${model.name}"`;
   const ann = findAnnotation(annotations, "hypertable")!;
   const column = requireString(ann.args, "column", ctx);
@@ -79,6 +91,7 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
   const columns = columnMap(model);
   const table = dbTable(model);
   const retention = buildRetention(annotations, model.name);
+  const relations = buildRelations(model, byName);
 
   return {
     ...(model.name !== table ? { model: model.name } : {}),
@@ -88,7 +101,64 @@ function buildHypertable(model: DMMF.Model, annotations: ReturnType<typeof parse
     ...(chunkInterval !== undefined ? { chunkInterval: chunkInterval as Interval } : {}),
     ...(Object.keys(columns).length > 0 ? { columns } : {}),
     ...(retention ? { retention } : {}),
+    ...(relations.length > 0 ? { relations } : {}),
   };
+}
+
+/**
+ * Extract the model's relation fields into RelationConfigs for runtime EXISTS-based filtering.
+ * Resolves join keys for both the owning side (this model holds the FK: relationFromFields ->
+ * relationToFields) and the inverse side (the FK lives on the related model — look up its owning
+ * field by relationName). All field names are resolved to DB column names (@map).
+ */
+function buildRelations(model: DMMF.Model, byName: Map<string, DMMF.Model>): RelationConfig[] {
+  const relations: RelationConfig[] = [];
+  for (const f of model.fields) {
+    if (f.kind !== "object") continue;
+    const related = byName.get(f.type);
+    if (!related) continue;
+
+    let on: { related: string; outer: string }[];
+    let fk: string[] | undefined;
+
+    if (f.relationFromFields && f.relationFromFields.length > 0) {
+      // Owning side: the FK is on THIS model (relationFromFields), referencing relationToFields.
+      const toFields = f.relationToFields ?? [];
+      on = f.relationFromFields.map((fromField, i) => ({
+        related: resolveCol(related, toFields[i] ?? ""),
+        outer: resolveCol(model, fromField),
+      }));
+      fk = f.relationFromFields.map((fromField) => resolveCol(model, fromField));
+    } else {
+      // Inverse side: the FK is on the RELATED model — find its owning field by relationName.
+      const owning = related.fields.find(
+        (g) => g.kind === "object" && g.relationName === f.relationName && (g.relationFromFields?.length ?? 0) > 0,
+      );
+      if (!owning?.relationFromFields || !owning.relationToFields) continue;
+      const toFields = owning.relationToFields;
+      on = owning.relationFromFields.map((fromField, i) => ({
+        related: resolveCol(related, fromField),
+        outer: resolveCol(model, toFields[i] ?? ""),
+      }));
+    }
+
+    const columns = columnMap(related);
+    relations.push({
+      field: f.name,
+      table: dbTable(related),
+      ...(related.schema ? { schema: related.schema } : {}),
+      list: f.isList,
+      on,
+      ...(Object.keys(columns).length > 0 ? { columns } : {}),
+      ...(fk ? { fk } : {}),
+    });
+  }
+  return relations;
+}
+
+/** Resolve a field name on a model to its DB column name (the @map value, or the field name). */
+function resolveCol(model: DMMF.Model, fieldName: string): string {
+  return model.fields.find((f) => f.name === fieldName)?.dbName ?? fieldName;
 }
 
 function buildRetention(

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -67,6 +67,8 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   return { hypertables, continuousAggregates };
 }
 
+/** Build a HypertableConfig from a `@timescale.hypertable` model — validates the time column and
+ * resolves @map/@@schema, retention, and relations. */
 function buildHypertable(
   model: DMMF.Model,
   annotations: ReturnType<typeof parseAnnotations>,
@@ -161,6 +163,7 @@ function resolveCol(model: DMMF.Model, fieldName: string): string {
   return model.fields.find((f) => f.name === fieldName)?.dbName ?? fieldName;
 }
 
+/** Parse the optional `@timescale.retention(dropAfter)` annotation on a hypertable model. */
 function buildRetention(
   annotations: ReturnType<typeof parseAnnotations>,
   modelName: string,
@@ -173,6 +176,8 @@ function buildRetention(
   return { dropAfter: dropAfter as Interval };
 }
 
+/** Build a CaggConfig from a `@timescale.continuousAggregate` view + its field annotations
+ * (`@timescale.bucket` / `groupBy` / `aggregate`), validating columns against the source model. */
 function buildCagg(
   view: DMMF.Model,
   annotations: ReturnType<typeof parseAnnotations>,
@@ -266,6 +271,7 @@ function buildCagg(
   };
 }
 
+/** Parse the optional `refresh: { startOffset, endOffset, scheduleInterval }` policy off a cagg annotation. */
 function buildRefresh(ann: ReturnType<typeof parseAnnotations>[number], ctx: string): RefreshPolicy | undefined {
   const obj = optionalObject(ann.args, "refresh", ctx);
   if (!obj) return undefined;
@@ -283,6 +289,7 @@ function buildRefresh(ann: ReturnType<typeof parseAnnotations>[number], ctx: str
   };
 }
 
+/** Find a scalar (non-relation) field by name on a model. */
 function findScalarField(model: DMMF.Model, name: string): DMMF.Field | undefined {
   return model.fields.find((f) => f.name === name && f.kind === "scalar");
 }

--- a/test/integration/relation-filters.test.ts
+++ b/test/integration/relation-filters.test.ts
@@ -1,0 +1,129 @@
+// Relation filters in timeBucket where, end-to-end on real TimescaleDB. The generator extracts
+// relation metadata (to-one `device`, composite-key to-many `tags`) into the registry, and the
+// runtime builds EXISTS subqueries. Counts mirror the research probe's Prisma results.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED relation-filters.test.ts: Docker is not available. Relation filters are NOT verified.\n",
+  );
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time     DateTime
+  id       Int
+  deviceId Int?
+  device   Device? @relation(fields: [deviceId], references: [id])
+  tags     Tag[]
+
+  @@id([id, time])
+}
+model Device {
+  id       Int       @id
+  active   Boolean
+  readings Reading[]
+}
+model Tag {
+  id          Int      @id
+  label       String
+  readingId   Int
+  readingTime DateTime
+  reading     Reading  @relation(fields: [readingId, readingTime], references: [id, time])
+}`;
+
+// Plain columns (no DB-level FKs — the relations are enforced logically via the EXISTS join,
+// which keeps the hypertable conversion simple).
+const INIT_SQL = `CREATE TABLE "Device" ("id" INTEGER PRIMARY KEY, "active" BOOLEAN NOT NULL);
+CREATE TABLE "Reading" ("time" TIMESTAMP(3) NOT NULL, "id" INTEGER NOT NULL, "deviceId" INTEGER,
+  CONSTRAINT "Reading_pkey" PRIMARY KEY ("id","time"));
+CREATE TABLE "Tag" ("id" INTEGER PRIMARY KEY, "label" TEXT NOT NULL, "readingId" INTEGER NOT NULL,
+  "readingTime" TIMESTAMP(3) NOT NULL);`;
+
+const t = (m: number) => new Date(`2026-06-15T10:${String(m).padStart(2, "0")}:00Z`);
+
+describe.skipIf(!DOCKER_OK)("timeBucket relation filters (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    await prisma.device.createMany({ data: [{ id: 1, active: true }, { id: 2, active: false }] });
+    // R1 active+[prod,dev]; R2 inactive+[prod]; R3 no-device+[]; R4 active+[dev]
+    await prisma.reading.createMany({
+      data: [
+        { id: 1, time: t(5), deviceId: 1 },
+        { id: 2, time: t(15), deviceId: 2 },
+        { id: 3, time: t(25), deviceId: null },
+        { id: 4, time: t(35), deviceId: 1 },
+      ],
+    });
+    await prisma.tag.createMany({
+      data: [
+        { id: 1, label: "prod", readingId: 1, readingTime: t(5) },
+        { id: 2, label: "dev", readingId: 1, readingTime: t(5) },
+        { id: 3, label: "prod", readingId: 2, readingTime: t(15) },
+        { id: 4, label: "dev", readingId: 4, readingTime: t(35) },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") };
+  const count = async (where?: unknown): Promise<number> => {
+    const rows = await prisma.reading.timeBucket({ bucket: "1 hour", range, where, aggregate: { n: { count: "id" } } });
+    return rows.reduce((s: number, r: { n: number }) => s + Number(r.n), 0);
+  };
+
+  it("no filter counts all rows", async () => {
+    expect(await count()).toBe(4);
+  });
+
+  it("to-one is / isNot / null", async () => {
+    expect(await count({ device: { is: { active: true } } })).toBe(2); // R1, R4
+    expect(await count({ device: { isNot: { active: true } } })).toBe(2); // R2 + R3 (no device)
+    expect(await count({ device: { is: null } })).toBe(1); // R3
+    expect(await count({ device: { isNot: null } })).toBe(3); // R1, R2, R4
+    expect(await count({ device: { active: true } })).toBe(2); // shorthand == is
+  });
+
+  it("to-many some / none / every (composite join, vacuous truth)", async () => {
+    expect(await count({ tags: { some: { label: "prod" } } })).toBe(2); // R1, R2
+    expect(await count({ tags: { none: { label: "prod" } } })).toBe(2); // R3 (no tags), R4
+    expect(await count({ tags: { every: { label: "prod" } } })).toBe(2); // R2, R3 (vacuous)
+  });
+
+  it("composes with scalar filters and AND/OR", async () => {
+    expect(await count({ AND: [{ device: { is: { active: true } } }, { tags: { some: { label: "dev" } } }] })).toBe(2); // R1, R4
+    expect(await count({ deviceId: { not: null }, tags: { none: { label: "dev" } } })).toBe(1); // R2 (has device, no dev tag)
+  });
+});

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -360,3 +360,61 @@ model SensorReading {
     ).rejects.toThrow(/Invalid interval/);
   });
 });
+
+describe("extractTimescaleSchema — relations", () => {
+  it("extracts to-one (owning, with fk) and to-many (inverse) relations", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time     DateTime
+  id       Int     @id
+  deviceId Int?
+  device   Device? @relation(fields: [deviceId], references: [id])
+  tags     Tag[]
+}
+model Device {
+  id       Int       @id
+  active   Boolean
+  readings Reading[]
+}
+model Tag {
+  id        Int     @id
+  label     String
+  readingId Int
+  reading   Reading @relation(fields: [readingId], references: [id])
+}
+`);
+    expect(result.hypertables[0]?.relations).toEqual([
+      { field: "device", table: "Device", list: false, on: [{ related: "id", outer: "deviceId" }], fk: ["deviceId"] },
+      { field: "tags", table: "Tag", list: true, on: [{ related: "readingId", outer: "id" }] },
+    ]);
+  });
+
+  it("resolves @@map / @map on the related model into the join keys + column map", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time")
+model Reading {
+  time     DateTime
+  id       Int     @id
+  deviceId Int?
+  device   Device? @relation(fields: [deviceId], references: [id])
+}
+model Device {
+  id       Int       @id @map("device_id")
+  active   Boolean   @map("is_active")
+  readings Reading[]
+  @@map("devices")
+}
+`);
+    expect(result.hypertables[0]?.relations).toEqual([
+      {
+        field: "device",
+        table: "devices",
+        list: false,
+        on: [{ related: "device_id", outer: "deviceId" }],
+        columns: { id: "device_id", active: "is_active" },
+        fk: ["deviceId"],
+      },
+    ]);
+  });
+});

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { whereToSql, type WhereCtx } from "../../src/client/where.js";
+import { whereToSql, type RuntimeRelation, type WhereCtx } from "../../src/client/where.js";
 
 function harness() {
   const params: unknown[] = [];
@@ -9,6 +9,30 @@ function harness() {
       params.push(v);
       return `$${params.length}`;
     },
+  };
+  return { ctx, params };
+}
+
+function relHarness() {
+  const params: unknown[] = [];
+  const device: RuntimeRelation = {
+    table: `"public"."Device"`,
+    list: false,
+    on: [{ related: "id", outer: "deviceId" }],
+    fk: ["deviceId"],
+  };
+  const tags: RuntimeRelation = { table: `"public"."Tag"`, list: true, on: [{ related: "readingId", outer: "id" }] };
+  const relations = new Map<string, RuntimeRelation>([
+    ["device", device],
+    ["tags", tags],
+  ]);
+  const ctx: WhereCtx = {
+    col: (f) => `"${f}"`,
+    push: (v) => {
+      params.push(v);
+      return `$${params.length}`;
+    },
+    rel: { outerTable: `"public"."Reading"`, get: (f) => relations.get(f) },
   };
   return { ctx, params };
 }
@@ -125,5 +149,77 @@ describe("whereToSql", () => {
       /unsupported where operator "some"/,
     );
     expect(() => whereToSql({ deviceId: { not: [1, 2] } }, harness().ctx)).toThrow(/cannot be an array/);
+  });
+});
+
+describe("whereToSql relation filters (EXISTS)", () => {
+  const exists = (negate: boolean, table: string, join: string, inner: string) =>
+    `${negate ? "NOT " : ""}EXISTS (SELECT 1 FROM ${table} AS "_rel" WHERE ${join} AND (${inner}))`;
+  const dev = `"_rel"."id" = "public"."Reading"."deviceId"`;
+  const tag = `"_rel"."readingId" = "public"."Reading"."id"`;
+
+  it("to-one is / isNot / shorthand build EXISTS / NOT EXISTS", () => {
+    const a = relHarness();
+    expect(whereToSql({ device: { is: { active: true } } }, a.ctx)).toBe(
+      exists(false, `"public"."Device"`, dev, `"_rel"."active" = $1`),
+    );
+    expect(a.params).toEqual([true]);
+    expect(whereToSql({ device: { isNot: { active: true } } }, relHarness().ctx)).toBe(
+      exists(true, `"public"."Device"`, dev, `"_rel"."active" = $1`),
+    );
+    // shorthand (no is/isNot) == is
+    expect(whereToSql({ device: { active: true } }, relHarness().ctx)).toBe(
+      exists(false, `"public"."Device"`, dev, `"_rel"."active" = $1`),
+    );
+  });
+
+  it("to-one is/isNot null use the FK column", () => {
+    expect(whereToSql({ device: { is: null } }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NULL`);
+    expect(whereToSql({ device: { isNot: null } }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NOT NULL`);
+  });
+
+  it("to-many some / none / every (every negates the inner)", () => {
+    const a = relHarness();
+    expect(whereToSql({ tags: { some: { label: "x" } } }, a.ctx)).toBe(
+      exists(false, `"public"."Tag"`, tag, `"_rel"."label" = $1`),
+    );
+    expect(a.params).toEqual(["x"]);
+    expect(whereToSql({ tags: { none: { label: "x" } } }, relHarness().ctx)).toBe(
+      exists(true, `"public"."Tag"`, tag, `"_rel"."label" = $1`),
+    );
+    expect(whereToSql({ tags: { every: { label: "x" } } }, relHarness().ctx)).toBe(
+      exists(true, `"public"."Tag"`, tag, `NOT ("_rel"."label" = $1)`),
+    );
+  });
+
+  it("empty inner becomes TRUE (some {} = has any; every {} = all)", () => {
+    expect(whereToSql({ tags: { some: {} } }, relHarness().ctx)).toBe(exists(false, `"public"."Tag"`, tag, "TRUE"));
+    expect(whereToSql({ tags: { every: {} } }, relHarness().ctx)).toBe(
+      exists(true, `"public"."Tag"`, tag, `NOT (TRUE)`),
+    );
+  });
+
+  it("reuses scalar machinery (incl. nested not) inside the related filter", () => {
+    const a = relHarness();
+    expect(whereToSql({ tags: { some: { label: { not: { in: ["x", "y"] } } } } }, a.ctx)).toBe(
+      exists(false, `"public"."Tag"`, tag, `NOT ("_rel"."label" IN ($1, $2))`),
+    );
+    expect(a.params).toEqual(["x", "y"]);
+  });
+
+  it("relation filters compose with AND/OR and scalar filters", () => {
+    const a = relHarness();
+    expect(whereToSql({ deviceId: { gt: 0 }, tags: { some: { label: "x" } } }, a.ctx)).toBe(
+      `"deviceId" > $1 AND ${exists(false, `"public"."Tag"`, tag, `"_rel"."label" = $2`)}`,
+    );
+    expect(a.params).toEqual([0, "x"]);
+  });
+
+  it("throws on a bad list operator and on a nested relation filter (one level only)", () => {
+    expect(() => whereToSql({ tags: { has: {} } }, relHarness().ctx)).toThrow(/unsupported list relation filter "has"/);
+    // a relation filter inside the related where is not supported (the inner has no relations)
+    expect(() => whereToSql({ device: { is: { tags: { some: {} } } } }, relHarness().ctx)).toThrow(
+      /unsupported where operator "some"/,
+    );
   });
 });


### PR DESCRIPTION
## What

Closes the last open part of limitation #1: `timeBucket` `where` now supports **relation filters** via `EXISTS` subqueries, matching Prisma's `findMany` exactly.

```ts
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  where: {
    device: { is: { active: true } },      // to-one  → EXISTS (…)
    tags:   { some: { label: "prod" } },   // to-many → EXISTS (…)
    alerts: { none: { level: "crit" } },   //         → NOT EXISTS (…)
    checks: { every: { passed: true } },   //         → NOT EXISTS (… AND NOT (…))  (vacuous truth)
    owner:  { isNot: null },               // existence
  },
  aggregate: { n: { count: "deviceId" } },
});
```

## How — grounded in Prisma's actual SQL

A throwaway probe (deleted) captured Prisma's real `findMany` SQL **and result sets** for every filter on a nullable/empty relation. Decisive findings, all reproduced:
- `isNot` / `none` **include the no-related-record row**; `every` is **vacuously true** for rows with no related records.
- `is`/`isNot: null` test FK existence.
- empty inner (`some: {}`) → `TRUE`.

Each filter compiles to `EXISTS` / `NOT EXISTS` with a recursive inner `where` against the related table — which **reuses the entire scalar + nested-`not` machinery**, so the inner filter gets all operators for free.

- **generator** (`dmmf.ts`): extracts join keys for both the **owning** side (`relationFromFields`/`relationToFields`) and the **inverse** side (look up the owning field by `relationName`), resolving `@map`/`@@schema`; emits per-relation metadata into the registry. Composite keys handled (parallel arrays).
- **runtime** (`where.ts`): `EXISTS (SELECT 1 FROM rel AS _rel WHERE <join> AND (<inner>))`, aliased so self-relations are unambiguous.

**Scope:** to-one + to-many, single- and composite-key FKs, one-level inner (related scalars; nested relation-in-relation throws). Documented.

## Testing

- **Unit** — `where.test.ts`: exact `EXISTS`/`NOT EXISTS` SQL for `is`/`isNot`/`some`/`none`/`every`/shorthand/null, empty-inner, nested-`not` reuse, AND/OR composition, error cases. `dmmf.test.ts`: owning + inverse + `@map` extraction.
- **Integration (real TimescaleDB)** — to-one + **composite-key** to-many, `every` vacuous truth, NULL handling, AND/OR composition; counts mirror the Prisma probe.
- All gates green: **119** unit/type, `test:types`, `build`, `attw`, integration **18/18**.

README: limitation reworded + a "Relation filters" docs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `timeBucket().where` now supports relation filters: `some`, `none`, `every`, `is`, and `isNot` (with `isNot: null` / `is: null` behavior for to-one relations).
  * Relation filtering is now driven by model relation metadata, enabling correct SQL generation for both to-one and to-many links.
  * Nested relation filters inside another relation filter are supported only one level deep.

* **Documentation**
  * Added detailed guidance on relation-filter operators, NULL semantics, and supported nesting behavior.

* **Tests**
  * Added unit and integration coverage for relation-filter behavior (including real TimescaleDB execution when available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->