### PR TITLE
feat: first() / last() aggregates in timeBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ const rows = await prisma.sensorReading.timeBucket({
 
 Aggregate columns are checked against the model's scalar fields **at compile time**
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
-`groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`.
+`groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`, and
+[`first` / `last`](#earliest--latest-value-first--last).
 
 #### Relation filters (`some` / `none` / `every` / `is` / `isNot`)
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,29 @@ const rows = await prisma.sensorReading.timeBucket({
   [`as`](#exact-aggregate-results-as-bigint--string) (a carried/interpolated value is a JS `number`,
   not an exact bigint/decimal).
 
+#### Earliest / latest value (`first` / `last`)
+
+`first` / `last` return the value of one column at the **earliest / latest time** in each bucket
+(TimescaleDB `first(value, time)` / `last(value, time)`) — e.g. the open/close price per hour:
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  groupBy: ["deviceId"],
+  aggregate: {
+    open:  { first: "temperature" }, // value at the earliest time in the bucket
+    close: { last: "temperature" },  // value at the latest time
+    tag:   { last: "label" },        // any column type — keeps the column's type
+  },
+});
+// rows: Array<{ bucket: Date; deviceId: number; open: number; close: number; tag: string }>
+```
+
+- Ordered by the model's **time column by default**; pass `by: "<field>"` to order by another column.
+- `first` / `last` accept **any** column and the result keeps that column's type. They take no
+  `as` / `fill`, and are `null` in empty buckets under `gapfill`.
+
 ### Reading a continuous aggregate
 
 A continuous aggregate is a Prisma `view`, so reads are ordinary, fully-typed Prisma:

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -46,26 +46,37 @@ export type CountAs = "number" | "bigint";
  */
 export type Fill = "locf" | "interpolate";
 
-/** A single aggregate operation: one function applied to one column of `R` (+ optional `as` / `fill`). */
+/**
+ * A single aggregate operation: one function applied to one column of `R` (+ optional `as` / `fill`).
+ * `first`/`last` are different — they return the value of one column ordered by another (`by`,
+ * defaulting to the model's time column), so they accept any column and return its type.
+ */
 export type AggregateOp<R> =
   | { sum: NumericColumn<R>; as?: SumAs; fill?: Fill }
   | { avg: NumericColumn<R>; as?: AvgAs; fill?: Fill }
   | { min: NumericColumn<R>; fill?: Fill }
   | { max: NumericColumn<R>; fill?: Fill }
-  | { count: AnyColumn<R>; as?: CountAs; fill?: Fill };
+  | { count: AnyColumn<R>; as?: CountAs; fill?: Fill }
+  | { first: AnyColumn<R>; by?: AnyColumn<R> }
+  | { last: AnyColumn<R>; by?: AnyColumn<R> };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
 
-/** Map an aggregate op to its result-row TS type: a `fill`ed value is a JS `number`; otherwise the
- * `as` selector decides (default `number`). Nullability under `gapfill` is layered on in TimeBucketRow. */
-export type AggOutput<Op> = Op extends { fill: Fill }
-  ? number
-  : Op extends { as: "bigint" }
-    ? bigint
-    : Op extends { as: "string" }
-      ? string
-      : number;
+/** Map an aggregate op to its result-row TS type: `first`/`last` return the value column's type; a
+ * `fill`ed value is a JS `number`; otherwise the `as` selector decides (default `number`).
+ * Nullability under `gapfill` is layered on in TimeBucketRow. */
+export type AggOutput<R, Op> = Op extends { first: infer C extends keyof R }
+  ? R[C]
+  : Op extends { last: infer C extends keyof R }
+    ? R[C]
+    : Op extends { fill: Fill }
+      ? number
+      : Op extends { as: "bigint" }
+        ? bigint
+        : Op extends { as: "string" }
+          ? string
+          : number;
 
 /** Arguments to `timeBucket`. `R` is the model's scalar row, `W` its where input. */
 export interface TimeBucketArgs<R, W = unknown> {
@@ -96,7 +107,7 @@ type GapNull<A> = A extends { gapfill: true } ? null : never;
 export type TimeBucketRow<R, A extends TimeBucketArgs<R, unknown>> = Prettify<
   { bucket: Date } & { [K in Extract<GroupByOf<A>, keyof R>]: R[K] } & {
     // -readonly: `const A` marks the aggregate keys readonly; the result row shouldn't be.
-    -readonly [K in keyof A["aggregate"]]: AggOutput<A["aggregate"][K]> | GapNull<A>;
+    -readonly [K in keyof A["aggregate"]]: AggOutput<R, A["aggregate"][K]> | GapNull<A>;
   }
 >;
 
@@ -228,11 +239,25 @@ export function buildTimeBucketQuery(
   }
   for (const [resultName, op] of aggregateEntries) {
     assertSafeIdent(resultName, "aggregate result column");
-    // Split the optional `as` / `fill` selectors from the single function entry ({ sum: "x", as: "bigint" }).
-    const { as: outputAs, fill, ...fnPart } = op;
+    // Split the optional `as` / `fill` / `by` selectors from the single function entry ({ sum: "x", as: "bigint" }).
+    const { as: outputAs, fill, by, ...fnPart } = op;
     const entry = Object.entries(fnPart)[0];
     if (!entry) throw new Error(`timeBucket: aggregate "${resultName}" must specify a function.`);
     const [fn, column] = entry;
+    const src = quoteIdent(col(column));
+    const alias = quoteIdent(resultName);
+
+    // first/last: the value of `column` ordered by `by` (default: the model's time column). They
+    // return the value column's own type, so they take no `as`/`fill`.
+    if (fn === "first" || fn === "last") {
+      if (outputAs !== undefined) throw new Error(`timeBucket: "${fn}" on "${resultName}" does not support as.`);
+      if (fill !== undefined) throw new Error(`timeBucket: "${fn}" on "${resultName}" does not support fill.`);
+      const orderBy = by !== undefined ? quoteIdent(col(by)) : time;
+      select.push(`${fn}(${src}, ${orderBy}) AS ${alias}`);
+      continue;
+    }
+    if (by !== undefined) throw new Error(`timeBucket: "by" is only valid on first / last (on "${resultName}").`);
+
     const allowedAs = AGG_AS[fn];
     if (!allowedAs) {
       throw new Error(`timeBucket: unsupported aggregate function "${fn}" for "${resultName}".`);
@@ -242,8 +267,6 @@ export function buildTimeBucketQuery(
         `timeBucket: as: ${JSON.stringify(outputAs)} is not valid for "${fn}" on "${resultName}" (allowed: ${[...allowedAs].join(", ")}).`,
       );
     }
-    const src = quoteIdent(col(column));
-    const alias = quoteIdent(resultName);
     // `aggregateExpr` applies `fill` (gapfill-only locf/interpolate) or the `as` cast.
     select.push(`${aggregateExpr(fn, src, outputAs, fill, gapfill, resultName)} AS ${alias}`);
   }

--- a/test/integration/first-last.test.ts
+++ b/test/integration/first-last.test.ts
@@ -1,0 +1,98 @@
+// first() / last() aggregates in timeBucket, end-to-end on real TimescaleDB: the value of one
+// column at the earliest / latest time in each bucket (ordered by the model's time column by
+// default). Verified for a numeric and a text column against known per-bucket extremes.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED first-last.test.ts: Docker is not available. first/last are NOT verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  label       String
+
+  @@id([deviceId, time])
+}`;
+
+const INIT_SQL = `CREATE TABLE "SensorReading" (
+  "time" TIMESTAMP(3) NOT NULL,
+  "deviceId" INTEGER NOT NULL,
+  "temperature" DOUBLE PRECISION NOT NULL,
+  "label" TEXT NOT NULL,
+  CONSTRAINT "SensorReading_pkey" PRIMARY KEY ("deviceId","time")
+);`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket first / last (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Within the 00:00 bucket: earliest 00:10 (temp 10, "a"), latest 00:50 (temp 20, "b").
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:10:00Z"), temperature: 10, label: "a" },
+        { deviceId: 1, time: new Date("2026-06-15T00:30:00Z"), temperature: 15, label: "c" },
+        { deviceId: 1, time: new Date("2026-06-15T00:50:00Z"), temperature: 20, label: "b" },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("returns the value at the earliest / latest time per bucket (numeric and text)", async () => {
+    const rows = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      groupBy: ["deviceId"],
+      aggregate: {
+        firstTemp: { first: "temperature" },
+        lastTemp: { last: "temperature" },
+        firstLabel: { first: "label" },
+        lastLabel: { last: "label" },
+      },
+    });
+    expect(rows).toHaveLength(1);
+    // first/last are by time (default), NOT by value — so lastLabel is "b" (at 00:50), not "c".
+    expect(rows[0]).toMatchObject({
+      deviceId: 1,
+      firstTemp: 10,
+      lastTemp: 20,
+      firstLabel: "a",
+      lastLabel: "b",
+    });
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -104,7 +104,37 @@ type _gf = Expect<
 const nogf = timeBucket({ bucket: "1 hour", range: { start, end }, aggregate: { raw: { avg: "temperature" } } });
 type _nogf = Expect<Equal<(typeof nogf)[number], { bucket: Date; raw: number }>>;
 
+// --- first / last: result type is the value column's type (default ordered by time) ---
+const fl = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: {
+    firstTemp: { first: "temperature" }, // number
+    lastLabel: { last: "label" }, // string
+    firstTime: { first: "time" }, // Date
+    lastTempByDevice: { last: "temperature", by: "deviceId" }, // number, ordered by another column
+  },
+});
+type _fl = Expect<
+  Equal<
+    (typeof fl)[number],
+    { bucket: Date; firstTemp: number; lastLabel: string; firstTime: Date; lastTempByDevice: number }
+  >
+>;
+
+// first / last become nullable under gapfill, keeping their column type
+const flgf = timeBucket({ bucket: "1 hour", range: { start, end }, gapfill: true, aggregate: { lastLabel: { last: "label" } } });
+type _flgf = Expect<Equal<(typeof flgf)[number], { bucket: Date; lastLabel: string | null }>>;
+
 // --- negatives: each must fail to compile ---
+
+// first on a column that doesn't exist
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "nope" is not a column of Row
+  aggregate: { x: { first: "nope" } },
+});
 
 // an invalid fill mode
 timeBucket({

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -200,4 +200,44 @@ describe("buildTimeBucketQuery", () => {
       }),
     ).toThrow(/invalid fill/);
   });
+
+  it("first / last order by the time column by default; `by` overrides", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: {
+        firstTemp: { first: "temperature" },
+        lastTemp: { last: "temperature" },
+        firstByLabel: { first: "temperature", by: "label" },
+      },
+    });
+    expect(sql).toContain(`first("temperature", "time") AS "firstTemp"`);
+    expect(sql).toContain(`last("temperature", "time") AS "lastTemp"`);
+    expect(sql).toContain(`first("temperature", "label") AS "firstByLabel"`);
+  });
+
+  it("first / last resolve @map columns for both value and `by`", () => {
+    const { sql } = buildTimeBucketQuery(
+      "sensor_readings",
+      "ts",
+      { ...base, aggregate: { latest: { last: "temperature", by: "deviceId" } } },
+      { deviceId: "device_id", time: "ts" },
+    );
+    expect(sql).toContain(`last("temperature", "device_id") AS "latest"`);
+  });
+
+  it("first / last reject as and fill; `by` is rejected on other aggregates", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { first: "temperature", as: "bigint" } } }),
+    ).toThrow(/does not support as/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        gapfill: true,
+        aggregate: { x: { last: "temperature", fill: "locf" } },
+      }),
+    ).toThrow(/does not support fill/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { avg: "temperature", by: "time" } } }),
+    ).toThrow(/"by" is only valid on first \/ last/);
+  });
 });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -220,9 +220,9 @@ describe("buildTimeBucketQuery", () => {
       "sensor_readings",
       "ts",
       { ...base, aggregate: { latest: { last: "temperature", by: "deviceId" } } },
-      { deviceId: "device_id", time: "ts" },
+      { deviceId: "device_id", time: "ts", temperature: "temp_c" },
     );
-    expect(sql).toContain(`last("temperature", "device_id") AS "latest"`);
+    expect(sql).toContain(`last("temp_c", "device_id") AS "latest"`); // both value + by mapped
   });
 
   it("first / last reject as and fill; `by` is rejected on other aggregates", () => {


### PR DESCRIPTION
## What

Task #2 of the gap-analysis backlog. Adds TimescaleDB `first(value, time)` / `last(value, time)` to the `timeBucket()` aggregate spec — the value of a column at the **earliest / latest time** in each bucket:

```ts
const rows = await prisma.sensorReading.timeBucket({
  bucket: "1 hour",
  range: { start, end },
  groupBy: ["deviceId"],
  aggregate: {
    open:  { first: "temperature" }, // value at the earliest time
    close: { last: "temperature" },  // value at the latest time
    tag:   { last: "label" },        // any column type
  },
});
// rows: Array<{ bucket: Date; deviceId: number; open: number; close: number; tag: string }>
```

- Ordered by the model's **time column by default** (we already know it); `by: "<field>"` overrides.
- `first`/`last` accept **any** column and the result row **keeps that column's type** (`AggOutput` now resolves `R[col]`). No `as`/`fill`; nullable under `gapfill`.

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

- Signatures `first(anyelement, "any")` / `last(anyelement, "any")` — value + ordering column, returns the value's type.
- Verified they pick **by ordering position, not by value** (a NULL middle row doesn't affect them; `last(temp, label)` returned the max-label row's value). Context7 confirms the `LAST(price, ts)` per-bucket pattern.

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 159 unit tests; 93.36% stmts / 88.59% branch / 92.85% funcs / 94.25% lines
- full integration ✅ — 9 files / 24 tests. New `first-last.test.ts` verifies numeric + text first/last by time (`lastLabel = "b"` at 00:50, not the lexically-larger `"c"`).

_Note: one integration file flaked once locally on a back-to-back 9-container run (container-start contention) and passed on isolation + re-run; CI runs on a clean runner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `first` and `last` aggregates to `timeBucket`, returning the value from the bucket’s earliest/latest timestamp.
  * Supported optional `by` for ordering within each bucket (defaults to the model time column).
  * Updated result typing to preserve the selected column’s type.
* **Documentation**
  * Documented `first`/`last` semantics, default ordering, `gapfill` behavior (empty buckets return `null`), and supported options.
* **Bug Fixes**
  * Enforced valid combinations: `first`/`last` reject `as`/`fill`, and `by` is restricted to `first`/`last`.
* **Tests**
  * Added integration, unit, and type tests for numeric/text columns, typing, and invalid option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->