### PR TITLE
docs: fix mangled `@timescale` autolink in 0.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* columnstore compression policies (`[@timescale](https://github.com/timescale).compression` + `$timescale`) ([#16](https://github.com/Krister-Johansson/prisma-extension-timescaledb/issues/16)) ([00e485a](https://github.com/Krister-Johansson/prisma-extension-timescaledb/commit/00e485a1b2013449ed0adfc28ad4cd6806fd54f2))
+* columnstore compression policies (`@timescale.compression` + `$timescale`) ([#16](https://github.com/Krister-Johansson/prisma-extension-timescaledb/issues/16)) ([00e485a](https://github.com/Krister-Johansson/prisma-extension-timescaledb/commit/00e485a1b2013449ed0adfc28ad4cd6806fd54f2))
 
 ## [0.2.0](https://github.com/Krister-Johansson/prisma-extension-timescaledb/compare/prisma-extension-timescaledb-v0.1.0...prisma-extension-timescaledb-v0.2.0) (2026-06-16)
 


### PR DESCRIPTION
release-please autolinked `@timescale` as a GitHub user mention **inside** the code span when generating the 0.3.0 changelog, breaking `` `@timescale.compression` `` into `` `[@timescale](https://github.com/timescale).compression` ``. This restores the plain inline code (same root cause as the earlier `@@schema`/`@@map` autolink fixes in #5 / #15).

The v0.3.0 GitHub Release notes were corrected the same way.

Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entry formatting for columnstore compression policies reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->