### PR TITLE
feat: timezone / origin / offset for timeBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ const rows = await prisma.sensorReading.timeBucket({
 - `first` / `last` accept **any** column and the result keeps that column's type. They take no
   `as` / `fill`, and are `null` in empty buckets under `gapfill`.
 
+#### Time zones & bucket alignment (`timezone` / `origin` / `offset`)
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 day",
+  range: { start, end },
+  timezone: "Europe/Stockholm", // day/week/month buckets align to this zone's calendar (DST-aware)
+  // origin: new Date("2026-01-01T00:00:00Z"), // align buckets to an instant
+  // offset: "6 hours",                        // shift bucket boundaries by an interval
+  aggregate: { avgTemp: { avg: "temperature" } },
+});
+```
+
+- `timezone` requires a **`timestamptz` time column** (`@db.Timestamptz`) — calendar bucketing is
+  undefined for a tz-naive column; without it, `time_bucket` aligns to UTC.
+- `origin` (a `Date`) and `offset` (an interval) shift the bucket boundaries. `origin` + `offset`
+  together require a `timezone`, and none of `timezone` / `origin` / `offset` combine with `gapfill` yet.
+
 ### Reading a continuous aggregate
 
 A continuous aggregate is a Prisma `view`, so reads are ordinary, fully-typed Prisma:

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -201,11 +201,18 @@ function bucketExpression(time: string, args: TimeBucketRuntimeArgs): string {
   }
   const extra: string[] = [];
   if (timezone !== undefined) {
-    if (!TZ_RE.test(timezone)) throw new Error(`timeBucket: invalid timezone ${JSON.stringify(timezone)}.`);
+    // typeof check first: a non-string (null/true from a non-TS caller) would coerce through
+    // TZ_RE.test and then crash in quoteLiteral with a raw TypeError.
+    if (typeof timezone !== "string" || !TZ_RE.test(timezone)) {
+      throw new Error(`timeBucket: invalid timezone ${JSON.stringify(timezone)}.`);
+    }
     extra.push(quoteLiteral(timezone)); // positional 3rd arg — must precede the named args
   }
   if (origin !== undefined) {
-    if (!(origin instanceof Date)) throw new Error("timeBucket: `origin` must be a Date.");
+    // Reject Invalid Date too (it passes `instanceof Date` but throws a raw RangeError at toISOString()).
+    if (!(origin instanceof Date) || Number.isNaN(origin.getTime())) {
+      throw new Error("timeBucket: `origin` must be a valid Date.");
+    }
     extra.push(`origin => ${quoteLiteral(origin.toISOString())}`);
   }
   if (offset !== undefined) {

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -5,7 +5,7 @@ import { Prisma } from "@prisma/client/extension";
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import type { RelationConfig } from "../core/types.js";
-import { assertSafeIdent, qualifiedIdent, quoteIdent } from "../core/sql.js";
+import { assertSafeIdent, qualifiedIdent, quoteIdent, quoteLiteral } from "../core/sql.js";
 import { whereToSql, type RuntimeRelation } from "./where.js";
 
 // --- type machinery --------------------------------------------------------
@@ -96,6 +96,15 @@ export interface TimeBucketArgs<R, W = unknown> {
    * Enabling this makes every aggregate in the result row nullable.
    */
   gapfill?: boolean;
+  /**
+   * Bucket in this IANA timezone (e.g. `"Europe/Stockholm"`) so day/week/month buckets align to
+   * that zone's calendar boundaries across DST. **Requires a `timestamptz` time column** (`@db.Timestamptz`).
+   */
+  timezone?: string;
+  /** Align bucket boundaries to this instant (TimescaleDB `time_bucket(..., origin => ...)`). */
+  origin?: Date;
+  /** Shift bucket boundaries by this interval (TimescaleDB `time_bucket(..., offset => ...)`). */
+  offset?: Interval;
 }
 
 type GroupByOf<A> = A extends { groupBy: ReadonlyArray<infer G> } ? G : never;
@@ -157,6 +166,53 @@ export interface TimeBucketRuntimeArgs {
   groupBy?: readonly string[];
   aggregate: Record<string, Record<string, string>>;
   gapfill?: boolean;
+  timezone?: string;
+  origin?: Date;
+  offset?: string;
+}
+
+// IANA timezone names: letters/digits and `_ + - /` (e.g. "Europe/Stockholm", "UTC", "Etc/GMT+5").
+// The value is also quoted as a literal (injection-safe); this rejects obvious garbage with a clear error.
+const TZ_RE = /^[A-Za-z][A-Za-z0-9_+/-]*$/;
+
+/**
+ * Build the bucketing expression for the SELECT/GROUP BY. The plain `time_bucket($1, time)` unless:
+ *  - `gapfill` -> `time_bucket_gapfill($1, time)` (bounds inferred from the range WHERE), or
+ *  - `timezone`/`origin`/`offset` -> the 3-arg `time_bucket` forms. `timezone` is the positional
+ *    3rd arg (requires a timestamptz column); `origin` is a bare ISO literal that coerces to the
+ *    column's type; `offset` is an INTERVAL literal. TimescaleDB has no `timestamp + origin + offset`
+ *    overload, so origin+offset together require a timezone — and gapfill can't combine with these yet.
+ */
+function bucketExpression(time: string, args: TimeBucketRuntimeArgs): string {
+  const gapfill = args.gapfill === true;
+  const { timezone, origin, offset } = args;
+  const hasModifier = timezone !== undefined || origin !== undefined || offset !== undefined;
+
+  if (gapfill) {
+    if (hasModifier) {
+      throw new Error("timeBucket: gapfill cannot be combined with timezone / origin / offset yet.");
+    }
+    return `time_bucket_gapfill($1, ${time})`;
+  }
+  if (!hasModifier) return `time_bucket($1, ${time})`;
+
+  if (origin !== undefined && offset !== undefined && timezone === undefined) {
+    throw new Error("timeBucket: origin and offset together require a timezone (no matching TimescaleDB overload).");
+  }
+  const extra: string[] = [];
+  if (timezone !== undefined) {
+    if (!TZ_RE.test(timezone)) throw new Error(`timeBucket: invalid timezone ${JSON.stringify(timezone)}.`);
+    extra.push(quoteLiteral(timezone)); // positional 3rd arg — must precede the named args
+  }
+  if (origin !== undefined) {
+    if (!(origin instanceof Date)) throw new Error("timeBucket: `origin` must be a Date.");
+    extra.push(`origin => ${quoteLiteral(origin.toISOString())}`);
+  }
+  if (offset !== undefined) {
+    assertInterval(offset);
+    extra.push(`"offset" => INTERVAL ${quoteLiteral(offset)}`);
+  }
+  return `time_bucket($1, ${time}, ${extra.join(", ")})`;
 }
 
 /**
@@ -219,13 +275,10 @@ export function buildTimeBucketQuery(
   const params: unknown[] = [args.bucket, args.range.start, args.range.end];
   const time = quoteIdent(timeColumn);
 
-  // gapfill emits a row for every bucket across the range (empty ones get null aggregates unless
-  // `fill`ed). Its bounds are inferred from the `time >= $2 AND time < $3` predicate below — always
-  // present since `range` is required — so the 2-arg form needs no extra args.
+  // The bucketing expression: plain time_bucket, gapfill (bounds inferred from the range WHERE), or
+  // a 3-arg time_bucket with timezone / origin / offset (see bucketExpression).
   const gapfill = args.gapfill === true;
-  const bucketExpr = gapfill ? `time_bucket_gapfill($1, ${time})` : `time_bucket($1, ${time})`;
-
-  const select: string[] = [`${bucketExpr} AS "bucket"`];
+  const select: string[] = [`${bucketExpression(time, args)} AS "bucket"`];
 
   const groupCols = args.groupBy ?? [];
   for (const g of groupCols) {

--- a/test/integration/timezone.test.ts
+++ b/test/integration/timezone.test.ts
@@ -1,0 +1,104 @@
+// timezone / offset for timeBucket, end-to-end on real TimescaleDB. Two rows straddling UTC
+// midnight bucket into ONE local day under a +2h timezone but TWO buckets under default UTC —
+// the DST-aware calendar behaviour. Requires a timestamptz column (@db.Timestamptz).
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED timezone.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time     DateTime @db.Timestamptz(3)
+  deviceId Int
+  value    Float
+
+  @@id([deviceId, time])
+}`;
+
+const INIT_SQL = `CREATE TABLE "Reading" (
+  "time" TIMESTAMPTZ NOT NULL,
+  "deviceId" INTEGER NOT NULL,
+  "value" DOUBLE PRECISION NOT NULL,
+  CONSTRAINT "Reading_pkey" PRIMARY KEY ("deviceId","time")
+);`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-17T00:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket timezone / offset (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Two rows straddling UTC midnight: 23:30Z (Jun 15) and 00:30Z (Jun 16).
+    await prisma.reading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T23:30:00Z"), value: 1 },
+        { deviceId: 1, time: new Date("2026-06-16T00:30:00Z"), value: 2 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("buckets by the given timezone (DST-aware), unlike the default UTC", async () => {
+    // Europe/Stockholm is UTC+2 in June, so 23:30Z and 00:30Z are 01:30 & 02:30 local on Jun 16.
+    const local = await prisma.reading.timeBucket({
+      bucket: "1 day",
+      range,
+      timezone: "Europe/Stockholm",
+      aggregate: { n: { count: "deviceId" } },
+    });
+    expect(local).toHaveLength(1); // both rows land on the same local (Stockholm) day
+    expect(Number(local[0].n)).toBe(2);
+
+    const utc = await prisma.reading.timeBucket({
+      bucket: "1 day",
+      range,
+      aggregate: { n: { count: "deviceId" } },
+    });
+    expect(utc).toHaveLength(2); // the rows straddle UTC midnight
+  });
+
+  it("offset shifts bucket boundaries", async () => {
+    // 6h offset -> daily buckets start at 06:00. 23:30Z(15) and 00:30Z(16) both fall in
+    // [Jun 15 06:00, Jun 16 06:00) -> a single bucket.
+    const shifted = await prisma.reading.timeBucket({
+      bucket: "1 day",
+      range,
+      offset: "6 hours",
+      aggregate: { n: { count: "deviceId" } },
+    });
+    expect(shifted).toHaveLength(1);
+    expect(Number(shifted[0].n)).toBe(2);
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -126,7 +126,28 @@ type _fl = Expect<
 const flgf = timeBucket({ bucket: "1 hour", range: { start, end }, gapfill: true, aggregate: { lastLabel: { last: "label" } } });
 type _flgf = Expect<Equal<(typeof flgf)[number], { bucket: Date; lastLabel: string | null }>>;
 
+// --- timezone / origin / offset args (result row unchanged — bucket stays Date) ---
+timeBucket({ bucket: "1 hour", range: { start, end }, timezone: "Europe/Stockholm", aggregate: { n: { count: "label" } } });
+const tzr = timeBucket({
+  bucket: "1 day",
+  range: { start, end },
+  timezone: "UTC",
+  origin: new Date(),
+  offset: "30 minutes",
+  aggregate: { n: { count: "label" } },
+});
+type _tzr = Expect<Equal<(typeof tzr)[number], { bucket: Date; n: number }>>;
+
 // --- negatives: each must fail to compile ---
+
+// offset must be a valid interval literal
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "1 fortnight" is not a valid Interval
+  offset: "1 fortnight",
+  aggregate: { n: { count: "label" } },
+});
 
 // first on a column that doesn't exist
 timeBucket({

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -272,5 +272,12 @@ describe("buildTimeBucketQuery", () => {
     expect(() =>
       buildTimeBucketQuery("SensorReading", "time", { ...base, gapfill: true, timezone: "UTC" }),
     ).toThrow(/gapfill cannot be combined with timezone/);
+    // non-string / invalid values from non-TS callers fail with a clear error, not a raw Type/RangeError
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, timezone: true as never })).toThrow(
+      /invalid timezone/,
+    );
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, origin: new Date("nope") })).toThrow(
+      /must be a valid Date/,
+    );
   });
 });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -240,4 +240,37 @@ describe("buildTimeBucketQuery", () => {
       buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { avg: "temperature", by: "time" } } }),
     ).toThrow(/"by" is only valid on first \/ last/);
   });
+
+  it("timezone buckets in the given zone (validated + quoted, positional 3rd arg)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, timezone: "Europe/Stockholm" });
+    expect(sql).toContain(`time_bucket($1, "time", 'Europe/Stockholm') AS "bucket"`);
+  });
+
+  it("origin emits a bare ISO literal; offset emits an INTERVAL", () => {
+    const origin = new Date("2026-06-15T12:00:00.000Z");
+    const o = buildTimeBucketQuery("SensorReading", "time", { ...base, origin });
+    expect(o.sql).toContain(`time_bucket($1, "time", origin => '2026-06-15T12:00:00.000Z') AS "bucket"`);
+    const f = buildTimeBucketQuery("SensorReading", "time", { ...base, offset: "6 hours" });
+    expect(f.sql).toContain(`time_bucket($1, "time", "offset" => INTERVAL '6 hours') AS "bucket"`);
+  });
+
+  it("timezone + origin + offset compose (timezone positional, then named args)", () => {
+    const origin = new Date("2026-06-15T00:00:00.000Z");
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, timezone: "UTC", origin, offset: "1 hour" });
+    expect(sql).toContain(
+      `time_bucket($1, "time", 'UTC', origin => '2026-06-15T00:00:00.000Z', "offset" => INTERVAL '1 hour') AS "bucket"`,
+    );
+  });
+
+  it("rejects bad timezone, origin+offset without timezone, and gapfill combined with modifiers", () => {
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, timezone: "no spaces'" })).toThrow(
+      /invalid timezone/,
+    );
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, origin: new Date(), offset: "1 hour" }),
+    ).toThrow(/origin and offset together require a timezone/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, gapfill: true, timezone: "UTC" }),
+    ).toThrow(/gapfill cannot be combined with timezone/);
+  });
 });


### PR DESCRIPTION
## What

Task #4 of the gap-analysis backlog. Adds the 3-arg `time_bucket` forms to `timeBucket()`:

```ts
const rows = await prisma.sensorReading.timeBucket({
  bucket: "1 day",
  range: { start, end },
  timezone: "Europe/Stockholm", // DST-aware calendar buckets
  // origin: someDate,          // align boundaries to an instant
  // offset: "6 hours",         // shift boundaries by an interval
  aggregate: { avgTemp: { avg: "temperature" } },
});
```

- **`timezone`** (IANA string, shape-validated + quoted — injection-safe): day/week/month buckets align to that zone's calendar across DST. **Requires a `timestamptz` time column** (`@db.Timestamptz`) — there's no `timezone` overload for tz-naive `timestamp`.
- **`origin`** (`Date`): align boundaries to an instant — emitted as a **bare ISO literal** that coerces to the column's own type (so it works for both `timestamp` and `timestamptz`, unlike a hard-coded cast).
- **`offset`** (`Interval`): shift boundaries by an interval (universal).

Result row is unchanged (`bucket: Date`).

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

Enumerated the overloads and verified: the `timezone text` overload exists only for `timestamptz` ts (a no-tz + timezone call errors "not unique"); a **bare `origin` literal coerces per column type** on both `timestamp` and `timestamptz`; `offset` is universal; and there's **no `timestamp + origin + offset` overload** → so `origin`+`offset` together require a `timezone`. Both are guarded with clear errors, as is combining any of them with `gapfill` (a documented limitation for now).

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 170 unit tests; 93.66% stmts / 88% branch / 93.38% funcs / 94.63% lines
- full integration ✅ — 11 files / 29 tests. New `timezone.test.ts` (on a `@db.Timestamptz` column) asserts two rows straddling UTC midnight bucket into **one** local day under `Europe/Stockholm` but **two** under default UTC, and that `offset: "6 hours"` merges them into one shifted bucket.

_Note: the local 11-container integration run occasionally flakes on container startup (resource contention) and passes on re-run; CI runs on a clean runner and has been consistently green._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended `timeBucket` with `timezone`, `origin`, and `offset` to align bucket boundaries using IANA timezones and TimescaleDB modifiers.
  * Added support for correct behavior/constraints when combining these options with `gapfill` (where applicable).

* **Documentation**
  * Documented parameter usage, requirements (including `timestamptz`), and bucket-alignment rules with examples and limitations.

* **Tests**
  * Added integration coverage for DST-aware bucketing and offset shifting.
  * Expanded unit/type tests to verify generated queries and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->