### PR TITLE
feat: $timescale.setChunkInterval (resize a live hypertable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,19 @@ window), matching `@timescale.retention`'s `dropAfter` — absolute-timestamp cu
 The introspection helpers wrap `hypertable_size`, `hypertable_detailed_size`, `approximate_row_count`,
 and `hypertable_columnstore_stats`.
 
+#### Resizing chunks (`setChunkInterval`)
+
+```ts
+await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
+```
+
+Changes the time-dimension chunk interval of a **live** hypertable (`set_partitioning_interval`, the
+non-deprecated successor to `set_chunk_time_interval`). It affects only chunks created **after** the
+call — existing chunks keep their interval, so it never rewrites data. This is the runtime complement
+to the [`chunkInterval`](#annotation-reference) annotation: `chunkInterval` sets the size at create
+time, and re-generating the schema can't change it later (`create_hypertable` is a no-op once the
+table exists), so use `setChunkInterval` to adjust it in place.
+
 ---
 
 ## Data retention (`@timescale.retention`)

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -186,6 +186,15 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
 
   /** Disable chunk skipping on a `column` of a hypertable — `disable_chunk_skipping`. Idempotent (no-op if not enabled). */
   disableChunkSkipping(model: HModels, column: string): Promise<void>;
+
+  /**
+   * Change the chunk (partition) interval of a hypertable's time dimension —
+   * `set_partitioning_interval` (the non-deprecated successor to `set_chunk_time_interval`). Affects
+   * only chunks created AFTER the call; existing chunks keep their interval. Accepts the Prisma model
+   * name (resolved via @@map/@@schema). This is the way to resize a *live* hypertable: re-generating
+   * the schema does not change it, since `create_hypertable` is a no-op once the table exists.
+   */
+  setChunkInterval(model: HModels, interval: Interval): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -440,6 +449,16 @@ export function makeManage<HModels extends string = string, CModels extends stri
 
     async disableChunkSkipping(model, column) {
       await client.$executeRawUnsafe(chunkSkippingSql(model, column, "disable_chunk_skipping"));
+    },
+
+    async setChunkInterval(model, interval) {
+      const ref = resolveHypertable(model);
+      assertInterval(interval);
+      const rel = relationLiteral(ref.table, ref.schema);
+      // The polymorphic `anyelement` interval resolves from the typed `INTERVAL '...'` literal (a
+      // bind param would be type-ambiguous); no dimension_name => the time dimension. No cast on the
+      // relation (constraint 2).
+      await client.$executeRawUnsafe(`SELECT set_partitioning_interval(${rel}, INTERVAL ${quoteLiteral(interval)})`);
     },
   };
 }

--- a/test/integration/set-chunk-interval.test.ts
+++ b/test/integration/set-chunk-interval.test.ts
@@ -1,0 +1,72 @@
+// Changing a live hypertable's chunk interval at runtime on real TimescaleDB:
+// $timescale.setChunkInterval -> set_partitioning_interval. The default harness hypertable is
+// created with chunkInterval "1 day"; we resize it and confirm via timescaledb_information.dimensions.
+// Runtime-only feature (no migration emitted), so no migrate-reset assertion is needed.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED set-chunk-interval.test.ts: Docker is not available. Not verified.\n");
+}
+
+/** The hypertable's current time-dimension chunk interval, in seconds (robust to interval display). */
+async function chunkIntervalSeconds(h: Harness): Promise<number> {
+  const [row] = await h.query<{ s: number }>(
+    `SELECT EXTRACT(EPOCH FROM time_interval)::int AS s
+       FROM timescaledb_information.dimensions
+      WHERE hypertable_name = 'SensorReading' AND column_name = 'time'`,
+  );
+  return Number(row?.s ?? 0);
+}
+
+const DAY = 86_400;
+const SIX_HOURS = 21_600;
+
+describe.skipIf(!DOCKER_OK)("set chunk interval (runtime)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness(); // default SensorReading hypertable, created with chunkInterval "1 day"
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("changes the time-dimension chunk interval and is idempotent", async () => {
+    // Created at "1 day" by the annotation.
+    expect(await chunkIntervalSeconds(h)).toBe(DAY);
+
+    await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
+    expect(await chunkIntervalSeconds(h)).toBe(SIX_HOURS);
+
+    // Re-applying the same value is a no-op, not an error.
+    await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
+    expect(await chunkIntervalSeconds(h)).toBe(SIX_HOURS);
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -79,6 +79,15 @@ m.disableChunkSkipping("SensorRaeding", "eventId");
 loose.enableChunkSkipping("anything", "eventId"); // ok — string fallback
 loose.disableChunkSkipping("anything", "eventId"); // ok — string fallback
 
+// chunk interval: hypertable model-name checked; interval is the branded template type
+m.setChunkInterval("SensorReading", "6 hours"); // ok
+m.setChunkInterval("DeviceLog", "1 day"); // ok
+// @ts-expect-error - "SensorRead" is not a registered hypertable
+m.setChunkInterval("SensorRead", "1 day");
+// @ts-expect-error - `interval` must be a valid interval (branded template)
+m.setChunkInterval("SensorReading", "1 fortnight");
+loose.setChunkInterval("anything", "1 day"); // ok — string fallback
+
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {
   hypertables: [{ model: "SensorReading", table: "sensor_readings" }],

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -379,3 +379,30 @@ describe("makeManage chunk skipping", () => {
     );
   });
 });
+
+describe("makeManage chunk interval", () => {
+  it("setChunkInterval emits set_partitioning_interval with an INTERVAL literal (no cast)", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).setChunkInterval("SensorReading", "1 day");
+    expect(calls).toHaveLength(1);
+    // set_partitioning_interval is the non-deprecated successor to set_chunk_time_interval; its
+    // polymorphic `anyelement` interval is passed as a typed literal (a bind param is ambiguous).
+    expect(calls[0]!.sql).toBe(`SELECT set_partitioning_interval('"SensorReading"', INTERVAL '1 day')`);
+    expect(calls[0]!.params).toEqual([]);
+    expect(calls[0]!.sql).not.toContain("::");
+  });
+
+  it("resolves the model to its @@map / @@schema relation", async () => {
+    const { client, calls } = fakeClient();
+    const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+    await makeManage(client, new Map(), { hypertableByModel }).setChunkInterval("SensorReading", "7 days");
+    expect(calls[0]!.sql).toBe(`SELECT set_partitioning_interval('"metrics"."sensor_readings"', INTERVAL '7 days')`);
+  });
+
+  it("rejects an invalid interval and an unsafe model name", async () => {
+    await expect(
+      makeManage(fakeClient().client).setChunkInterval("SensorReading", "1 fortnight" as never),
+    ).rejects.toThrow(/Invalid interval/);
+    await expect(makeManage(fakeClient().client).setChunkInterval("bad name", "1 day")).rejects.toThrow(/Invalid/);
+  });
+});


### PR DESCRIPTION
## What

Adds `$timescale.setChunkInterval(model, interval)` — change a hypertable's time-dimension chunk interval **after** creation.

```ts
await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
```

Emits `SELECT set_partitioning_interval('"SensorReading"', INTERVAL '6 hours')`.

## Why these choices (deep research)

- **`set_partitioning_interval`, not `set_chunk_time_interval`.** Context7 against the TimescaleDB source flagged `set_chunk_time_interval` as **deprecated** in favour of `set_partitioning_interval`; an empirical probe (timescaledb 2.27.2) confirmed the successor works identically (INTERVAL literal, time dimension by default, reflected in `timescaledb_information.dimensions.time_interval`).
- **Runtime-only by design.** Re-generating the schema can't resize a live hypertable — `create_hypertable` is a no-op once the table exists, and the fixed-name objects migration doesn't re-run on a deployed DB. So this is the runtime complement to the `chunkInterval` annotation (which only sets the size at create time). No migration is emitted.
- **Only new chunks.** Verified in the probe: after the change, only chunks created afterward use the new interval; existing chunks keep their range (no data rewrite).
- **Typed literal, no cast.** The polymorphic `anyelement` interval resolves from `INTERVAL '…'` (a bind param is type-ambiguous — same lesson as `dropChunks`); the relation is a quoted string literal (constraint 2). Interval is validated (branded `Interval`); model name resolves via `@@map`/`@@schema`.

## Tests
- **Unit:** SQL shape, `@map`/`@@schema` resolution, invalid-interval + unsafe-name guards.
- **Type-level:** model-name constraint + branded-interval rejection + loose `string` fallback.
- **Integration:** runtime resize verified through `timescaledb_information.dimensions.time_interval` (1 day → 6 hours), idempotent re-apply.

Local gates green: `build`, `test` (203), `test:types`, `attw`, `test:integration`, `coverage` (94.3/88.9/92.8/95.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime chunk interval resizing capability for hypertables via a new API method, allowing users to change the time-partition interval for future chunks without rewriting existing data.

* **Documentation**
  * Added documentation describing the new chunk resizing feature with TypeScript usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->