### PR TITLE
feat: chunk skipping (enable/disable_chunk_skipping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,9 +580,9 @@ await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
 > - **Range stats only exist on compressed chunks.** Pair it with
 >   [`@timescale.compression`](#data-compression-timescalecompression); uncompressed chunks are always
 >   scanned.
-> - **Not the `segmentBy` or time column.** `segmentBy` already gives per-segment min/max, and
->   enabling skipping there returns **wrong (empty) results** — the generator rejects it, as it does
->   the time/partitioning column.
+> - **Not a partitioning or `segmentBy` column.** `segmentBy` already gives per-segment min/max, and
+>   enabling skipping there returns **wrong (empty) results** — the generator rejects it, along with
+>   the time column and the hash space-partition column (both already prune chunks).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 - [Runtime usage](#runtime-usage)
 - [Data retention (`@timescale.retention`)](#data-retention-timescaleretention)
 - [Data compression (`@timescale.compression`)](#data-compression-timescalecompression)
+- [Chunk skipping (`@timescale.hypertable(chunkSkipping)`)](#chunk-skipping-timescalehypertablechunkskipping)
 - [Without the generator](#without-the-generator-manual-config)
 - [Renamed tables/columns (`@@map` / `@map`)](#renamed-tablescolumns-map--map)
 - [Shadow database](#shadow-database)
@@ -526,6 +527,65 @@ await prisma.$timescale.removeCompressionPolicy("SensorReading");
 
 ---
 
+## Chunk skipping (`@timescale.hypertable(chunkSkipping)`)
+
+For a **compressed** hypertable, chunk skipping records per-chunk **min/max range stats** for a
+secondary (non-time) column, so the planner can exclude whole chunks that can't match a filter on
+that column — a big win for queries like `WHERE deviceId = …` or `WHERE eventId BETWEEN …` on data
+that correlates with time. Add `chunkSkipping` (one Prisma field name, or several comma-separated)
+to the hypertable annotation:
+
+```prisma
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day", chunkSkipping: "eventId")
+/// @timescale.compression(after: "7 days", segmentBy: "deviceId")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  eventId     BigInt
+  temperature Float
+
+  @@id([deviceId, time])
+}
+```
+
+The generator emits a **reset-safe** block into the managed migration. The
+`timescaledb.enable_chunk_skipping` GUC must be on for the function to be callable, so it's set
+(`SET LOCAL`) inside one self-contained `DO` block:
+
+```sql
+DO $$ BEGIN
+  SET LOCAL timescaledb.enable_chunk_skipping = on;
+  PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE);
+END $$;
+```
+
+You can also toggle it at runtime — the path to use with the
+[manual config](#without-the-generator-manual-config) (the column is a Prisma field name, mapped to
+its `@map` column):
+
+```ts
+await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
+await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
+```
+
+> [!IMPORTANT]
+> Three things to know — chunk skipping is otherwise a silent no-op:
+> - **Turn the GUC on at query time too.** The planner only skips chunks when
+>   `timescaledb.enable_chunk_skipping` is on for the *querying* session — enabling the column (above)
+>   isn't enough. Set it as a persistent default on the database (run once, e.g. in a manual
+>   migration): `ALTER DATABASE your_db SET timescaledb.enable_chunk_skipping = on;`, or per
+>   connection via the libpq option `…?options=-c%20timescaledb.enable_chunk_skipping%3Don`. This
+>   package doesn't emit the `ALTER DATABASE` automatically — it's a database-wide setting and may
+>   need elevated privileges (e.g. on managed/Tiger Cloud).
+> - **Range stats only exist on compressed chunks.** Pair it with
+>   [`@timescale.compression`](#data-compression-timescalecompression); uncompressed chunks are always
+>   scanned.
+> - **Not the `segmentBy` or time column.** `segmentBy` already gives per-segment min/max, and
+>   enabling skipping there returns **wrong (empty) results** — the generator rejects it, as it does
+>   the time/partitioning column.
+
+---
+
 ## Without the generator (manual config)
 
 The client extension works **without** the generator — pass the config directly:
@@ -540,7 +600,7 @@ const prisma = new PrismaClient({ adapter }).$extends(
 
 The SQL builders are also exported from `prisma-extension-timescaledb/core` for hand-written
 migrations: `createExtensionSql`, `createHypertableSql`, `createContinuousAggregateSql`,
-`createRetentionPolicySql`, `createCompressionPolicySql`.
+`createRetentionPolicySql`, `createCompressionPolicySql`, `createChunkSkippingSql`.
 
 ---
 
@@ -616,7 +676,7 @@ database) ships in this repo.
 
 | Annotation | On | Arguments |
 | --- | --- | --- |
-| `@timescale.hypertable` | model | `column` (required), `chunkInterval` (default `"7 days"`); `partitionColumn` + `partitions` (optional) — a hash space dimension |
+| `@timescale.hypertable` | model | `column` (required), `chunkInterval` (default `"7 days"`); `partitionColumn` + `partitions` (optional) — a hash space dimension; `chunkSkipping` (optional) — secondary column(s) to [enable chunk skipping](#chunk-skipping-timescalehypertablechunkskipping) on |
 | `@timescale.retention` | model (also a hypertable) | `dropAfter` (required) — drop chunks older than this interval |
 | `@timescale.compression` | model (also a hypertable) | `after` (required) — compress chunks older than this; `segmentBy`, `orderBy` (optional) — columnstore tuning (Prisma field names) |
 | `@timescale.continuousAggregate` | view | `source`, `bucket`, `timeColumn` (required); `refresh: { startOffset, endOffset, scheduleInterval }` (optional) |
@@ -646,6 +706,12 @@ model SensorReading {
 `partitionColumn` takes a Prisma field name (mapped to its `@map` column); `partitions` is a positive
 integer. It's transparent to `timeBucket` queries and survives `prisma migrate reset` like everything
 else this package emits.
+
+**Chunk skipping** — add `chunkSkipping` (a Prisma field name, or several comma-separated) to
+`@timescale.hypertable` to record per-chunk min/max range stats on a secondary column so the planner
+can exclude non-matching **compressed** chunks. Remember to turn `timescaledb.enable_chunk_skipping`
+on at query time — see [Chunk skipping](#chunk-skipping-timescalehypertablechunkskipping) for the
+full story and caveats.
 
 ---
 

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -172,6 +172,20 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
 
   /** Columnstore-compression effectiveness: chunk counts and before/after sizes (`hypertable_columnstore_stats`). */
   compressionStats(model: HModels): Promise<CompressionStats>;
+
+  /**
+   * Enable chunk skipping on a secondary `column` of a hypertable — `enable_chunk_skipping`. The
+   * planner can then exclude whole chunks that cannot match a filter on that column, but ONLY for
+   * compressed chunks and ONLY when `timescaledb.enable_chunk_skipping` is on at query time (set it
+   * on the connection or database — see the README; this call just registers the column). Accepts
+   * the Prisma model name (resolved via @@map/@@schema) and a Prisma field name (mapped to its DB
+   * column). Idempotent (`if_not_exists`). Do NOT pass the `segmentBy` column — skipping there
+   * returns wrong (empty) results.
+   */
+  enableChunkSkipping(model: HModels, column: string): Promise<void>;
+
+  /** Disable chunk skipping on a `column` of a hypertable — `disable_chunk_skipping`. Idempotent (no-op if not enabled). */
+  disableChunkSkipping(model: HModels, column: string): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -238,6 +252,25 @@ export function makeManage<HModels extends string = string, CModels extends stri
     assertSafeIdent(ref.name, "continuous aggregate name");
     if (ref.schema !== undefined) assertSafeIdent(ref.schema, "continuous aggregate schema");
     return ref;
+  };
+
+  /**
+   * Build the single-statement `DO` block for enable/disable chunk skipping. The GUC
+   * `timescaledb.enable_chunk_skipping` must be on for the function to be callable, so `SET LOCAL`
+   * + the `PERFORM` live in ONE block run by ONE `$executeRawUnsafe` — i.e. one pooled connection —
+   * so the GUC reliably applies to the call. The column is a Prisma field name mapped to its DB
+   * column (@map); `if_not_exists => TRUE` makes both directions idempotent.
+   */
+  const chunkSkippingSql = (
+    model: string,
+    column: string,
+    fn: "enable_chunk_skipping" | "disable_chunk_skipping",
+  ): string => {
+    const ref = resolveHypertable(model);
+    const dbColumn = (ref.columns ?? {})[column] ?? column;
+    assertSafeIdent(dbColumn, "chunk-skipping column");
+    const rel = relationLiteral(ref.table, ref.schema);
+    return `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM ${fn}(${rel}, ${quoteLiteral(dbColumn)}, if_not_exists => TRUE); END $$`;
   };
 
   return {
@@ -399,6 +432,14 @@ export function makeManage<HModels extends string = string, CModels extends stri
         beforeTotalBytes: r?.before_compression_total_bytes ?? null,
         afterTotalBytes: r?.after_compression_total_bytes ?? null,
       };
+    },
+
+    async enableChunkSkipping(model, column) {
+      await client.$executeRawUnsafe(chunkSkippingSql(model, column, "enable_chunk_skipping"));
+    },
+
+    async disableChunkSkipping(model, column) {
+      await client.$executeRawUnsafe(chunkSkippingSql(model, column, "disable_chunk_skipping"));
     },
   };
 }

--- a/src/core/chunkSkipping.ts
+++ b/src/core/chunkSkipping.ts
@@ -1,0 +1,64 @@
+// Chunk-skipping SQL builder (TimescaleDB `enable_chunk_skipping`; CLAUDE.md constraints 2, 3).
+//
+// Chunk skipping records per-chunk min/max range stats for a secondary (non-partitioning) column
+// when chunks are compressed, letting the planner exclude whole chunks that can't match a filter
+// on that column. Two facts, both verified empirically against timescale/timescaledb:2.27.2,
+// shape this builder:
+//   1. `enable_chunk_skipping(rel, col)` is only callable when the session GUC
+//      `timescaledb.enable_chunk_skipping` is `on` (it is `PGC_USERSET`, so settable per-session).
+//   2. The same GUC must also be `on` at QUERY time for the planner to actually skip, and skipping
+//      only helps COMPRESSED chunks — both are the user's runtime concern, documented in the README;
+//      this migration only registers the column.
+// Wrapping `SET LOCAL <guc> = on` + the `enable_chunk_skipping` calls in ONE `DO` block keeps it
+// self-contained: the block runs atomically (its own implicit transaction when none is active), so
+// the GUC is reliably on for the calls whether or not Prisma wraps the migration in a transaction.
+import type { MigrationSql } from "./types.js";
+import { assertSafeIdent, quoteLiteral, relationLiteral } from "./sql.js";
+
+/** Chunk-skipping builder input. All names are DB names (post-@@map / @@schema). */
+export interface ChunkSkippingConfig {
+  /** Hypertable relation name as it exists in the DB, unquoted. */
+  table: string;
+  /** Database schema (@@schema) when using multiSchema; omitted for the default schema. */
+  schema?: string;
+  /** Secondary columns (DB names) to enable chunk skipping on. Must be non-empty. */
+  columns: readonly string[];
+}
+
+/**
+ * Build the reset-safe chunk-skipping SQL: a single `DO` block that turns the
+ * `timescaledb.enable_chunk_skipping` GUC on (`SET LOCAL`, scoped to the block) and then calls
+ * `enable_chunk_skipping(rel, col, if_not_exists => TRUE)` for every column.
+ *
+ * - The relation is a quoted string *literal* `'"Table"'` — NO `::regclass` / `::name` cast
+ *   (constraint 2), same lesson as `create_hypertable`.
+ * - `if_not_exists => TRUE` makes replay safe (constraint 3): on `migrate reset` re-enabling an
+ *   already-registered column is a NOTICE, not an error.
+ *
+ * Down: dropping the table (Prisma's own down) removes its chunk-skipping settings, so there is no
+ * separate `disable_chunk_skipping` step (mirrors `create_hypertable`).
+ */
+export function createChunkSkippingSql(config: ChunkSkippingConfig): MigrationSql {
+  const { table, schema, columns } = config;
+
+  assertSafeIdent(table, "chunk-skipping table");
+  if (schema !== undefined) assertSafeIdent(schema, "chunk-skipping schema");
+  if (columns.length === 0) {
+    throw new Error("createChunkSkippingSql: at least one column is required.");
+  }
+  for (const col of columns) assertSafeIdent(col, "chunk-skipping column");
+
+  const rel = relationLiteral(table, schema);
+  const performs = columns
+    .map((col) => `  PERFORM enable_chunk_skipping(${rel}, ${quoteLiteral(col)}, if_not_exists => TRUE);`)
+    .join("\n");
+
+  const up = `DO $$ BEGIN
+  SET LOCAL timescaledb.enable_chunk_skipping = on;
+${performs}
+END $$;`;
+
+  const down = `-- No separate disable step: dropping "${table}" (Prisma's own down) removes its chunk-skipping settings.`;
+
+  return { up, down };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,4 +18,5 @@ export { createHypertableSql } from "./hypertable.js";
 export { createContinuousAggregateSql } from "./continuousAggregate.js";
 export { createRetentionPolicySql, type RetentionPolicyConfig } from "./retention.js";
 export { createCompressionPolicySql, type CompressionPolicyConfig } from "./compression.js";
+export { createChunkSkippingSql, type ChunkSkippingConfig } from "./chunkSkipping.js";
 export { quoteIdent, quoteLiteral, qualifiedIdent, relationLiteral, assertSafeIdent } from "./sql.js";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -91,6 +91,13 @@ export interface HypertableConfig {
   retention?: RetentionConfig;
   /** Optional columnstore-compression policy (`@timescale.compression`); omitted means no policy. */
   compression?: CompressionConfig;
+  /**
+   * Secondary columns (DB names) to enable chunk skipping on (`@timescale.hypertable(chunkSkipping:
+   * ...)`); omitted means none. Each must be a non-partitioning, non-`segmentBy` column — skipping
+   * only helps compressed chunks and the planner needs `timescaledb.enable_chunk_skipping = on` at
+   * query time (see README).
+   */
+  chunkSkipping?: readonly string[];
   /** Relations to other models, for relation filters in `timeBucket` where (EXISTS subqueries). */
   relations?: readonly RelationConfig[];
 }

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -120,6 +120,7 @@ function buildHypertable(
   const retention = buildRetention(annotations, model.name);
   const compression = buildCompression(annotations, model);
   const spacePartition = buildSpacePartition(ann, model, ctx);
+  const chunkSkipping = buildChunkSkipping(ann, model, ctx, column, compression);
   const relations = buildRelations(model, byName);
 
   return {
@@ -132,6 +133,7 @@ function buildHypertable(
     ...(retention ? { retention } : {}),
     ...(compression ? { compression } : {}),
     ...(spacePartition ? { spacePartition } : {}),
+    ...(chunkSkipping ? { chunkSkipping } : {}),
     ...(relations.length > 0 ? { relations } : {}),
   };
 }
@@ -295,6 +297,43 @@ function buildSpacePartition(
     throw new Error(`${ctx}: partitions must be a positive integer (got ${JSON.stringify(partitionsRaw)}).`);
   }
   return { column: dbCol(field), partitions };
+}
+
+/**
+ * Parse the optional `chunkSkipping` arg (a comma-separated list of Prisma field names) off the
+ * hypertable annotation into DB column names. Each must be a scalar field and is rejected if it is
+ * the time/partitioning column (that dimension already prunes chunks) or a compression `segmentBy`
+ * column (enabling chunk skipping there returns wrong query results — verified empirically).
+ */
+function buildChunkSkipping(
+  ann: ReturnType<typeof parseAnnotations>[number],
+  model: DMMF.Model,
+  ctx: string,
+  timeColumn: string,
+  compression: CompressionConfig | undefined,
+): string[] | undefined {
+  const raw = optionalString(ann.args, "chunkSkipping", ctx);
+  if (raw === undefined) return undefined;
+  const segmentBy = new Set(compression?.segmentBy ?? []); // DB names
+  const columns = splitList(raw).map((name) => {
+    const field = findScalarField(model, name);
+    if (!field) {
+      throw new Error(`${ctx}: chunkSkipping column "${name}" is not a scalar field on the model.`);
+    }
+    if (name === timeColumn) {
+      throw new Error(
+        `${ctx}: chunkSkipping column "${name}" is the time/partitioning column; that dimension already prunes chunks.`,
+      );
+    }
+    const db = dbCol(field);
+    if (segmentBy.has(db)) {
+      throw new Error(
+        `${ctx}: chunkSkipping column "${name}" is also a compression segmentBy column; skipping on a segmentBy column returns wrong results — drop it from one of the two.`,
+      );
+    }
+    return db;
+  });
+  return columns.length > 0 ? columns : undefined;
 }
 
 /** Build a CaggConfig from a `@timescale.continuousAggregate` view + its field annotations

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -120,7 +120,7 @@ function buildHypertable(
   const retention = buildRetention(annotations, model.name);
   const compression = buildCompression(annotations, model);
   const spacePartition = buildSpacePartition(ann, model, ctx);
-  const chunkSkipping = buildChunkSkipping(ann, model, ctx, column, compression);
+  const chunkSkipping = buildChunkSkipping(ann, model, ctx, dbCol(field), compression, spacePartition?.column);
   const relations = buildRelations(model, byName);
 
   return {
@@ -301,16 +301,19 @@ function buildSpacePartition(
 
 /**
  * Parse the optional `chunkSkipping` arg (a comma-separated list of Prisma field names) off the
- * hypertable annotation into DB column names. Each must be a scalar field and is rejected if it is
- * the time/partitioning column (that dimension already prunes chunks) or a compression `segmentBy`
- * column (enabling chunk skipping there returns wrong query results — verified empirically).
+ * hypertable annotation into DB column names. Each must be a scalar field and is rejected if it is a
+ * partitioning column — the time dimension or the hash space-partition column (both already prune
+ * chunks) — or a compression `segmentBy` column (enabling chunk skipping there returns wrong query
+ * results — verified empirically). Comparisons are on DB names (`timeColumnDb`/`partitionColumnDb`
+ * are already resolved), so an `@map` alias is caught too.
  */
 function buildChunkSkipping(
   ann: ReturnType<typeof parseAnnotations>[number],
   model: DMMF.Model,
   ctx: string,
-  timeColumn: string,
+  timeColumnDb: string,
   compression: CompressionConfig | undefined,
+  partitionColumnDb: string | undefined,
 ): string[] | undefined {
   const raw = optionalString(ann.args, "chunkSkipping", ctx);
   if (raw === undefined) return undefined;
@@ -320,12 +323,17 @@ function buildChunkSkipping(
     if (!field) {
       throw new Error(`${ctx}: chunkSkipping column "${name}" is not a scalar field on the model.`);
     }
-    if (name === timeColumn) {
+    const db = dbCol(field);
+    if (db === timeColumnDb) {
       throw new Error(
         `${ctx}: chunkSkipping column "${name}" is the time/partitioning column; that dimension already prunes chunks.`,
       );
     }
-    const db = dbCol(field);
+    if (partitionColumnDb !== undefined && db === partitionColumnDb) {
+      throw new Error(
+        `${ctx}: chunkSkipping column "${name}" is the hash space-partition column; that dimension already prunes chunks — chunkSkipping must target a non-partitioning column.`,
+      );
+    }
     if (segmentBy.has(db)) {
       throw new Error(
         `${ctx}: chunkSkipping column "${name}" is also a compression segmentBy column; skipping on a segmentBy column returns wrong results — drop it from one of the two.`,

--- a/src/generator/emit-migrations.ts
+++ b/src/generator/emit-migrations.ts
@@ -12,6 +12,7 @@ import { createHypertableSql } from "../core/hypertable.js";
 import { createContinuousAggregateSql } from "../core/continuousAggregate.js";
 import { createRetentionPolicySql } from "../core/retention.js";
 import { createCompressionPolicySql } from "../core/compression.js";
+import { createChunkSkippingSql } from "../core/chunkSkipping.js";
 
 export const EXTENSION_MIGRATION = "00000000000000_timescaledb_extension";
 export const OBJECTS_MIGRATION = "99999999999999_timescaledb_objects";
@@ -56,6 +57,15 @@ ${createExtensionSql().up}
         ...(c.orderBy ? { orderBy: c.orderBy } : {}),
       }).up;
       parts.push(`-- Compression (columnstore) policy: ${h.table}\n${sql}`);
+    }
+    if (h.chunkSkipping && h.chunkSkipping.length > 0) {
+      // After compression: chunk skipping records its range stats when chunks compress.
+      const sql = createChunkSkippingSql({
+        table: h.table,
+        ...(h.schema !== undefined ? { schema: h.schema } : {}),
+        columns: h.chunkSkipping,
+      }).up;
+      parts.push(`-- Chunk skipping: ${h.table}\n${sql}`);
     }
   }
   for (const c of caggs) {

--- a/test/integration/chunk-skipping.test.ts
+++ b/test/integration/chunk-skipping.test.ts
@@ -1,0 +1,115 @@
+// Chunk skipping end-to-end on real TimescaleDB. Two angles, one container:
+//   1. Generated + reset-safe: the `chunkSkipping` annotation emits a DO block that turns the
+//      `timescaledb.enable_chunk_skipping` GUC on and calls enable_chunk_skipping(...), surviving
+//      `migrate reset` (idempotent replay).
+//   2. Runtime: $timescale.disableChunkSkipping / enableChunkSkipping toggle the column, idempotently.
+// Verified against the internal catalog `_timescaledb_catalog.chunk_column_stats` (there is no public
+// timescaledb_information view for chunk skipping). The GUC requirement and the "compressed chunks
+// only" caveat are exercised implicitly: the enable call only succeeds because we set the GUC.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED chunk-skipping.test.ts: Docker is not available. Not verified.\n");
+}
+
+// eventId is a secondary (non-partitioning, non-segmentBy) column — the correct target for chunk
+// skipping. segmentBy is deviceId, so the generator guard does not trip.
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day", chunkSkipping: "eventId")
+/// @timescale.compression(after: "7 days", segmentBy: "deviceId")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  eventId     BigInt
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const INIT_SQL = `-- CreateTable
+CREATE TABLE "SensorReading" (
+    "time" TIMESTAMP(3) NOT NULL,
+    "deviceId" INTEGER NOT NULL,
+    "eventId" BIGINT NOT NULL,
+    "temperature" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "SensorReading_pkey" PRIMARY KEY ("deviceId","time")
+);
+
+-- CreateIndex
+CREATE INDEX "SensorReading_deviceId_time_idx" ON "SensorReading"("deviceId", "time");
+`;
+
+/** Count the hypertable-level chunk-skipping registrations for SensorReading.eventId. */
+async function skippingColumns(h: Harness): Promise<number> {
+  const [row] = await h.query<{ n: number }>(
+    `SELECT count(*)::int AS n
+       FROM _timescaledb_catalog.chunk_column_stats s
+       JOIN _timescaledb_catalog.hypertable h ON h.id = s.hypertable_id
+      WHERE h.table_name = 'SensorReading' AND s.column_name = 'eventId'`,
+  );
+  return row?.n ?? 0;
+}
+
+describe.skipIf(!DOCKER_OK)("chunk skipping (generated + runtime)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("disables / re-enables chunk skipping at runtime ($timescale), idempotently", async () => {
+    // The generator already enabled eventId from the annotation.
+    expect(await skippingColumns(h)).toBe(1);
+
+    await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
+    expect(await skippingColumns(h)).toBe(0);
+    // Idempotent: re-disabling a not-enabled column is a no-op, not an error.
+    await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
+    expect(await skippingColumns(h)).toBe(0);
+
+    await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
+    expect(await skippingColumns(h)).toBe(1);
+    // Idempotent: re-enabling is a no-op.
+    await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
+    expect(await skippingColumns(h)).toBe(1);
+  });
+
+  it("emits a reset-safe enable_chunk_skipping from the annotation", async () => {
+    // Reproduced across `migrate reset` (idempotent replay, zero manual steps) — run twice.
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await skippingColumns(h)).toBe(1);
+    h.prisma(["migrate", "reset", "--force"]);
+    expect(await skippingColumns(h)).toBe(1);
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -69,6 +69,16 @@ m.removeContinuousAggregatePolicy("SensorHrly");
 loose.addContinuousAggregatePolicy("anything", { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" }); // ok — string fallback
 loose.removeContinuousAggregatePolicy("anything"); // ok — string fallback
 
+// chunk skipping: hypertable model-name checked; the column is a free Prisma field-name string
+m.enableChunkSkipping("SensorReading", "eventId"); // ok
+m.disableChunkSkipping("DeviceLog", "eventId"); // ok
+// @ts-expect-error - "SensorRead" is not a registered hypertable
+m.enableChunkSkipping("SensorRead", "eventId");
+// @ts-expect-error - typo on the model name
+m.disableChunkSkipping("SensorRaeding", "eventId");
+loose.enableChunkSkipping("anything", "eventId"); // ok — string fallback
+loose.disableChunkSkipping("anything", "eventId"); // ok — string fallback
+
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {
   hypertables: [{ model: "SensorReading", table: "sensor_readings" }],

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -4,6 +4,7 @@ import { createHypertableSql } from "../../src/core/hypertable.js";
 import { createContinuousAggregateSql } from "../../src/core/continuousAggregate.js";
 import { createRetentionPolicySql } from "../../src/core/retention.js";
 import { createCompressionPolicySql } from "../../src/core/compression.js";
+import { createChunkSkippingSql } from "../../src/core/chunkSkipping.js";
 import type { CaggConfig } from "../../src/core/types.js";
 
 describe("createExtensionSql", () => {
@@ -280,5 +281,51 @@ CALL add_columnstore_policy('"SensorReading"', after => INTERVAL '7 days', if_no
     expect(() =>
       createCompressionPolicySql({ table: "T", after: "1 day", orderBy: [{ column: "time", nulls: "frist" as never }] }),
     ).toThrow(/Invalid orderBy nulls/);
+  });
+});
+
+describe("createChunkSkippingSql", () => {
+  const sql = createChunkSkippingSql({ table: "SensorReading", columns: ["eventId"] });
+
+  it("wraps enable_chunk_skipping in a DO block that first turns the GUC on (SET LOCAL)", () => {
+    // The GUC `timescaledb.enable_chunk_skipping` must be on for the function to be callable;
+    // doing it as `SET LOCAL` inside one DO block keeps it self-contained and works whether or
+    // not Prisma wraps the migration in a transaction (verified empirically against 2.27.2).
+    expect(sql.up).toBe(`DO $$ BEGIN
+  SET LOCAL timescaledb.enable_chunk_skipping = on;
+  PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE);
+END $$;`);
+  });
+
+  it("is idempotent (if_not_exists) and passes the relation as a quoted string literal (no cast)", () => {
+    expect(sql.up).toContain("if_not_exists => TRUE");
+    expect(sql.up).toContain(`'"SensorReading"'`);
+    expect(sql.up).not.toContain("::regclass");
+    expect(sql.up).not.toContain("::name");
+  });
+
+  it("enables every requested column with one shared SET LOCAL", () => {
+    const { up } = createChunkSkippingSql({ table: "SensorReading", columns: ["eventId", "sensorId"] });
+    expect(up.match(/SET LOCAL/g)).toHaveLength(1);
+    expect(up).toContain(`PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE);`);
+    expect(up).toContain(`PERFORM enable_chunk_skipping('"SensorReading"', 'sensorId', if_not_exists => TRUE);`);
+    // the GUC must be set before any enable call inside the block
+    expect(up.indexOf("SET LOCAL")).toBeLessThan(up.indexOf("PERFORM enable_chunk_skipping"));
+  });
+
+  it("schema-qualifies the relation under multiSchema (@@schema)", () => {
+    const { up } = createChunkSkippingSql({ table: "sensor_readings", schema: "metrics", columns: ["event_id"] });
+    expect(up).toContain(`PERFORM enable_chunk_skipping('"metrics"."sensor_readings"', 'event_id', if_not_exists => TRUE);`);
+  });
+
+  it("down does not try to disable (Prisma's table drop handles it)", () => {
+    expect(sql.down).toMatch(/dropping "SensorReading"/);
+  });
+
+  it("rejects bad identifiers and an empty column list", () => {
+    expect(() => createChunkSkippingSql({ table: "a-b", columns: ["x"] })).toThrow(/Invalid/);
+    expect(() => createChunkSkippingSql({ table: "X", schema: "a-b", columns: ["x"] })).toThrow(/Invalid/);
+    expect(() => createChunkSkippingSql({ table: "X", columns: ["a-b"] })).toThrow(/Invalid/);
+    expect(() => createChunkSkippingSql({ table: "X", columns: [] })).toThrow(/at least one/);
   });
 });

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -587,6 +587,89 @@ model SensorReading {
   });
 });
 
+describe("extractTimescaleSchema — chunk skipping", () => {
+  it("parses chunkSkipping into a list of DB column names (single column)", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "eventId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  eventId  BigInt
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables[0]?.chunkSkipping).toEqual(["eventId"]);
+  });
+
+  it("supports a comma-separated list and maps @map names", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "eventId, sensorId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  eventId  BigInt @map("event_id")
+  sensorId Int
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables[0]?.chunkSkipping).toEqual(["event_id", "sensorId"]);
+  });
+
+  it("omits chunkSkipping when the annotation is absent", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables[0]?.chunkSkipping).toBeUndefined();
+  });
+
+  it("rejects an unknown chunkSkipping column", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "nope")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "nope" is not a scalar field/);
+  });
+
+  it("rejects the time / partitioning column (it already prunes chunks)", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "time" is the time\/partitioning column/);
+  });
+
+  it("rejects a column that is also a compression segmentBy column (it would skip wrong chunks)", async () => {
+    // Verified empirically: enabling chunk skipping on the segmentBy column makes the planner
+    // exclude matching chunks and return wrong (empty) results, so reject it at generation time.
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "deviceId")
+/// @timescale.compression(after: "7 days", segmentBy: "deviceId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "deviceId" is also a compression segmentBy column/);
+  });
+});
+
 describe("extractTimescaleSchema — relations", () => {
   it("extracts to-one (owning, with fk) and to-many (inverse) relations", async () => {
     const result = await extract(`

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -653,6 +653,19 @@ model SensorReading {
     ).rejects.toThrow(/chunkSkipping column "time" is the time\/partitioning column/);
   });
 
+  it("rejects the hash space-partition column (it already prunes chunks)", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", partitionColumn: "deviceId", partitions: 4, chunkSkipping: "deviceId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "deviceId" is the hash space-partition column/);
+  });
+
   it("rejects a column that is also a compression segmentBy column (it would skip wrong chunks)", async () => {
     // Verified empirically: enabling chunk skipping on the segmentBy column makes the planner
     // exclude matching chunks and return wrong (empty) results, so reject it at generation time.

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -186,6 +186,35 @@ model SensorReading {
     // Compression is emitted after the create_hypertable it depends on.
     expect(objects.indexOf("create_hypertable")).toBeLessThan(objects.indexOf("add_columnstore_policy"));
   });
+
+  it("emits chunk skipping (DO block + enable_chunk_skipping) after its hypertable", async () => {
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views"]
+}
+datasource db {
+  provider = "postgresql"
+}
+
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day", chunkSkipping: "eventId")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  eventId  BigInt
+  @@id([deviceId, time])
+}
+`,
+    });
+    const objects = emitMigrations(extractTimescaleSchema(dmmf))[`${OBJECTS_MIGRATION}/migration.sql`]!;
+    expect(objects).toContain("SET LOCAL timescaledb.enable_chunk_skipping = on;");
+    expect(objects).toContain(`PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE);`);
+    expect(objects).not.toContain("::regclass");
+    // Chunk skipping is emitted after the create_hypertable it depends on.
+    expect(objects.indexOf("create_hypertable")).toBeLessThan(objects.indexOf("enable_chunk_skipping"));
+  });
 });
 
 describe("emitTypes", () => {

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -339,3 +339,43 @@ describe("makeManage continuous-aggregate policies", () => {
     await expect(makeManage(fakeClient().client).removeContinuousAggregatePolicy("bad name")).rejects.toThrow(/Invalid/);
   });
 });
+
+describe("makeManage chunk skipping", () => {
+  it("enableChunkSkipping emits one DO block that sets the GUC then enables (pool-safe, idempotent)", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).enableChunkSkipping("SensorReading", "eventId");
+    expect(calls).toHaveLength(1);
+    // One statement / one connection: SET LOCAL + enable_chunk_skipping in a single DO block, so the
+    // session GUC is reliably on for the call even under Prisma's connection pool.
+    expect(calls[0]!.sql).toBe(
+      `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE); END $$`,
+    );
+    expect(calls[0]!.params).toEqual([]);
+  });
+
+  it("disableChunkSkipping emits an idempotent disable in the same DO-block form", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).disableChunkSkipping("SensorReading", "eventId");
+    expect(calls[0]!.sql).toBe(
+      `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM disable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE); END $$`,
+    );
+  });
+
+  it("maps the Prisma field name to its DB column and schema-qualifies the relation (@map / @@schema)", async () => {
+    const { client, calls } = fakeClient();
+    const hypertableByModel = new Map([
+      ["SensorReading", { table: "sensor_readings", schema: "metrics", columns: { eventId: "event_id" } }],
+    ]);
+    await makeManage(client, new Map(), { hypertableByModel }).enableChunkSkipping("SensorReading", "eventId");
+    expect(calls[0]!.sql).toBe(
+      `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM enable_chunk_skipping('"metrics"."sensor_readings"', 'event_id', if_not_exists => TRUE); END $$`,
+    );
+  });
+
+  it("rejects an unsafe model/relation name and an unsafe column name", async () => {
+    await expect(makeManage(fakeClient().client).enableChunkSkipping("bad name", "eventId")).rejects.toThrow(/Invalid/);
+    await expect(makeManage(fakeClient().client).disableChunkSkipping("SensorReading", "bad col")).rejects.toThrow(
+      /Invalid/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds **chunk skipping** — per-chunk min/max range stats on a secondary (non-time) column so the planner can exclude whole **compressed** chunks that can't match a filter on that column (e.g. `WHERE eventId = …`).

### Annotation (reset-safe migration)
```prisma
/// @timescale.hypertable(column: "time", chunkInterval: "1 day", chunkSkipping: "eventId")
/// @timescale.compression(after: "7 days", segmentBy: "deviceId")
model SensorReading { … }
```
Emits, after the hypertable, a self-contained block:
```sql
DO $$ BEGIN
  SET LOCAL timescaledb.enable_chunk_skipping = on;
  PERFORM enable_chunk_skipping('"SensorReading"', 'eventId', if_not_exists => TRUE);
END $$;
```

### Runtime
```ts
await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
```

## Why these design choices (all empirically verified against `timescaledb:2.27.2-pg17`)

- **GUC handling.** `enable_chunk_skipping(...)` is only callable when `timescaledb.enable_chunk_skipping` is `on`. It's `PGC_USERSET`, so a `SET LOCAL` inside one `DO` block makes the call succeed and — crucially for the runtime path — keeps `SET` + `PERFORM` on **one pooled connection** (a separate `SET` and `SELECT` could land on different connections).
- **`segmentBy` guard.** Enabling skipping on the `segmentBy` column makes the planner return **wrong (empty) results**. The generator rejects it (and the time/partitioning column) with a clear error — same spirit as the existing partition-column-in-unique-key guard.
- **Query-time requirements documented, not auto-emitted.** Skipping is a silent no-op unless (1) the GUC is also on for the *querying* session and (2) the chunks are compressed. The README spells both out. The package does **not** auto-`ALTER DATABASE … SET` — it's a DB-wide setting and privilege-sensitive on managed/Tiger Cloud.

## Tests
- **Unit:** builder SQL (`createChunkSkippingSql`), dmmf parsing + all three guards, migration emission, runtime SQL (DO block, @map mapping, idempotency).
- **Type-level:** model-name constraint + loose string fallback.
- **Integration:** catalog-verified (`_timescaledb_catalog.chunk_column_stats`) enable/disable at runtime + reset-safe annotation across `migrate reset`.

Local gates green: `build`, `test` (199), `test:types`, `attw`, `test:integration` (33), `coverage` (94.2/88.9/92.8/95.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TimescaleDB chunk skipping support via `@timescale.hypertable(..., chunkSkipping: ...)` for eligible compressed hypertable columns.
  * Added query-time runtime controls: `enableChunkSkipping()` and `disableChunkSkipping()` (idempotent enable behavior).
  * Exported `createChunkSkippingSql` for manual/admin migration workflows.
* **Documentation**
  * Expanded the README with a full “Chunk skipping” guide, required annotations/constraints, reset-safe migration notes, and runtime caveats.
* **Tests**
  * Added integration and unit coverage for migration output, SQL generation, validation rules, and reset/idempotency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->