### PR TITLE
fix: reject unsupported integer time columns and non-positive intervals up front

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -24,8 +24,9 @@ model SensorReading {
 }
 ```
 
-- `column` (required): the time partitioning column. Must be a `DateTime` (or integer
-  time) field on the model. The generator validates this against the DMMF.
+- `column` (required): the time partitioning column. Must be a `DateTime` field on the model
+  (integer time columns are not supported yet — the generator emits interval-based SQL). The
+  generator validates this against the DMMF.
 - `chunkInterval` (optional, default `"7 days"`): chunk size.
 
 Prisma still owns the `CREATE TABLE`. The generator only appends the hypertable

--- a/src/core/interval.ts
+++ b/src/core/interval.ts
@@ -43,16 +43,18 @@ export type Interval = `${number} ${Unit}`;
 // (mirrors the `${number} ${Unit}` template type).
 const INTERVAL_RE = new RegExp(`^\\d+(?:\\.\\d+)? (?:${UNITS.join("|")})$`);
 
-/** Return true if `value` is a well-formed interval literal. */
+/** Return true if `value` is a well-formed interval literal with a positive amount. */
 export function isInterval(value: string): value is Interval {
-  return INTERVAL_RE.test(value);
+  // Shape must match AND the amount must be positive: "0 days" / "0.0 seconds" are well-formed but
+  // meaningless as a chunk size / policy threshold / bucket width (TimescaleDB rejects them anyway).
+  return INTERVAL_RE.test(value) && Number.parseFloat(value) > 0;
 }
 
 /** Assert `value` is a well-formed interval literal, narrowing its type. */
 export function assertInterval(value: string): asserts value is Interval {
   if (!isInterval(value)) {
     throw new Error(
-      `Invalid interval ${JSON.stringify(value)}: expected "<amount> <unit>" where unit is one of ${UNITS.join(", ")} (e.g. "1 hour", "7 days").`,
+      `Invalid interval ${JSON.stringify(value)}: expected "<amount> <unit>" with a positive amount, where unit is one of ${UNITS.join(", ")} (e.g. "1 hour", "7 days").`,
     );
   }
 }

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -32,8 +32,11 @@ export interface TimescaleSchema {
   relationsByModel: Record<string, RelationConfig[]>;
 }
 
-// Field types acceptable as a hypertable / time_bucket partitioning column.
-const TIME_TYPES = new Set(["DateTime", "Int", "BigInt"]);
+// Field types acceptable as a hypertable / continuous-aggregate partitioning column. DateTime
+// only: integer time columns aren't supported yet — every builder emits interval-based SQL
+// (`by_range(col, INTERVAL …)`, `time_bucket($1, col)`), so accepting Int/BigInt here would pass
+// generation and then fail at `migrate`. Reject them up front with a clear message instead.
+const TIME_TYPES = new Set(["DateTime"]);
 const AGG_FNS = new Set<AggregateSpec["fn"]>(["avg", "sum", "min", "max", "count"]);
 
 /** Extract and validate all TimescaleDB configs from a Prisma DMMF document. */
@@ -107,7 +110,7 @@ function buildHypertable(
   }
   if (!TIME_TYPES.has(field.type)) {
     throw new Error(
-      `${ctx}: column "${column}" has type ${field.type}; the partitioning column must be a DateTime or integer field.`,
+      `${ctx}: column "${column}" has type ${field.type}; the partitioning column must be a DateTime field (integer time columns are not supported yet).`,
     );
   }
   if (chunkInterval !== undefined) assertInterval(chunkInterval);
@@ -274,7 +277,7 @@ function buildCagg(
   }
   if (!TIME_TYPES.has(timeField.type)) {
     throw new Error(
-      `${ctx}: timeColumn "${timeColumn}" has type ${timeField.type}; it must be a DateTime or integer field.`,
+      `${ctx}: timeColumn "${timeColumn}" has type ${timeField.type}; it must be a DateTime field (integer time columns are not supported yet).`,
     );
   }
 

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -210,6 +210,17 @@ ${body}
     ).rejects.toThrow(/timeColumn "label" has type String; it must be a DateTime field/);
   });
 
+  it("rejects an integer timeColumn up front (DateTime-only contract for caggs too)", async () => {
+    await expect(
+      extract(
+        view(`@timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "deviceId")`,
+          `  bucket  DateTime /// @timescale.bucket\n  avgTemp Float /// @timescale.aggregate(fn: "avg", column: "temperature")\n  @@unique([bucket])`),
+      ),
+    ).rejects.toThrow(
+      /timeColumn "deviceId" has type Int; it must be a DateTime field \(integer time columns are not supported yet\)/,
+    );
+  });
+
   it("source is a known model but not a hypertable", async () => {
     // SOURCE (SensorReading) here is a plain model — no @timescale.hypertable annotation.
     await expect(

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -113,7 +113,13 @@ model M {
 
   it("column has a non-time type", async () => {
     await expect(extract(htModel(`@timescale.hypertable(column: "label")`))).rejects.toThrow(
-      /must be a DateTime or integer field/,
+      /must be a DateTime field/,
+    );
+  });
+
+  it("rejects an integer time column up front (not supported yet — would fail at migrate)", async () => {
+    await expect(extract(htModel(`@timescale.hypertable(column: "id")`))).rejects.toThrow(
+      /has type Int; the partitioning column must be a DateTime field \(integer time columns are not supported yet\)/,
     );
   });
 
@@ -201,7 +207,7 @@ ${body}
         view(`@timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "label")`,
           `  bucket  DateTime /// @timescale.bucket\n  avgTemp Float /// @timescale.aggregate(fn: "avg", column: "temperature")\n  @@unique([bucket])`),
       ),
-    ).rejects.toThrow(/timeColumn "label" has type String; it must be a DateTime or integer field/);
+    ).rejects.toThrow(/timeColumn "label" has type String; it must be a DateTime field/);
   });
 
   it("source is a known model but not a hypertable", async () => {

--- a/test/unit/interval.test.ts
+++ b/test/unit/interval.test.ts
@@ -24,9 +24,11 @@ describe("interval", () => {
     }
   });
 
-  it("rejects malformed intervals and non-input units (quarter, millennium)", () => {
+  it("rejects malformed intervals, non-input units (quarter, millennium), and non-positive amounts", () => {
     // `quarter` / `millennium` are EXTRACT fields, not interval input units in PostgreSQL.
-    for (const v of ["hour", "1hour", "1 fortnight", "1 quarter", "1 millennium", "1  hour", " 1 hour", "1 hour ", "-1 hours", ""]) {
+    // "0 …" is well-formed shape-wise, but a zero amount is meaningless for a chunk size / policy
+    // threshold / bucket width (negatives are already rejected by the grammar — no leading `-`).
+    for (const v of ["hour", "1hour", "1 fortnight", "1 quarter", "1 millennium", "1  hour", " 1 hour", "1 hour ", "-1 hours", "0 days", "0.0 seconds", "00 hours", ""]) {
       expect(isInterval(v)).toBe(false);
       expect(() => assertInterval(v)).toThrow(/Invalid interval/);
     }


### PR DESCRIPTION
## What

A focused hardening pass closing two validation gaps where invalid input passed `prisma generate` and only failed (confusingly) later.

### 1. Integer time columns — silent footgun → clear up-front error
`SPEC §1.1` advertised "a `DateTime` (or integer time) field" and the DMMF validator accepted `Int`/`BigInt` partition columns — but **every** builder emits interval-based SQL (`by_range(col, INTERVAL …)`, `time_bucket($1, col)`, `drop_after => INTERVAL`, `after => INTERVAL`). So an `Int`/`BigInt` hypertable passed generation and then **failed at `migrate`** (`by_range('t', INTERVAL '1 day')` is invalid for an integer column).

- `TIME_TYPES` narrowed to `DateTime`; the type checks now reject `Int`/`BigInt` with *"the partitioning column must be a DateTime field (integer time columns are not supported yet)"*.
- `SPEC.md §1.1` claim corrected to match the implementation.

### 2. Non-positive intervals
`"0 days"` / `"0.0 seconds"` are well-formed shape-wise but meaningless as a chunk size / policy threshold / bucket width (TimescaleDB rejects them anyway; negatives were already rejected by the grammar). `isInterval`/`assertInterval` now require a **positive amount**.

**No behavior change for valid schemas** (DateTime time columns + positive intervals) — purely tightened validation with clearer errors.

## Verification (all green locally)
- build (v0.4.0) · typecheck · test:types · attw ✅
- coverage ✅ — 150 unit tests; 93.16% stmts / 88.11% branch / 92.79% funcs / 94.09% lines
- full integration ✅ — 7 files / 21 tests (unaffected; all use DateTime + positive intervals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interval validation now rejects non-positive amounts (including `0` / `0.0`); error messaging was aligned with the stricter rule.
  * Time partitioning columns are now restricted to `DateTime` only for both hypertables and continuous aggregates; integer time columns are rejected with a clear “not supported yet” message.

* **Documentation**
  * Updated the Hypertable `column` annotation documentation to explicitly require `DateTime` for the time partitioning column (integer time columns not supported yet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->