### PR TITLE
feat: gap-filling in timeBucket (gapfill + locf / interpolate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ const rows = await prisma.sensorReading.timeBucket({
 - `fill: "locf"` carries the last observed value forward into empty buckets; `fill: "interpolate"`
   linearly interpolates between the surrounding values. Both are `null` at the range edges where
   there's no neighbouring value, and gap-filling happens **per `groupBy` group**.
-- **Under `gapfill`, every aggregate is nullable** (`number | null`) — empty buckets have no data.
+- **Under `gapfill`, every aggregate becomes nullable** — its base type still follows `as` / `fill`
+  (so an unfilled `{ sum, as: "bigint" }` comes back as `bigint | null`), since empty buckets have no data.
 - `fill` requires `gapfill: true` and is mutually exclusive with
   [`as`](#exact-aggregate-results-as-bigint--string) (a carried/interpolated value is a JS `number`,
   not an exact bigint/decimal).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 - 🧹 **Retention policies** — drop old chunks automatically via `@timescale.retention` or `$timescale`
 - 🗜️ **Columnstore compression** — compress old chunks automatically via `@timescale.compression` or `$timescale` (TimescaleDB hypercore)
 - ♻️ **Reset-safe migrations** — survive `prisma migrate reset` (proven twice, on real TimescaleDB)
-- 🔎 **Typed `timeBucket(...)` queries** with result-row inference and compile-time column checks
+- 🔎 **Typed `timeBucket(...)` queries** with result-row inference, compile-time column checks, and gap-filling (`locf` / `interpolate`)
 - 🛟 **Generator-optional** — the client extension works from a manual config too, so a Prisma
   internal-API change can't fully break you
 
@@ -295,6 +295,34 @@ const rows = await prisma.sensorReading.timeBucket({
 
 The result-row type follows `as` per aggregate, and the disallowed combinations (`avg` + `bigint`,
 `count` + `string`) are compile errors.
+
+#### Gap-filling empty buckets (`gapfill` + `fill`)
+
+By default `timeBucket` returns only buckets that have rows. Set `gapfill: true` to emit a row for
+**every** bucket across `range` (TimescaleDB `time_bucket_gapfill`), then fill the empty ones per
+aggregate:
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  gapfill: true,
+  aggregate: {
+    avgTemp: { avg: "temperature", fill: "locf" },        // carry the last value forward
+    smooth:  { avg: "temperature", fill: "interpolate" }, // linear interpolation
+    raw:     { avg: "temperature" },                      // null in empty buckets
+  },
+});
+// rows: Array<{ bucket: Date; avgTemp: number | null; smooth: number | null; raw: number | null }>
+```
+
+- `fill: "locf"` carries the last observed value forward into empty buckets; `fill: "interpolate"`
+  linearly interpolates between the surrounding values. Both are `null` at the range edges where
+  there's no neighbouring value, and gap-filling happens **per `groupBy` group**.
+- **Under `gapfill`, every aggregate is nullable** (`number | null`) — empty buckets have no data.
+- `fill` requires `gapfill: true` and is mutually exclusive with
+  [`as`](#exact-aggregate-results-as-bigint--string) (a carried/interpolated value is a JS `number`,
+  not an exact bigint/decimal).
 
 ### Reading a continuous aggregate
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -38,23 +38,34 @@ export type SumAs = "number" | "bigint" | "string";
 export type AvgAs = "number" | "string";
 export type CountAs = "number" | "bigint";
 
-/** A single aggregate operation: one function applied to one column of `R` (+ optional `as`). */
+/**
+ * Gap-fill mode for an aggregate under `gapfill: true`: `"locf"` carries the last observed value
+ * forward into empty buckets; `"interpolate"` linearly interpolates between surrounding values. A
+ * filled aggregate comes back as a JS `number` — `fill` is mutually exclusive with `as`, since a
+ * carried/interpolated value isn't the exact bigint/decimal that `as` selects.
+ */
+export type Fill = "locf" | "interpolate";
+
+/** A single aggregate operation: one function applied to one column of `R` (+ optional `as` / `fill`). */
 export type AggregateOp<R> =
-  | { sum: NumericColumn<R>; as?: SumAs }
-  | { avg: NumericColumn<R>; as?: AvgAs }
-  | { min: NumericColumn<R> }
-  | { max: NumericColumn<R> }
-  | { count: AnyColumn<R>; as?: CountAs };
+  | { sum: NumericColumn<R>; as?: SumAs; fill?: Fill }
+  | { avg: NumericColumn<R>; as?: AvgAs; fill?: Fill }
+  | { min: NumericColumn<R>; fill?: Fill }
+  | { max: NumericColumn<R>; fill?: Fill }
+  | { count: AnyColumn<R>; as?: CountAs; fill?: Fill };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
 
-/** Map an aggregate op's `as` selector to its result-row TS type (default `number`). */
-export type AggOutput<Op> = Op extends { as: "bigint" }
-  ? bigint
-  : Op extends { as: "string" }
-    ? string
-    : number;
+/** Map an aggregate op to its result-row TS type: a `fill`ed value is a JS `number`; otherwise the
+ * `as` selector decides (default `number`). Nullability under `gapfill` is layered on in TimeBucketRow. */
+export type AggOutput<Op> = Op extends { fill: Fill }
+  ? number
+  : Op extends { as: "bigint" }
+    ? bigint
+    : Op extends { as: "string" }
+      ? string
+      : number;
 
 /** Arguments to `timeBucket`. `R` is the model's scalar row, `W` its where input. */
 export interface TimeBucketArgs<R, W = unknown> {
@@ -68,15 +79,24 @@ export interface TimeBucketArgs<R, W = unknown> {
   groupBy?: ReadonlyArray<AnyColumn<R>>;
   /** One or more aggregates; keys become result columns. */
   aggregate: AggregateInput<R>;
+  /**
+   * Emit a row for every bucket across `range`, not just buckets that have data (TimescaleDB
+   * `time_bucket_gapfill`). Empty buckets get `null` aggregates unless that aggregate sets `fill`.
+   * Enabling this makes every aggregate in the result row nullable.
+   */
+  gapfill?: boolean;
 }
 
 type GroupByOf<A> = A extends { groupBy: ReadonlyArray<infer G> } ? G : never;
+/** Under `gapfill: true`, empty buckets carry `null` aggregates, so every aggregate is nullable. */
+type GapNull<A> = A extends { gapfill: true } ? null : never;
 
-/** The inferred result row: bucket + selected group-by columns + each aggregate (typed by `as`). */
+/** The inferred result row: bucket + selected group-by columns + each aggregate (typed by `as`/`fill`,
+ * nullable under `gapfill`). */
 export type TimeBucketRow<R, A extends TimeBucketArgs<R, unknown>> = Prettify<
   { bucket: Date } & { [K in Extract<GroupByOf<A>, keyof R>]: R[K] } & {
     // -readonly: `const A` marks the aggregate keys readonly; the result row shouldn't be.
-    -readonly [K in keyof A["aggregate"]]: AggOutput<A["aggregate"][K]>;
+    -readonly [K in keyof A["aggregate"]]: AggOutput<A["aggregate"][K]> | GapNull<A>;
   }
 >;
 
@@ -125,6 +145,35 @@ export interface TimeBucketRuntimeArgs {
   where?: Record<string, unknown>;
   groupBy?: readonly string[];
   aggregate: Record<string, Record<string, string>>;
+  gapfill?: boolean;
+}
+
+/**
+ * Build the SQL for one aggregate, applying `fill` (gapfill-only) or the `as` cast.
+ *  - no `fill`: `fn(col)<as-cast>` (unchanged default behavior).
+ *  - `locf`: carry the last value forward — `locf(fn(col)<default-cast>)`.
+ *  - `interpolate`: linear, numeric-only — cast the aggregate to double precision *inside*
+ *    interpolate (avg over an int column is `numeric`, which interpolate has no overload for).
+ * `fill` requires `gapfill` and is mutually exclusive with `as` (a filled value is a JS number).
+ */
+function aggregateExpr(
+  fn: string,
+  src: string,
+  outputAs: string | undefined,
+  fill: string | undefined,
+  gapfill: boolean,
+  resultName: string,
+): string {
+  if (fill === undefined) return `${fn}(${src})${castFor(fn, outputAs)}`;
+  if (!gapfill) {
+    throw new Error(`timeBucket: aggregate "${resultName}" sets fill: ${JSON.stringify(fill)} but requires gapfill: true.`);
+  }
+  if (outputAs !== undefined) {
+    throw new Error(`timeBucket: aggregate "${resultName}" cannot combine fill with as — a filled value is a JS number.`);
+  }
+  if (fill === "locf") return `locf(${fn}(${src})${castFor(fn, undefined)})`;
+  if (fill === "interpolate") return `interpolate(${fn}(${src})::double precision)`;
+  throw new Error(`timeBucket: invalid fill ${JSON.stringify(fill)} on "${resultName}" (expected "locf" or "interpolate").`);
 }
 
 /**
@@ -159,7 +208,13 @@ export function buildTimeBucketQuery(
   const params: unknown[] = [args.bucket, args.range.start, args.range.end];
   const time = quoteIdent(timeColumn);
 
-  const select: string[] = [`time_bucket($1, ${time}) AS "bucket"`];
+  // gapfill emits a row for every bucket across the range (empty ones get null aggregates unless
+  // `fill`ed). Its bounds are inferred from the `time >= $2 AND time < $3` predicate below — always
+  // present since `range` is required — so the 2-arg form needs no extra args.
+  const gapfill = args.gapfill === true;
+  const bucketExpr = gapfill ? `time_bucket_gapfill($1, ${time})` : `time_bucket($1, ${time})`;
+
+  const select: string[] = [`${bucketExpr} AS "bucket"`];
 
   const groupCols = args.groupBy ?? [];
   for (const g of groupCols) {
@@ -173,8 +228,8 @@ export function buildTimeBucketQuery(
   }
   for (const [resultName, op] of aggregateEntries) {
     assertSafeIdent(resultName, "aggregate result column");
-    // Split the optional `as` selector from the single function entry ({ sum: "x", as: "bigint" }).
-    const { as: outputAs, ...fnPart } = op;
+    // Split the optional `as` / `fill` selectors from the single function entry ({ sum: "x", as: "bigint" }).
+    const { as: outputAs, fill, ...fnPart } = op;
     const entry = Object.entries(fnPart)[0];
     if (!entry) throw new Error(`timeBucket: aggregate "${resultName}" must specify a function.`);
     const [fn, column] = entry;
@@ -189,8 +244,8 @@ export function buildTimeBucketQuery(
     }
     const src = quoteIdent(col(column));
     const alias = quoteIdent(resultName);
-    // The cast picks the JS return type: default `number`, or exact `bigint`/`string` via `as`.
-    select.push(`${fn}(${src})${castFor(fn, outputAs)} AS ${alias}`);
+    // `aggregateExpr` applies `fill` (gapfill-only locf/interpolate) or the `as` cast.
+    select.push(`${aggregateExpr(fn, src, outputAs, fill, gapfill, resultName)} AS ${alias}`);
   }
 
   // Relation-filter lookup (some/none/every/is/isNot -> EXISTS). Precompute every model's

--- a/test/integration/gapfill.test.ts
+++ b/test/integration/gapfill.test.ts
@@ -1,0 +1,98 @@
+// Gap-filling in timeBucket, end-to-end on real TimescaleDB: gapfill: true emits a row for every
+// bucket across the range (via time_bucket_gapfill, bounds inferred from the range WHERE), and the
+// per-aggregate fill modes carry forward (locf) / interpolate empty buckets. Values verified
+// against a known gap (bucket 01:00 has no data between 00:00 and 02:00).
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED gapfill.test.ts: Docker is not available. Gap-filling is NOT verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T03:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket gap-filling (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Bucket 00:00 -> avg 15; 01:00 -> GAP (no rows); 02:00 -> avg 40.
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:30:00Z"), temperature: 10 },
+        { deviceId: 1, time: new Date("2026-06-15T00:45:00Z"), temperature: 20 },
+        { deviceId: 1, time: new Date("2026-06-15T02:15:00Z"), temperature: 40 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("emits empty buckets and fills them with locf / interpolate", async () => {
+    const rows = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      gapfill: true,
+      aggregate: {
+        raw: { avg: "temperature" },
+        carried: { avg: "temperature", fill: "locf" },
+        line: { avg: "temperature", fill: "interpolate" },
+      },
+    });
+    // Three hourly buckets across the range, even though 01:00 has no data.
+    expect(rows).toHaveLength(3);
+    const [b0, b1, b2] = rows;
+    expect(b0).toMatchObject({ raw: 15, carried: 15, line: 15 });
+    expect(b1.raw).toBeNull(); // empty bucket -> null raw aggregate
+    expect(b1.carried).toBe(15); // last observation carried forward
+    expect(b1.line).toBe(27.5); // linear interpolation between 15 and 40
+    expect(b2).toMatchObject({ raw: 40, carried: 40, line: 40 });
+  });
+
+  it("without gapfill, only buckets that have data are returned", async () => {
+    const rows = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: { raw: { avg: "temperature" } },
+    });
+    expect(rows).toHaveLength(2); // 00:00 and 02:00 only — no row for the empty 01:00 bucket
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -80,7 +80,40 @@ type _exact = Expect<
   >
 >;
 
+// --- gapfill: every aggregate becomes nullable; a `fill`ed aggregate is number|null ---
+const gf = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  groupBy: ["deviceId"],
+  gapfill: true,
+  aggregate: {
+    carried: { avg: "temperature", fill: "locf" },
+    line: { avg: "temperature", fill: "interpolate" },
+    raw: { avg: "temperature" },
+    total: { sum: "temperature", as: "bigint" }, // `as` still applies; nullable under gapfill
+  },
+});
+type _gf = Expect<
+  Equal<
+    (typeof gf)[number],
+    { bucket: Date; deviceId: number; carried: number | null; line: number | null; raw: number | null; total: bigint | null }
+  >
+>;
+
+// without gapfill, aggregates stay non-null (unchanged)
+const nogf = timeBucket({ bucket: "1 hour", range: { start, end }, aggregate: { raw: { avg: "temperature" } } });
+type _nogf = Expect<Equal<(typeof nogf)[number], { bucket: Date; raw: number }>>;
+
 // --- negatives: each must fail to compile ---
+
+// an invalid fill mode
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  gapfill: true,
+  // @ts-expect-error - "ffill" is not a valid fill mode
+  aggregate: { x: { avg: "temperature", fill: "ffill" } },
+});
 
 // avg cannot be "bigint" (it is fractional)
 timeBucket({

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -144,4 +144,60 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`EXISTS (SELECT 1 FROM "Reading" AS "_rel2" WHERE "_rel2"."deviceId" = "_rel"."id"`);
     expect(sql).not.toContain("::regclass");
   });
+
+  it("gapfill: true switches to time_bucket_gapfill (bounds inferred from the range WHERE)", () => {
+    const { sql, params } = buildTimeBucketQuery("SensorReading", "time", { ...base, gapfill: true });
+    expect(sql).toContain(`time_bucket_gapfill($1, "time") AS "bucket"`);
+    expect(sql).not.toMatch(/time_bucket\(\$1/); // not the plain (non-gapfill) form
+    expect(sql).toContain(`WHERE "time" >= $2 AND "time" < $3`);
+    expect(params).toEqual(["1 hour", range.start, range.end]);
+  });
+
+  it("fill locf / interpolate wrap the aggregate; an unfilled aggregate stays plain", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      gapfill: true,
+      aggregate: {
+        carried: { avg: "temperature", fill: "locf" },
+        line: { avg: "temperature", fill: "interpolate" },
+        raw: { avg: "temperature" },
+      },
+    });
+    expect(sql).toContain(`locf(avg("temperature")::double precision) AS "carried"`);
+    expect(sql).toContain(`interpolate(avg("temperature")::double precision) AS "line"`);
+    expect(sql).toContain(`avg("temperature")::double precision AS "raw"`);
+  });
+
+  it("locf keeps the per-fn default cast (count -> ::int, min/max native)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      gapfill: true,
+      aggregate: { c: { count: "deviceId", fill: "locf" }, m: { max: "temperature", fill: "locf" } },
+    });
+    expect(sql).toContain(`locf(count("deviceId")::int) AS "c"`);
+    expect(sql).toContain(`locf(max("temperature")) AS "m"`);
+  });
+
+  it("rejects fill without gapfill, and fill combined with as", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { avg: "temperature", fill: "locf" } } }),
+    ).toThrow(/requires gapfill: true/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        gapfill: true,
+        aggregate: { x: { sum: "deviceId", as: "bigint", fill: "locf" } },
+      }),
+    ).toThrow(/cannot combine fill with as/);
+  });
+
+  it("rejects an invalid fill value (non-TS caller)", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        gapfill: true,
+        aggregate: { x: { avg: "temperature", fill: "ffill" } },
+      }),
+    ).toThrow(/invalid fill/);
+  });
 });


### PR DESCRIPTION
## What

First item off the TimescaleDB gap-analysis backlog. Adds **gap-filling** to the typed `timeBucket()` helper:

```ts
const rows = await prisma.sensorReading.timeBucket({
  bucket: "1 hour",
  range: { start, end },
  gapfill: true,                                        // emit a row per bucket, even empty ones
  aggregate: {
    avgTemp: { avg: "temperature", fill: "locf" },        // carry last value forward
    smooth:  { avg: "temperature", fill: "interpolate" }, // linear interpolation
    raw:     { avg: "temperature" },                      // null in empty buckets
  },
});
// rows: Array<{ bucket: Date; avgTemp: number|null; smooth: number|null; raw: number|null }>
```

- `gapfill: true` → `time_bucket_gapfill($1, time)`; per-aggregate `fill: "locf" | "interpolate"`.
- **Under `gapfill`, every aggregate is nullable** (`number | null`); a `fill`ed aggregate returns a JS `number` and is **mutually exclusive with `as`**. Runtime rejects `fill` without `gapfill`, `fill`+`as`, and invalid `fill` values.

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

- The **2-arg `time_bucket_gapfill($1, "time")` infers its bounds from the existing `WHERE "time" >= $2 AND "time" < $3`** — no extra args, no cast — mirroring our current `time_bucket($1, "time")`. Confirmed with all-inferred params (exactly the adapter's binding shape); the earlier "param" failure was only a psql untyped-`$` overload-ambiguity artifact, not a gapfill limitation.
- `locf(<agg>)` carries forward **per group**; `interpolate(<agg>)` is linear and numeric-only (so the aggregate is cast to `double precision` inside it — `avg` over an int column is `numeric`, which `interpolate` has no overload for). Both `null` at range edges.

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 156 unit tests; 93.28% stmts / 88.35% branch / 92.85% funcs / 94.18% lines
- full integration ✅ — **8 files / 23 tests**. New `gapfill.test.ts` inserts a known gap (empty `01:00` bucket between `00:00`→avg 15 and `02:00`→avg 40) and asserts the gap row is emitted with `raw = null`, `locf = 15`, `interpolate = 27.5`, and that **without** gapfill only the 2 non-empty buckets return.

Non-gapfill `timeBucket` SQL/behavior is unchanged (the bucket expression and aggregate casts only differ when `gapfill`/`fill` are set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gap-filling for time-bucket queries so results include every bucket in the requested range.
  * Introduced per-aggregate `fill` options (`locf` or `interpolate`) to control how empty buckets are populated.
* **Documentation**
  * Documented gap-filling configuration, fill modes, and how aggregate outputs become nullable when gap-filling is enabled.
* **Tests**
  * Added integration, type-level, and unit coverage to validate gap-filling behavior and supported/unsupported option combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->