### PR TITLE
ci: manual workflow_dispatch to (re)publish the current version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,17 +34,17 @@ jobs:
       # No secret => these steps skip, so publishing stays off until the secret is added.
       # prepublishOnly (build + tests + attw) runs as the pre-publish gate.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
         with:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
       - run: npm publish --provenance --access public
-        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,10 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual re-publish of the current version on main — e.g. when an auto-publish failed AFTER the
+  # GitHub release was already created (so release_created is no longer true on a re-run). Safe to
+  # re-trigger: npm publish errors out as a no-op if the version is already on the registry.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -25,22 +29,22 @@ jobs:
           # Maintains a release PR that bumps the version and updates CHANGELOG.md from
           # Conventional Commits; merging that PR creates the git tag + GitHub release.
 
-      # ── npm publish — runs ONLY when a release was just created AND an NPM_TOKEN secret is
-      # configured. No secret => these steps skip, so publishing stays off until you opt in
-      # (just add the NPM_TOKEN repo secret; no workflow change needed). prepublishOnly
-      # (build + tests + attw) runs as the pre-publish gate.
+      # ── npm publish — runs when a release was just created (or this workflow is manually
+      # dispatched to re-publish the current version on main) AND an NPM_TOKEN secret is configured.
+      # No secret => these steps skip, so publishing stays off until the secret is added.
+      # prepublishOnly (build + tests + attw) runs as the pre-publish gate.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: ${{ steps.release.outputs.release_created && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
         with:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        if: ${{ steps.release.outputs.release_created && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-        if: ${{ steps.release.outputs.release_created && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
       - run: npm publish --provenance --access public
-        if: ${{ steps.release.outputs.release_created && env.NPM_TOKEN != '' }}
+        if: ${{ (steps.release.outputs.release_created || github.event_name == 'workflow_dispatch') && env.NPM_TOKEN != '' }}
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The 0.5.0 auto-publish failed at the npm step (`EOTP` — the token lacked 2FA-bypass), **after** release-please had already created the v0.5.0 GitHub release + tag. Because the publish is gated on release-please's `release_created` output (only true on the release-merge push), a plain re-run can't re-publish — `release_created` is false once the release exists.

## What

- Add a `workflow_dispatch` trigger to `release-please.yml`.
- Extend the four publish-step `if:` gates to also fire on manual dispatch: `(release_created || github.event_name == 'workflow_dispatch') && NPM_TOKEN != ''`.

This lets us re-publish the current `main` version on demand (with provenance, in CI), and leaves a permanent manual re-publish/fallback button. Safe to re-trigger — `npm publish` no-ops with an error if the version is already on the registry. Auto-publish on real releases is unchanged; still gated on `NPM_TOKEN`, and `prepublishOnly` (build + tests + attw) stays the pre-publish gate.

After this merges, dispatching the workflow will publish the (already-tagged) **0.5.0** now that the `NPM_TOKEN` secret has been recreated with 2FA-bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to support manually re-publishing the current main version if an earlier auto-publish attempt fails after a GitHub release is already created.
  * Adjusted publish execution rules so npm publishing runs on the initial release creation or when manually dispatched on the main branch, while still requiring the npm authentication token to be configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->