### PR TITLE
feat: continuous-aggregate refresh-policy management ($timescale)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,15 @@ const hourly = await prisma.sensorHourly.findMany({
 ```ts
 await prisma.$timescale.refreshContinuousAggregate("SensorHourly");              // full refresh
 await prisma.$timescale.refreshContinuousAggregate("SensorHourly", { start, end }); // window
+
+// Manage the cagg's refresh policy at runtime — the complement of the `refresh: { … }` annotation
+// (and the way to set one on the manual-config path):
+await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", {
+  startOffset: "1 month",
+  endOffset: "1 hour",
+  scheduleInterval: "1 hour",
+});
+await prisma.$timescale.removeContinuousAggregatePolicy("SensorHourly");
 ```
 
 > **Typo-safe.** The model/view names passed to every `$timescale` method (and

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -2,7 +2,7 @@
 import { assertSafeIdent, qualifiedIdent, quoteLiteral, relationLiteral } from "../core/sql.js";
 import { assertInterval, type Interval } from "../core/interval.js";
 import { columnstoreReloptions, parseOrderByTerm } from "../core/compression.js";
-import type { CompressionOrderBy } from "../core/types.js";
+import type { CompressionOrderBy, RefreshPolicy } from "../core/types.js";
 
 /** Resolved DB identity of a continuous aggregate (name + optional @@schema). */
 export interface CaggRef {
@@ -119,6 +119,16 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
   refreshContinuousAggregate(name: CModels, range?: RefreshRange): Promise<void>;
 
   /**
+   * Add (or no-op re-add) a refresh policy to a continuous aggregate — `add_continuous_aggregate_policy`.
+   * The complement of the `refresh: { ... }` annotation, and the way to set one on the manual-config path.
+   * Idempotent (`if_not_exists`); NB TimescaleDB won't update an existing policy's offsets — remove it first.
+   */
+  addContinuousAggregatePolicy(name: CModels, options: RefreshPolicy): Promise<void>;
+
+  /** Remove the refresh policy from a continuous aggregate (no-op if there is none). */
+  removeContinuousAggregatePolicy(name: CModels): Promise<void>;
+
+  /**
    * Add a data-retention policy to a hypertable — drops chunks whose data is older than
    * `dropAfter`. Accepts the Prisma model name (resolved to the DB relation via @@map/@@schema).
    * Idempotent: re-adding an identical policy is a no-op. NB: TimescaleDB will NOT update an
@@ -222,11 +232,17 @@ export function makeManage<HModels extends string = string, CModels extends stri
     return ref;
   };
 
+  /** Resolve a Prisma view model name to its continuous-aggregate DB ref (identity when unregistered). */
+  const resolveCagg = (name: string): CaggRef => {
+    const ref = viewByModel.get(name) ?? { name };
+    assertSafeIdent(ref.name, "continuous aggregate name");
+    if (ref.schema !== undefined) assertSafeIdent(ref.schema, "continuous aggregate schema");
+    return ref;
+  };
+
   return {
     async refreshContinuousAggregate(name, range) {
-      const ref = viewByModel.get(name) ?? { name };
-      assertSafeIdent(ref.name, "continuous aggregate name");
-      if (ref.schema !== undefined) assertSafeIdent(ref.schema, "continuous aggregate schema");
+      const ref = resolveCagg(name);
       // Open bounds (full refresh) must be a literal NULL, not a bound param: Postgres
       // can't infer the type of a NULL parameter for the function's "any" window args.
       const params: unknown[] = [];
@@ -248,6 +264,26 @@ export function makeManage<HModels extends string = string, CModels extends stri
           await sleep(Math.min(50 * 2 ** (attempt - 1), 1000));
         }
       }
+    },
+
+    async addContinuousAggregatePolicy(name, opts) {
+      const ref = resolveCagg(name);
+      assertInterval(opts.startOffset);
+      assertInterval(opts.endOffset);
+      assertInterval(opts.scheduleInterval);
+      const rel = relationLiteral(ref.name, ref.schema);
+      // Offsets are strict-grammar Intervals quoted as literals; if_not_exists keeps a re-add a no-op.
+      await client.$executeRawUnsafe(
+        `SELECT add_continuous_aggregate_policy(${rel}, start_offset => INTERVAL ${quoteLiteral(opts.startOffset)}, end_offset => INTERVAL ${quoteLiteral(opts.endOffset)}, schedule_interval => INTERVAL ${quoteLiteral(opts.scheduleInterval)}, if_not_exists => TRUE)`,
+      );
+    },
+
+    async removeContinuousAggregatePolicy(name) {
+      const ref = resolveCagg(name);
+      // remove_continuous_aggregate_policy's idempotent flag is (confusingly) named if_not_exists.
+      await client.$executeRawUnsafe(
+        `SELECT remove_continuous_aggregate_policy(${relationLiteral(ref.name, ref.schema)}, if_not_exists => TRUE)`,
+      );
     },
 
     async addRetentionPolicy(model, opts) {

--- a/test/integration/cagg-policy.test.ts
+++ b/test/integration/cagg-policy.test.ts
@@ -1,0 +1,70 @@
+// Continuous-aggregate refresh-policy management at runtime, on real TimescaleDB:
+// $timescale.removeContinuousAggregatePolicy / addContinuousAggregatePolicy. The default harness
+// schema already has a refresh policy from the annotation; verified against timescaledb_information.jobs.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED cagg-policy.test.ts: Docker is not available. Not verified.\n");
+}
+
+async function refreshJobs(h: Harness): Promise<number> {
+  const [row] = await h.query<{ n: number }>(
+    "SELECT count(*)::int AS n FROM timescaledb_information.jobs WHERE proc_name = 'policy_refresh_continuous_aggregate'",
+  );
+  return row?.n ?? 0;
+}
+
+const policy = { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" } as const;
+
+describe.skipIf(!DOCKER_OK)("continuous-aggregate refresh policy (runtime)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness(); // default models: SensorReading hypertable + SensorHourly cagg (with refresh policy)
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("add / remove the cagg refresh policy at runtime", async () => {
+    // The generator already added a refresh policy from the annotation.
+    expect(await refreshJobs(h)).toBe(1);
+
+    await prisma.$timescale.removeContinuousAggregatePolicy("SensorHourly");
+    expect(await refreshJobs(h)).toBe(0);
+
+    await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", policy);
+    expect(await refreshJobs(h)).toBe(1);
+
+    // Idempotent: re-adding the identical policy is a no-op, not an error.
+    await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", policy);
+    expect(await refreshJobs(h)).toBe(1);
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -59,6 +59,15 @@ m.dropChunks("SensorReading", { olderThan: new Date() });
 loose.dropChunks("anything", { olderThan: "1 day" }); // ok — string fallback
 loose.hypertableSize("anything"); // ok
 
+// continuous-aggregate policy helpers: cagg-name checked
+m.addContinuousAggregatePolicy("SensorHourly", { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" }); // ok
+m.removeContinuousAggregatePolicy("SensorHourly"); // ok
+// @ts-expect-error - "SensorHrly" is not a registered continuous aggregate
+m.addContinuousAggregatePolicy("SensorHrly", { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" });
+// @ts-expect-error - typo on the cagg name
+m.removeContinuousAggregatePolicy("SensorHrly");
+loose.removeContinuousAggregatePolicy("anything"); // ok — string fallback
+
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {
   hypertables: [{ model: "SensorReading", table: "sensor_readings" }],

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -66,6 +66,7 @@ m.removeContinuousAggregatePolicy("SensorHourly"); // ok
 m.addContinuousAggregatePolicy("SensorHrly", { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" });
 // @ts-expect-error - typo on the cagg name
 m.removeContinuousAggregatePolicy("SensorHrly");
+loose.addContinuousAggregatePolicy("anything", { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" }); // ok — string fallback
 loose.removeContinuousAggregatePolicy("anything"); // ok — string fallback
 
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -303,3 +303,39 @@ describe("makeManage chunk + size helpers", () => {
     await expect(makeManage(fakeClient().client).hypertableSize("bad name")).rejects.toThrow(/Invalid/);
   });
 });
+
+describe("makeManage continuous-aggregate policies", () => {
+  const policy = { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" } as const;
+
+  it("addContinuousAggregatePolicy emits add_continuous_aggregate_policy with interval offsets", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).addContinuousAggregatePolicy("SensorHourly", policy);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toBe(
+      `SELECT add_continuous_aggregate_policy('"SensorHourly"', start_offset => INTERVAL '1 month', end_offset => INTERVAL '1 hour', schedule_interval => INTERVAL '1 hour', if_not_exists => TRUE)`,
+    );
+  });
+
+  it("resolves the cagg model to its @@map / @@schema view name", async () => {
+    const { client, calls } = fakeClient();
+    const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly", schema: "metrics" }]]);
+    await makeManage(client, viewByModel).addContinuousAggregatePolicy("SensorHourly", policy);
+    expect(calls[0]!.sql).toContain(`add_continuous_aggregate_policy('"metrics"."sensor_hourly"'`);
+  });
+
+  it("removeContinuousAggregatePolicy emits an idempotent remove", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).removeContinuousAggregatePolicy("SensorHourly");
+    expect(calls[0]!.sql).toBe(`SELECT remove_continuous_aggregate_policy('"SensorHourly"', if_not_exists => TRUE)`);
+  });
+
+  it("rejects an invalid offset interval and an unsafe cagg name", async () => {
+    await expect(
+      makeManage(fakeClient().client).addContinuousAggregatePolicy("SensorHourly", {
+        ...policy,
+        startOffset: "1 fortnight" as never,
+      }),
+    ).rejects.toThrow(/Invalid interval/);
+    await expect(makeManage(fakeClient().client).removeContinuousAggregatePolicy("bad name")).rejects.toThrow(/Invalid/);
+  });
+});


### PR DESCRIPTION
## What

Task #6 of the gap-analysis backlog. Adds runtime management of a continuous aggregate's refresh policy:

```ts
await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", {
  startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour",
});
await prisma.$timescale.removeContinuousAggregatePolicy("SensorHourly");
```

- The runtime complement of the cagg `refresh: { … }` annotation — and the way to set/remove a refresh policy on the **manual-config** path. Closes the "we add a cagg refresh policy via the annotation but can't remove (or runtime-add) one" gap.
- Cagg names are **typo-checked** (`CModels`) and resolved via the registry (`@@map`/`@@schema`), mirroring retention/compression's runtime add/remove. Idempotent (`if_not_exists`). Refactored cagg-name resolution into a shared `resolveCagg` helper (DRY with `refreshContinuousAggregate`).

## Deep research (empirical, vs `timescale/timescaledb:2.27.2`)

Verified `add_continuous_aggregate_policy` (function, returns job id) and `remove_continuous_aggregate_policy(cagg, if_not_exists => TRUE)` (function, **idempotent** — NOTICE "policy not found, skipping") with a string-literal regclass. **Skipped `add_policies`/`remove_policies`** — cagg-focused convenience wrappers (variadic, subtle semantics) that are redundant with the individual retention/compression/refresh methods already exposed.

## Verification (all green locally)
- build · typecheck · test:types · attw ✅
- coverage ✅ — 182 unit tests; 93.96% stmts / 88.69% branch / 92.36% funcs / 94.91% lines
- full integration ✅ — 13 files / 31 tests. New `cagg-policy.test.ts`: the generator-added policy = 1 job → `remove` → 0 → `add` → 1 → idempotent re-add → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added continuous-aggregate refresh policy management via `addContinuousAggregatePolicy()` and `removeContinuousAggregatePolicy()`, supporting start/end offsets and schedule intervals with idempotent behavior.
* **Documentation**
  * Updated the README with runtime examples for adding and removing continuous-aggregate refresh policies.
* **Tests**
  * Added integration and unit coverage for policy add/remove, idempotency, SQL generation, and validation behavior, plus TypeScript type-safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->