### PR TITLE
feat: hash space partitioning (add_dimension + by_hash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ database) ships in this repo.
 
 | Annotation | On | Arguments |
 | --- | --- | --- |
-| `@timescale.hypertable` | model | `column` (required), `chunkInterval` (default `"7 days"`) |
+| `@timescale.hypertable` | model | `column` (required), `chunkInterval` (default `"7 days"`); `partitionColumn` + `partitions` (optional) — a hash space dimension |
 | `@timescale.retention` | model (also a hypertable) | `dropAfter` (required) — drop chunks older than this interval |
 | `@timescale.compression` | model (also a hypertable) | `after` (required) — compress chunks older than this; `segmentBy`, `orderBy` (optional) — columnstore tuning (Prisma field names) |
 | `@timescale.continuousAggregate` | view | `source`, `bucket`, `timeColumn` (required); `refresh: { startOffset, endOffset, scheduleInterval }` (optional) |
@@ -620,6 +620,23 @@ database) ships in this repo.
 `month(s)`, `year(s)`, `decade(s)`, or `centur(y|ies)` — validated at compile time *and* runtime
 (`"1 hour"`, `"7 days"`, `"2 years"`). (`quarter` is not an interval unit in PostgreSQL; combined
 forms like `"1 year 2 months"` aren't supported by this single-unit type.)
+
+**Space partitioning** — add `partitionColumn` + `partitions` to `@timescale.hypertable` for a hash
+space dimension (`add_dimension(..., by_hash(column, partitions))`) on top of the time dimension:
+
+```prisma
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day", partitionColumn: "deviceId", partitions: 4)
+model SensorReading {
+  time     DateTime
+  deviceId Int
+
+  @@id([deviceId, time]) // a partitioning column must be part of the table's PK / unique key
+}
+```
+
+`partitionColumn` takes a Prisma field name (mapped to its `@map` column); `partitions` is a positive
+integer. It's transparent to `timeBucket` queries and survives `prisma migrate reset` like everything
+else this package emits.
 
 ---
 

--- a/src/core/hypertable.ts
+++ b/src/core/hypertable.ts
@@ -18,7 +18,7 @@ const DEFAULT_CHUNK_INTERVAL = "7 days";
  * separate "un-hypertable" step (SPEC §2.2).
  */
 export function createHypertableSql(config: HypertableConfig): MigrationSql {
-  const { table, column, schema } = config;
+  const { table, column, schema, spacePartition } = config;
   const chunkInterval = config.chunkInterval ?? DEFAULT_CHUNK_INTERVAL;
 
   assertSafeIdent(table, "hypertable table");
@@ -26,12 +26,26 @@ export function createHypertableSql(config: HypertableConfig): MigrationSql {
   if (schema !== undefined) assertSafeIdent(schema, "hypertable schema");
   assertInterval(chunkInterval);
 
-  const up = `SELECT create_hypertable(
-  ${relationLiteral(table, schema)},
+  const rel = relationLiteral(table, schema);
+  let up = `SELECT create_hypertable(
+  ${rel},
   by_range(${quoteLiteral(column)}, INTERVAL ${quoteLiteral(chunkInterval)}),
   if_not_exists => TRUE,
   migrate_data  => TRUE
 );`;
+
+  // Optional hash space dimension: a second partitioning dimension on `column`, added AFTER the
+  // hypertable exists. The column name is a string literal (NAME) — preserves case, no cast — and
+  // `if_not_exists => TRUE` makes replay a no-op (constraint 3). Verified transaction-safe.
+  if (spacePartition) {
+    assertSafeIdent(spacePartition.column, "space partition column");
+    if (!Number.isInteger(spacePartition.partitions) || spacePartition.partitions < 1) {
+      throw new Error(
+        `createHypertableSql: spacePartition.partitions must be a positive integer (got ${JSON.stringify(spacePartition.partitions)}).`,
+      );
+    }
+    up += `\nSELECT add_dimension(${rel}, by_hash(${quoteLiteral(spacePartition.column)}, ${spacePartition.partitions}), if_not_exists => TRUE);`;
+  }
 
   const down = `-- No separate un-hypertable step: dropping "${table}" (Prisma's own down) removes the hypertable.`;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -78,6 +78,9 @@ export interface HypertableConfig {
   column: string;
   /** Chunk size; defaults to "7 days" when omitted. */
   chunkInterval?: Interval;
+  /** Optional hash space dimension (`add_dimension` + `by_hash`): partition by `column` (DB name)
+   * into `partitions` buckets, in addition to the time dimension. Omitted means time-only. */
+  spacePartition?: { column: string; partitions: number };
   /**
    * Map of Prisma field name -> DB column name, for runtime helpers that take Prisma field
    * names (timeBucket where/groupBy/aggregate) and must emit DB column names. Omitted when

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -274,6 +274,22 @@ function buildSpacePartition(
   if (!field) {
     throw new Error(`${ctx}: partitionColumn "${partitionColumn}" is not a scalar field on the model.`);
   }
+  // TimescaleDB requires every PK / unique index to include all partitioning columns, so a
+  // partitionColumn outside them fails at `migrate` ("cannot create a unique index without the
+  // column …"). Reject it at generation time with a clear error instead. Field names below are
+  // Prisma names, matching `partitionColumn`.
+  const keyFieldSets: (readonly string[])[] = [
+    ...(model.primaryKey?.fields ? [model.primaryKey.fields] : []),
+    ...model.fields.filter((f) => f.isId).map((f) => [f.name]), // single-field @id
+    ...model.uniqueIndexes.map((u) => u.fields),
+    ...model.fields.filter((f) => f.isUnique).map((f) => [f.name]), // single-field @unique
+  ];
+  const missingFrom = keyFieldSets.find((fields) => !fields.includes(partitionColumn));
+  if (missingFrom) {
+    throw new Error(
+      `${ctx}: partitionColumn "${partitionColumn}" must be included in every primary key / unique constraint (TimescaleDB requires all partitioning columns in unique indexes); it is missing from [${missingFrom.join(", ")}].`,
+    );
+  }
   const partitions = Number(partitionsRaw);
   if (!Number.isInteger(partitions) || partitions < 1) {
     throw new Error(`${ctx}: partitions must be a positive integer (got ${JSON.stringify(partitionsRaw)}).`);

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -119,6 +119,7 @@ function buildHypertable(
   const table = dbTable(model);
   const retention = buildRetention(annotations, model.name);
   const compression = buildCompression(annotations, model);
+  const spacePartition = buildSpacePartition(ann, model, ctx);
   const relations = buildRelations(model, byName);
 
   return {
@@ -130,6 +131,7 @@ function buildHypertable(
     ...(Object.keys(columns).length > 0 ? { columns } : {}),
     ...(retention ? { retention } : {}),
     ...(compression ? { compression } : {}),
+    ...(spacePartition ? { spacePartition } : {}),
     ...(relations.length > 0 ? { relations } : {}),
   };
 }
@@ -250,6 +252,33 @@ function buildCompression(
 /** Split a comma-separated annotation list (segmentBy / orderBy) into trimmed, non-empty entries. */
 function splitList(value: string): string[] {
   return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Parse the optional hash space dimension off the hypertable annotation: `partitionColumn` (a scalar
+ * field, resolved to its @map DB column) + `partitions` (a positive integer). Both are required
+ * together; omitted means a time-only hypertable.
+ */
+function buildSpacePartition(
+  ann: ReturnType<typeof parseAnnotations>[number],
+  model: DMMF.Model,
+  ctx: string,
+): { column: string; partitions: number } | undefined {
+  const partitionColumn = optionalString(ann.args, "partitionColumn", ctx);
+  const partitionsRaw = optionalString(ann.args, "partitions", ctx);
+  if (partitionColumn === undefined && partitionsRaw === undefined) return undefined;
+  if (partitionColumn === undefined || partitionsRaw === undefined) {
+    throw new Error(`${ctx}: partitionColumn and partitions must be set together (hash space dimension).`);
+  }
+  const field = findScalarField(model, partitionColumn);
+  if (!field) {
+    throw new Error(`${ctx}: partitionColumn "${partitionColumn}" is not a scalar field on the model.`);
+  }
+  const partitions = Number(partitionsRaw);
+  if (!Number.isInteger(partitions) || partitions < 1) {
+    throw new Error(`${ctx}: partitions must be a positive integer (got ${JSON.stringify(partitionsRaw)}).`);
+  }
+  return { column: dbCol(field), partitions };
 }
 
 /** Build a CaggConfig from a `@timescale.continuousAggregate` view + its field annotations

--- a/test/integration/space-partition.test.ts
+++ b/test/integration/space-partition.test.ts
@@ -1,0 +1,62 @@
+// Hash space partitioning end-to-end on real TimescaleDB: the generator emits a reset-safe
+// add_dimension(by_hash(...)) from partitionColumn / partitions, giving the hypertable a second
+// (space) dimension. Verified against timescaledb_information.dimensions, including migrate reset.
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED space-partition.test.ts: Docker is not available. Not verified.\n");
+}
+
+// deviceId is in the @@id, so it's eligible as a partitioning column. Matches the harness default
+// CREATE TABLE (time / deviceId / temperature).
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day", partitionColumn: "deviceId", partitions: 4)
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+async function spacePartitions(h: Harness): Promise<number> {
+  const [row] = await h.query<{ n: number | null }>(
+    "SELECT num_partitions::int AS n FROM timescaledb_information.dimensions WHERE hypertable_name = 'SensorReading' AND column_name = 'deviceId'",
+  );
+  return row?.n ?? 0;
+}
+
+describe.skipIf(!DOCKER_OK)("space partitioning (generated, reset-safe)", () => {
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+  });
+
+  afterAll(async () => {
+    await h?.stop();
+  });
+
+  it("emits a reset-safe hash space dimension from partitionColumn / partitions", async () => {
+    h.prisma(["migrate", "deploy"]);
+    expect(await spacePartitions(h)).toBe(4);
+
+    // Reproduced across `migrate reset` (idempotent replay, zero manual steps) — run twice.
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await spacePartitions(h)).toBe(4);
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await spacePartitions(h)).toBe(4);
+  });
+});

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -56,6 +56,42 @@ describe("createHypertableSql", () => {
     const { up } = createHypertableSql({ table: "sensor_readings", column: "ts", chunkInterval: "1 day", schema: "metrics" });
     expect(up).toContain(`'"metrics"."sensor_readings"'`);
   });
+
+  it("appends a reset-safe add_dimension(by_hash) for a hash space partition", () => {
+    const { up } = createHypertableSql({
+      table: "SensorReading",
+      column: "time",
+      chunkInterval: "1 day",
+      spacePartition: { column: "deviceId", partitions: 4 },
+    });
+    expect(up).toContain("SELECT create_hypertable(");
+    expect(up).toContain(`SELECT add_dimension('"SensorReading"', by_hash('deviceId', 4), if_not_exists => TRUE);`);
+    // create_hypertable must come before add_dimension (the table must be a hypertable first).
+    expect(up.indexOf("create_hypertable")).toBeLessThan(up.indexOf("add_dimension"));
+    expect(up).not.toContain("::regclass");
+  });
+
+  it("space partition schema-qualifies the relation and maps the column (@@schema / @map)", () => {
+    const { up } = createHypertableSql({
+      table: "sensor_readings",
+      column: "ts",
+      schema: "metrics",
+      spacePartition: { column: "device_id", partitions: 8 },
+    });
+    expect(up).toContain(`SELECT add_dimension('"metrics"."sensor_readings"', by_hash('device_id', 8), if_not_exists => TRUE);`);
+  });
+
+  it("space partition rejects a non-positive / non-integer count and a bad column", () => {
+    expect(() => createHypertableSql({ table: "X", column: "t", spacePartition: { column: "d", partitions: 0 } })).toThrow(
+      /positive integer/,
+    );
+    expect(() => createHypertableSql({ table: "X", column: "t", spacePartition: { column: "d", partitions: 2.5 } })).toThrow(
+      /positive integer/,
+    );
+    expect(() => createHypertableSql({ table: "X", column: "t", spacePartition: { column: "a-b", partitions: 4 } })).toThrow(
+      /Invalid/,
+    );
+  });
 });
 
 describe("createContinuousAggregateSql", () => {

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -521,6 +521,59 @@ model SensorReading {
   });
 });
 
+describe("extractTimescaleSchema — space partitioning", () => {
+  it("parses partitionColumn + partitions into a spacePartition config (mapped @map column)", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day", partitionColumn: "deviceId", partitions: 4)
+model SensorReading {
+  time     DateTime
+  deviceId Int      @map("device_id")
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables[0]).toMatchObject({ spacePartition: { column: "device_id", partitions: 4 } });
+  });
+
+  it("requires partitionColumn and partitions together", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", partitionColumn: "deviceId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/must be set together/);
+  });
+
+  it("rejects an unknown partitionColumn", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", partitionColumn: "nope", partitions: 4)
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/partitionColumn "nope" is not a scalar field/);
+  });
+
+  it("rejects a non-positive partition count", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", partitionColumn: "deviceId", partitions: 0)
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/partitions must be a positive integer/);
+  });
+});
+
 describe("extractTimescaleSchema — relations", () => {
   it("extracts to-one (owning, with fk) and to-many (inverse) relations", async () => {
     const result = await extract(`

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -572,6 +572,19 @@ model SensorReading {
 `),
     ).rejects.toThrow(/partitions must be a positive integer/);
   });
+
+  it("rejects a partitionColumn missing from the primary key (TimescaleDB partitioning requirement)", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", partitionColumn: "deviceId", partitions: 4)
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([time])
+}
+`),
+    ).rejects.toThrow(/must be included in every primary key \/ unique constraint/);
+  });
 });
 
 describe("extractTimescaleSchema — relations", () => {


### PR DESCRIPTION
## What

Task #5 of the gap-analysis backlog — the first **generator/migration** feature in the batch. Adds an optional hash **space dimension** to `@timescale.hypertable`:

```prisma
/// @timescale.hypertable(column: "time", chunkInterval: "1 day", partitionColumn: "deviceId", partitions: 4)
model SensorReading {
  time     DateTime
  deviceId Int
  @@id([deviceId, time]) // a partitioning column must be in the PK / unique key
}
```

- New annotation args `partitionColumn` (Prisma field → `@map` DB col) + `partitions` (positive int), required together.
- `createHypertableSql` appends `SELECT add_dimension(rel, by_hash('<col>', <n>), if_not_exists => TRUE);` **after** `create_hypertable`, so it's part of the hypertable's `up` (emit-migrations needs no change). The column is a **string-literal NAME** (case-preserved, no `::regclass`/cast).
- **No runtime change** — the space dimension is transparent to `timeBucket` queries (migration-only, like the retention/compression configs).

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

`add_dimension(rel, by_hash('deviceId', 4), if_not_exists => TRUE)` is a function (SELECT), **idempotent** (NOTICE "already a dimension, skipping" on replay → returns `f`), **transaction-safe** (works inside `BEGIN…COMMIT` → Prisma's migration), and a string-literal `'deviceId'` correctly matches the mixed-case column. `timescaledb_information.dimensions` confirms the 4-partition hash dimension.

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 177 unit tests; 94.05% stmts / 88.77% branch / 93.44% funcs / 94.92% lines
- full integration ✅ — **12 files / 30 tests**. New `space-partition.test.ts` asserts the hash dimension (`deviceId` → 4 partitions) is emitted and **reproduced across `migrate reset` (twice)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional hash-space partitioning for hypertables, configured via a partition column and bucket count.
  * Dimension creation is reset-safe and idempotent.

* **Documentation**
  * Updated the `@timescale.hypertable` annotation reference with `partitionColumn` and `partitions`, plus a new “Space partitioning” section and Prisma example.
  * Clarified primary/unique key requirements and that time-based queries remain transparent.

* **Tests**
  * Added integration and unit tests covering generation, validation, ordering, schema-qualified mapping, and reset-safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->