### PR TITLE
feat: $timescale chunk + size helpers (drop_chunks + introspection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,24 @@ refresh"*). `refreshContinuousAggregate` retries this transient case with bounde
 backoff (default: up to 8 attempts); if the contention persists beyond that budget, the original
 `55P03` error is rethrown.
 
+#### Inspecting & dropping chunks
+
+```ts
+// On-demand chunk drop (manual retention) — returns the dropped chunk names.
+const dropped = await prisma.$timescale.dropChunks("SensorReading", { olderThan: "30 days" });
+
+// Size, row-count, and compression introspection — sizes/counts come back as exact `bigint`.
+const bytes  = await prisma.$timescale.hypertableSize("SensorReading");         // bigint (total bytes)
+const detail = await prisma.$timescale.hypertableDetailedSize("SensorReading"); // { tableBytes, indexBytes, toastBytes, totalBytes }
+const rows   = await prisma.$timescale.approximateRowCount("SensorReading");    // bigint (planner estimate; fast)
+const stats  = await prisma.$timescale.compressionStats("SensorReading");       // { totalChunks, compressedChunks, beforeTotalBytes, afterTotalBytes }
+```
+
+`dropChunks` bounds (`olderThan` / `newerThan`) are intervals **relative to now** (combine both for a
+window), matching `@timescale.retention`'s `dropAfter` — absolute-timestamp cutoffs aren't supported.
+The introspection helpers wrap `hypertable_size`, `hypertable_detailed_size`, `approximate_row_count`,
+and `hypertable_columnstore_stats`.
+
 ---
 
 ## Data retention (`@timescale.retention`)

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -45,6 +45,37 @@ export interface CompressionOptions {
 /** Minimal raw-capable client surface we rely on (PrismaClient provides these). */
 export interface RawClient {
   $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+  /** Read-returning raw query, for the introspection helpers (sizes, row count, dropped chunks). */
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
+}
+
+/** Options for an on-demand chunk drop. At least one bound is required; each is an `Interval`
+ * relative to now (matching retention's `dropAfter`). Absolute-timestamp cutoffs aren't supported —
+ * `drop_chunks`'s bound type must match the partition column's exact (tz vs no-tz) type, which the
+ * registry doesn't carry; use an interval relative to now instead. */
+export interface DropChunksOptions {
+  /** Drop chunks whose time range is entirely older than this interval before now. */
+  olderThan?: Interval;
+  /** Drop chunks whose time range is entirely newer than this interval before now (combine with `olderThan` for a window). */
+  newerThan?: Interval;
+}
+
+/** Per-component byte sizes of a hypertable (from `hypertable_detailed_size`). */
+export interface HypertableSize {
+  tableBytes: bigint;
+  indexBytes: bigint;
+  toastBytes: bigint;
+  totalBytes: bigint;
+}
+
+/** Columnstore-compression effectiveness for a hypertable (from `hypertable_columnstore_stats`). */
+export interface CompressionStats {
+  totalChunks: bigint;
+  compressedChunks: bigint;
+  /** Total bytes before compression across compressed chunks; `null` when nothing is compressed. */
+  beforeTotalBytes: bigint | null;
+  /** Total bytes after compression across compressed chunks; `null` when nothing is compressed. */
+  afterTotalBytes: bigint | null;
 }
 
 /** Range for a continuous-aggregate refresh; null bounds mean "open" (full refresh). */
@@ -113,6 +144,24 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
    * the columnstore itself enabled — disabling it fails once any chunk has been compressed.
    */
   removeCompressionPolicy(model: HModels): Promise<void>;
+
+  /**
+   * Drop chunks from a hypertable on demand (manual retention) — `drop_chunks`. At least one of
+   * `olderThan` / `newerThan` is required; combine both for a window. Returns the dropped chunk names.
+   */
+  dropChunks(model: HModels, options: DropChunksOptions): Promise<string[]>;
+
+  /** Total on-disk size of a hypertable in bytes (`hypertable_size`). */
+  hypertableSize(model: HModels): Promise<bigint>;
+
+  /** Per-component byte sizes of a hypertable: table / index / toast / total (`hypertable_detailed_size`). */
+  hypertableDetailedSize(model: HModels): Promise<HypertableSize>;
+
+  /** Approximate row count from planner statistics (`approximate_row_count`) — fast, may be 0 until ANALYZE. */
+  approximateRowCount(model: HModels): Promise<bigint>;
+
+  /** Columnstore-compression effectiveness: chunk counts and before/after sizes (`hypertable_columnstore_stats`). */
+  compressionStats(model: HModels): Promise<CompressionStats>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -239,6 +288,81 @@ export function makeManage<HModels extends string = string, CModels extends stri
       const ref = resolveHypertable(model);
       const rel = relationLiteral(ref.table, ref.schema);
       await client.$executeRawUnsafe(`CALL remove_columnstore_policy(${rel}, if_exists => TRUE)`);
+    },
+
+    async dropChunks(model, opts) {
+      const ref = resolveHypertable(model);
+      const rel = relationLiteral(ref.table, ref.schema);
+      // Each bound is a validated Interval interpolated as `INTERVAL '...'` — a typed literal, so
+      // `older_than`'s polymorphic "any" parameter resolves (a bind param would be type-ambiguous).
+      const bound = (key: string, value: Interval | undefined): string | undefined => {
+        if (value === undefined) return undefined;
+        assertInterval(value);
+        return `${key} => INTERVAL ${quoteLiteral(value)}`;
+      };
+      const args = [bound("older_than", opts.olderThan), bound("newer_than", opts.newerThan)].filter(
+        (a): a is string => a !== undefined,
+      );
+      if (args.length === 0) {
+        throw new Error("dropChunks: specify olderThan and/or newerThan.");
+      }
+      const rows = await client.$queryRawUnsafe<{ chunk: string }[]>(
+        `SELECT drop_chunks(${rel}, ${args.join(", ")}) AS chunk`,
+      );
+      return rows.map((r) => r.chunk);
+    },
+
+    async hypertableSize(model) {
+      const ref = resolveHypertable(model);
+      const rows = await client.$queryRawUnsafe<{ bytes: bigint }[]>(
+        `SELECT hypertable_size(${relationLiteral(ref.table, ref.schema)}) AS bytes`,
+      );
+      return rows[0]?.bytes ?? 0n;
+    },
+
+    async hypertableDetailedSize(model) {
+      const ref = resolveHypertable(model);
+      const rows = await client.$queryRawUnsafe<
+        { table_bytes: bigint; index_bytes: bigint; toast_bytes: bigint; total_bytes: bigint }[]
+      >(
+        `SELECT table_bytes, index_bytes, toast_bytes, total_bytes FROM hypertable_detailed_size(${relationLiteral(ref.table, ref.schema)})`,
+      );
+      const r = rows[0];
+      return {
+        tableBytes: r?.table_bytes ?? 0n,
+        indexBytes: r?.index_bytes ?? 0n,
+        toastBytes: r?.toast_bytes ?? 0n,
+        totalBytes: r?.total_bytes ?? 0n,
+      };
+    },
+
+    async approximateRowCount(model) {
+      const ref = resolveHypertable(model);
+      const rows = await client.$queryRawUnsafe<{ count: bigint }[]>(
+        `SELECT approximate_row_count(${relationLiteral(ref.table, ref.schema)}) AS count`,
+      );
+      return rows[0]?.count ?? 0n;
+    },
+
+    async compressionStats(model) {
+      const ref = resolveHypertable(model);
+      const rows = await client.$queryRawUnsafe<
+        {
+          total_chunks: bigint;
+          number_compressed_chunks: bigint;
+          before_compression_total_bytes: bigint | null;
+          after_compression_total_bytes: bigint | null;
+        }[]
+      >(
+        `SELECT total_chunks, number_compressed_chunks, before_compression_total_bytes, after_compression_total_bytes FROM hypertable_columnstore_stats(${relationLiteral(ref.table, ref.schema)})`,
+      );
+      const r = rows[0];
+      return {
+        totalChunks: r?.total_chunks ?? 0n,
+        compressedChunks: r?.number_compressed_chunks ?? 0n,
+        beforeTotalBytes: r?.before_compression_total_bytes ?? null,
+        afterTotalBytes: r?.after_compression_total_bytes ?? null,
+      };
     },
   };
 }

--- a/test/integration/chunk-helpers.test.ts
+++ b/test/integration/chunk-helpers.test.ts
@@ -1,0 +1,98 @@
+// $timescale chunk + size helpers, end-to-end on real TimescaleDB: drop_chunks (on-demand
+// retention) plus the size / row-count / compression-stats introspection. Sizes come back as
+// exact JS bigints. Verified against a 3-chunk hypertable (one chunk per day).
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED chunk-helpers.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+}`;
+
+describe.skipIf(!DOCKER_OK)("$timescale chunk + size helpers (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // 3 rows, each in its own daily chunk, positioned relative to NOW so an interval-based drop is
+    // deterministic regardless of the wall clock: ~20, ~10 and ~2 days ago.
+    const at = (daysAgo: number) => new Date(Date.now() - daysAgo * 86_400_000);
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: at(20), temperature: 1 },
+        { deviceId: 1, time: at(10), temperature: 2 },
+        { deviceId: 1, time: at(2), temperature: 3 },
+      ],
+    });
+    await h.query(`ANALYZE "SensorReading"`); // so approximate_row_count has planner stats
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("reports total / detailed size and an approximate row count as bigints", async () => {
+    const size = await prisma.$timescale.hypertableSize("SensorReading");
+    expect(typeof size).toBe("bigint");
+    expect(size).toBeGreaterThan(0n);
+
+    const detailed = await prisma.$timescale.hypertableDetailedSize("SensorReading");
+    expect(typeof detailed.totalBytes).toBe("bigint");
+    expect(detailed.totalBytes).toBeGreaterThan(0n);
+    expect(detailed.totalBytes).toBe(detailed.tableBytes + detailed.indexBytes + detailed.toastBytes);
+
+    const rows = await prisma.$timescale.approximateRowCount("SensorReading");
+    expect(typeof rows).toBe("bigint");
+    expect(rows).toBe(3n);
+  });
+
+  it("dropChunks drops old chunks on demand and returns their names", async () => {
+    const dropped = await prisma.$timescale.dropChunks("SensorReading", { olderThan: "15 days" });
+    expect(dropped).toHaveLength(1); // only the ~20-days-ago chunk is entirely older than 15 days
+    expect(dropped.every((c: string) => c.includes("_hyper_"))).toBe(true);
+
+    const [{ n }] = await h.query<{ n: number }>(`SELECT count(*)::int AS n FROM "SensorReading"`);
+    expect(Number(n)).toBe(2); // the ~10- and ~2-days-ago rows remain
+  });
+
+  it("compressionStats reads catalog stats once columnstore is enabled", async () => {
+    await prisma.$timescale.addCompressionPolicy("SensorReading", { after: "7 days" });
+    const stats = await prisma.$timescale.compressionStats("SensorReading");
+    expect(typeof stats.totalChunks).toBe("bigint");
+    expect(stats.compressedChunks).toBe(0n); // policy hasn't run yet — nothing compressed
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -39,6 +39,26 @@ loose.refreshContinuousAggregate("anything"); // ok
 loose.addCompressionPolicy("anything", { after: "1 day" }); // ok — string fallback
 loose.removeCompressionPolicy("anything"); // ok
 
+// chunk + size helpers: model-name checked, with typed returns
+m.dropChunks("SensorReading", { olderThan: "30 days" }); // ok (interval bound)
+m.dropChunks("DeviceLog", { olderThan: "7 days", newerThan: "30 days" }); // ok (interval window)
+const _bytes: Promise<bigint> = m.hypertableSize("SensorReading");
+const _rows: Promise<bigint> = m.approximateRowCount("SensorReading");
+const _dropped: Promise<string[]> = m.dropChunks("SensorReading", { olderThan: "1 day" });
+void _bytes;
+void _rows;
+void _dropped;
+void m.hypertableDetailedSize("SensorReading"); // Promise<HypertableSize>
+void m.compressionStats("SensorReading"); // Promise<CompressionStats>
+// @ts-expect-error - typo on the model name
+m.dropChunks("SensorRead", { olderThan: "30 days" });
+// @ts-expect-error - typo on the model name
+m.hypertableSize("SensorRaeding");
+// @ts-expect-error - dropChunks bounds are intervals relative to now, not Dates
+m.dropChunks("SensorReading", { olderThan: new Date() });
+loose.dropChunks("anything", { olderThan: "1 day" }); // ok — string fallback
+loose.hypertableSize("anything"); // ok
+
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {
   hypertables: [{ model: "SensorReading", table: "sensor_readings" }],

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { makeManage, type RawClient } from "../../src/client/manage.js";
 
-function fakeClient() {
+function fakeClient(queryRows: unknown[] = []) {
   const calls: { sql: string; params: unknown[] }[] = [];
+  const queries: { sql: string; params: unknown[] }[] = [];
   const client: RawClient = {
     async $executeRawUnsafe(sql, ...params) {
       calls.push({ sql, params });
       return 0;
     },
+    async $queryRawUnsafe(sql: string, ...params: unknown[]) {
+      queries.push({ sql, params });
+      return queryRows as never;
+    },
   };
-  return { client, calls };
+  return { client, calls, queries };
 }
 
 /** A client whose $executeRawUnsafe throws `failWith` for the first `failTimes` calls. */
@@ -20,6 +25,9 @@ function flakyClient(failWith: unknown, failTimes: number) {
       attempts++;
       if (attempts <= failTimes) throw failWith;
       return 0;
+    },
+    async $queryRawUnsafe() {
+      return [] as never;
     },
   };
   return { client, attempts: () => attempts };
@@ -221,5 +229,77 @@ describe("makeManage compression policies", () => {
   it("rejects an unsafe model/relation name", async () => {
     const { client } = fakeClient();
     await expect(makeManage(client).addCompressionPolicy("bad name", { after: "1 day" })).rejects.toThrow(/Invalid/);
+  });
+});
+
+describe("makeManage chunk + size helpers", () => {
+  const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+
+  it("dropChunks with an interval bound interpolates a validated INTERVAL literal and maps the @@schema relation", async () => {
+    const { client, queries } = fakeClient([{ chunk: "_hyper_1_1_chunk" }, { chunk: "_hyper_1_2_chunk" }]);
+    const dropped = await makeManage(client, new Map(), { hypertableByModel }).dropChunks("SensorReading", {
+      olderThan: "30 days",
+    });
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toBe(
+      `SELECT drop_chunks('"metrics"."sensor_readings"', older_than => INTERVAL '30 days') AS chunk`,
+    );
+    expect(queries[0]!.params).toEqual([]);
+    expect(dropped).toEqual(["_hyper_1_1_chunk", "_hyper_1_2_chunk"]);
+  });
+
+  it("dropChunks supports an older/newer interval window (typed INTERVAL literals, no bind params)", async () => {
+    const { client, queries } = fakeClient([]);
+    await makeManage(client).dropChunks("SensorReading", { olderThan: "7 days", newerThan: "30 days" });
+    expect(queries[0]!.sql).toBe(
+      `SELECT drop_chunks('"SensorReading"', older_than => INTERVAL '7 days', newer_than => INTERVAL '30 days') AS chunk`,
+    );
+    expect(queries[0]!.params).toEqual([]);
+  });
+
+  it("dropChunks requires at least one bound and rejects an invalid interval", async () => {
+    await expect(makeManage(fakeClient().client).dropChunks("SensorReading", {})).rejects.toThrow(
+      /olderThan and\/or newerThan/,
+    );
+    await expect(
+      makeManage(fakeClient().client).dropChunks("SensorReading", { olderThan: "1 fortnight" as never }),
+    ).rejects.toThrow(/Invalid interval/);
+  });
+
+  it("hypertableSize / approximateRowCount return the scalar bigint", async () => {
+    const size = fakeClient([{ bytes: 253952n }]);
+    expect(await makeManage(size.client).hypertableSize("SensorReading")).toBe(253952n);
+    expect(size.queries[0]!.sql).toBe(`SELECT hypertable_size('"SensorReading"') AS bytes`);
+
+    const count = fakeClient([{ count: 1000n }]);
+    expect(await makeManage(count.client).approximateRowCount("SensorReading")).toBe(1000n);
+    expect(count.queries[0]!.sql).toBe(`SELECT approximate_row_count('"SensorReading"') AS count`);
+  });
+
+  it("hypertableDetailedSize maps the columns to camelCase bigints", async () => {
+    const { client, queries } = fakeClient([{ table_bytes: 1n, index_bytes: 2n, toast_bytes: 3n, total_bytes: 6n }]);
+    expect(await makeManage(client).hypertableDetailedSize("SensorReading")).toEqual({
+      tableBytes: 1n,
+      indexBytes: 2n,
+      toastBytes: 3n,
+      totalBytes: 6n,
+    });
+    expect(queries[0]!.sql).toContain(`FROM hypertable_detailed_size('"SensorReading"')`);
+  });
+
+  it("compressionStats maps chunk counts + before/after bytes (null when uncompressed)", async () => {
+    const { client } = fakeClient([
+      { total_chunks: 5n, number_compressed_chunks: 0n, before_compression_total_bytes: null, after_compression_total_bytes: null },
+    ]);
+    expect(await makeManage(client).compressionStats("SensorReading")).toEqual({
+      totalChunks: 5n,
+      compressedChunks: 0n,
+      beforeTotalBytes: null,
+      afterTotalBytes: null,
+    });
+  });
+
+  it("rejects an unsafe model/relation name", async () => {
+    await expect(makeManage(fakeClient().client).hypertableSize("bad name")).rejects.toThrow(/Invalid/);
   });
 });


### PR DESCRIPTION
## What

Task #3 of the gap-analysis backlog. Adds read-and-manage `$timescale` helpers (model names typo-checked like the existing ones):

```ts
const dropped = await prisma.$timescale.dropChunks("SensorReading", { olderThan: "30 days" }); // string[]
const bytes   = await prisma.$timescale.hypertableSize("SensorReading");         // bigint
const detail  = await prisma.$timescale.hypertableDetailedSize("SensorReading"); // { tableBytes, indexBytes, toastBytes, totalBytes }
const rows    = await prisma.$timescale.approximateRowCount("SensorReading");    // bigint
const stats   = await prisma.$timescale.compressionStats("SensorReading");       // { totalChunks, compressedChunks, beforeTotalBytes, afterTotalBytes }
```

- `dropChunks` = on-demand manual retention (`drop_chunks`), returns the dropped chunk names.
- Size/count/stats wrap `hypertable_size` / `hypertable_detailed_size` / `approximate_row_count` / `hypertable_columnstore_stats`. These are the **first `$timescale` methods that read rows**, so `RawClient` gained `$queryRawUnsafe`; sizes/counts come back as **exact `bigint`**.

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

- Confirmed signatures/return types; a quoted string-literal regclass is accepted (no `::regclass`).
- **`dropChunks` bounds are intervals relative to now only** (matching retention's `dropAfter`). `drop_chunks.older_than` is `"any"`-typed, so a bind `Date` param is type-ambiguous (`42P18`); and an absolute cast must match the partition column's exact tz-ness — I verified `::timestamp` works on **both** dim types but `::timestamptz` **fails** on a no-tz dim (Prisma's default `DateTime`), and the registry doesn't carry the column's type. Interval-relative-to-now sidesteps all of that and is the common manual-retention case.

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 166 unit tests; 93.6% stmts / 87.74% branch / 93.33% funcs / 94.46% lines
- full integration ✅ — 10 files / 27 tests. New `chunk-helpers.test.ts` inserts 3 chunks relative to now, asserts sizes/`detailedSize` identity/`approximateRowCount` as `bigint`, that `dropChunks({ olderThan: "15 days" })` drops exactly the ~20-days-ago chunk (deterministic regardless of wall clock), and that `compressionStats` reads catalog stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for inspecting and dropping chunks with documentation of available introspection functions and management operations.

* **New Features**
  * Added chunk dropping with time-relative bounds for flexible data retention management.
  * Added hypertable introspection helpers returning size metrics, approximate row counts, and compression statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->