### PR TITLE
feat: $timescale job control + introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,33 @@ to the [`chunkInterval`](#annotation-reference) annotation: `chunkInterval` sets
 time, and re-generating the schema can't change it later (`create_hypertable` is a no-op once the
 table exists), so use `setChunkInterval` to adjust it in place.
 
+#### Background jobs & policies (`listJobs` / `alterJob` / …)
+
+Every policy this package creates (retention, compression, cagg refresh) runs as a TimescaleDB
+**background job**. These helpers let you inspect and control them — the "did my retention actually
+run?" / "pause compression for now" surface.
+
+```ts
+// Inspect — filter by model (a hypertable or a continuous aggregate), or omit for all jobs.
+const jobs  = await prisma.$timescale.listJobs("SensorReading");   // [{ jobId, procName, scheduleInterval, scheduled, config, nextStart, ... }]
+const stats = await prisma.$timescale.jobStats("SensorReading");   // last/next run, status, totalRuns/Successes/Failures (bigint)
+const errs  = await prisma.$timescale.jobErrors("SensorReading");  // recent failures (SQLSTATE + message), newest first
+
+// Control — by numeric job id (from listJobs).
+const { jobId } = jobs[0];
+await prisma.$timescale.alterJob(jobId, { scheduled: false });            // pause
+await prisma.$timescale.alterJob(jobId, { scheduled: true, scheduleInterval: "2 days" }); // resume + reschedule
+await prisma.$timescale.runJob(jobId);                                    // run now, synchronously
+await prisma.$timescale.deleteJob(jobId);                                 // remove a custom job
+```
+
+`listJobs`/`jobStats`/`jobErrors` read the `timescaledb_information.jobs` / `job_stats` / `job_errors`
+views and resolve the model name to its hypertable table or cagg view (so the filter spans both).
+`alterJob` only changes the fields you pass (`scheduled`, `scheduleInterval`, `nextStart`, `maxRetries`,
+`retryPeriod`, `maxRuntime`, `config`) and is a no-op if the job is already gone. `runJob` wraps the
+`run_job` **procedure**, running the job inline. For the package's own policies, prefer the dedicated
+`remove*Policy` methods over `deleteJob`; `alterJob`/`runJob` work on all of them by id.
+
 ---
 
 ## Data retention (`@timescale.retention`)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -134,4 +134,11 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
 }
 
 export type { TimeBucketArgs, TimeBucketRow, AggregateInput } from "./timeBucket.js";
-export type { TimescaleManage, RefreshRange } from "./manage.js";
+export type {
+  TimescaleManage,
+  RefreshRange,
+  TimescaleJob,
+  JobStats,
+  JobError,
+  AlterJobOptions,
+} from "./manage.js";

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -97,6 +97,72 @@ export interface ManageOptions {
   sleep?: (ms: number) => Promise<void>;
 }
 
+/** A background job / policy row from `timescaledb_information.jobs`. */
+export interface TimescaleJob {
+  /** Numeric job id — the handle passed to alterJob / deleteJob / runJob. */
+  jobId: number;
+  /** Procedure name, e.g. `policy_retention`, `policy_compression`, `policy_refresh_continuous_aggregate`, or a custom action. */
+  procName: string;
+  /** Hypertable or continuous-aggregate (view) name the job targets; null for jobs not tied to a relation. */
+  hypertableName: string | null;
+  /** Run cadence (`schedule_interval`) as text, e.g. "1 day"; null for event-only jobs. */
+  scheduleInterval: string | null;
+  /** Whether the scheduler runs it (false = paused). */
+  scheduled: boolean;
+  /** The job's JSONB config (policy parameters), already parsed. */
+  config: unknown;
+  /** Next scheduled start; null if unscheduled. */
+  nextStart: Date | null;
+}
+
+/** Per-job run statistics from `timescaledb_information.job_stats`. */
+export interface JobStats {
+  jobId: number;
+  hypertableName: string | null;
+  lastRunStartedAt: Date | null;
+  lastSuccessfulFinish: Date | null;
+  /** `Success` | `Failed` | … ; null before the first tracked run. */
+  lastRunStatus: string | null;
+  /** `Scheduled` | `Running` | `Paused` | … */
+  jobStatus: string | null;
+  /** Duration of the last run, as text; null before the first run. */
+  lastRunDuration: string | null;
+  nextStart: Date | null;
+  totalRuns: bigint;
+  totalSuccesses: bigint;
+  totalFailures: bigint;
+}
+
+/** A recorded job failure from `timescaledb_information.job_errors`. */
+export interface JobError {
+  jobId: number;
+  procName: string | null;
+  startTime: Date | null;
+  finishTime: Date | null;
+  /** Postgres SQLSTATE of the failure. */
+  sqlerrcode: string | null;
+  /** Error message text (`err_message`). */
+  message: string | null;
+}
+
+/** Options for `alterJob` — only the provided fields change; at least one is required. */
+export interface AlterJobOptions {
+  /** New run cadence (`schedule_interval`). */
+  scheduleInterval?: Interval;
+  /** Max time a single run may take (`max_runtime`). */
+  maxRuntime?: Interval;
+  /** Retry attempts on failure (`max_retries`). */
+  maxRetries?: number;
+  /** Wait between retries (`retry_period`). */
+  retryPeriod?: Interval;
+  /** Pause (`false`) or resume (`true`) the job. */
+  scheduled?: boolean;
+  /** Force the next start time (e.g. to run soon). To run immediately and synchronously, use `runJob`. */
+  nextStart?: Date;
+  /** Replace the job's JSONB config. */
+  config?: unknown;
+}
+
 /**
  * The `$timescale` management namespace. The type parameters are the registered model-name
  * unions taken from the config/registry, so a name argument is checked at compile time — a
@@ -195,6 +261,33 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
    * the schema does not change it, since `create_hypertable` is a no-op once the table exists.
    */
   setChunkInterval(model: HModels, interval: Interval): Promise<void>;
+
+  /**
+   * List background jobs / policies — `timescaledb_information.jobs`. Pass a model name (hypertable
+   * or continuous aggregate) to filter to that relation's jobs; omit for all. Surfaces the policies
+   * this package creates (retention, compression, cagg refresh) plus any custom jobs, with their ids.
+   */
+  listJobs(model?: HModels | CModels): Promise<TimescaleJob[]>;
+
+  /** Per-job run statistics — last/next run, status, and success/failure counts (`job_stats`). Optionally filtered by model. */
+  jobStats(model?: HModels | CModels): Promise<JobStats[]>;
+
+  /** Recent job failures — SQLSTATE + message (`job_errors`), newest first. Optionally filtered by model. */
+  jobErrors(model?: HModels | CModels): Promise<JobError[]>;
+
+  /**
+   * Change a job's schedule or config — `alter_job`. Identify the job by its numeric id (from
+   * `listJobs`). `{ scheduled: false }` pauses a policy, `{ scheduled: true }` resumes it,
+   * `scheduleInterval` / `nextStart` reschedule, and `config` retunes it. No-op if the job no longer
+   * exists (`if_exists`). At least one option must be provided.
+   */
+  alterJob(jobId: number, options: AlterJobOptions): Promise<void>;
+
+  /** Delete a job by id — `delete_job`. (Policy jobs are better removed via their dedicated remove* method.) */
+  deleteJob(jobId: number): Promise<void>;
+
+  /** Run a job now, synchronously, regardless of its schedule — `run_job`. */
+  runJob(jobId: number): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -280,6 +373,36 @@ export function makeManage<HModels extends string = string, CModels extends stri
     assertSafeIdent(dbColumn, "chunk-skipping column");
     const rel = relationLiteral(ref.table, ref.schema);
     return `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM ${fn}(${rel}, ${quoteLiteral(dbColumn)}, if_not_exists => TRUE); END $$`;
+  };
+
+  /** Validate a job id and render it as a SQL integer literal (it is a number, so inlining is injection-safe). */
+  const jobIdLiteral = (jobId: number): string => {
+    if (!Number.isInteger(jobId) || jobId < 0) {
+      throw new Error(`Invalid job id ${JSON.stringify(jobId)}: expected a non-negative integer.`);
+    }
+    return String(jobId);
+  };
+
+  /** Resolve a model name to the DB relation name the jobs views key on: a hypertable's table, or a cagg's view name. */
+  const resolveRelationName = (model: string): { name: string; schema?: string } => {
+    const ht = hypertableByModel.get(model);
+    if (ht) return { name: ht.table, ...(ht.schema !== undefined ? { schema: ht.schema } : {}) };
+    const cagg = viewByModel.get(model);
+    if (cagg) return { name: cagg.name, ...(cagg.schema !== undefined ? { schema: cagg.schema } : {}) };
+    return { name: model };
+  };
+
+  /** Build a `hypertable_name`/`hypertable_schema` filter (bound params) for the jobs views; empty when no model. */
+  const jobFilter = (model: string | undefined, prefix = ""): { where: string; params: unknown[] } => {
+    if (model === undefined) return { where: "", params: [] };
+    const rel = resolveRelationName(model);
+    const params: unknown[] = [rel.name];
+    let where = `WHERE ${prefix}hypertable_name = $1`;
+    if (rel.schema !== undefined) {
+      params.push(rel.schema);
+      where += ` AND ${prefix}hypertable_schema = $2`;
+    }
+    return { where, params };
   };
 
   return {
@@ -459,6 +582,176 @@ export function makeManage<HModels extends string = string, CModels extends stri
       // bind param would be type-ambiguous); no dimension_name => the time dimension. No cast on the
       // relation (constraint 2).
       await client.$executeRawUnsafe(`SELECT set_partitioning_interval(${rel}, INTERVAL ${quoteLiteral(interval)})`);
+    },
+
+    async listJobs(model) {
+      const { where, params } = jobFilter(model);
+      const rows = await client.$queryRawUnsafe<
+        {
+          job_id: number;
+          proc_name: string;
+          hypertable_name: string | null;
+          schedule_interval: string | null;
+          scheduled: boolean;
+          config: unknown;
+          next_start: Date | null;
+        }[]
+      >(
+        [
+          "SELECT job_id, proc_name, hypertable_name, schedule_interval::text AS schedule_interval, scheduled, config, next_start",
+          "FROM timescaledb_information.jobs",
+          where,
+          "ORDER BY job_id",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        ...params,
+      );
+      return rows.map((r) => ({
+        jobId: Number(r.job_id),
+        procName: r.proc_name,
+        hypertableName: r.hypertable_name,
+        scheduleInterval: r.schedule_interval,
+        scheduled: r.scheduled,
+        config: r.config,
+        nextStart: r.next_start,
+      }));
+    },
+
+    async jobStats(model) {
+      const { where, params } = jobFilter(model);
+      const rows = await client.$queryRawUnsafe<
+        {
+          job_id: number;
+          hypertable_name: string | null;
+          last_run_started_at: Date | null;
+          last_successful_finish: Date | null;
+          last_run_status: string | null;
+          job_status: string | null;
+          last_run_duration: string | null;
+          next_start: Date | null;
+          total_runs: bigint | null;
+          total_successes: bigint | null;
+          total_failures: bigint | null;
+        }[]
+      >(
+        [
+          "SELECT job_id, hypertable_name, last_run_started_at, last_successful_finish, last_run_status,",
+          "job_status, last_run_duration::text AS last_run_duration, next_start,",
+          "COALESCE(total_runs, 0)::bigint AS total_runs,",
+          "COALESCE(total_successes, 0)::bigint AS total_successes,",
+          "COALESCE(total_failures, 0)::bigint AS total_failures",
+          "FROM timescaledb_information.job_stats",
+          where,
+          "ORDER BY job_id",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        ...params,
+      );
+      return rows.map((r) => ({
+        jobId: Number(r.job_id),
+        hypertableName: r.hypertable_name,
+        lastRunStartedAt: r.last_run_started_at,
+        lastSuccessfulFinish: r.last_successful_finish,
+        lastRunStatus: r.last_run_status,
+        jobStatus: r.job_status,
+        lastRunDuration: r.last_run_duration,
+        nextStart: r.next_start,
+        totalRuns: r.total_runs ?? 0n,
+        totalSuccesses: r.total_successes ?? 0n,
+        totalFailures: r.total_failures ?? 0n,
+      }));
+    },
+
+    async jobErrors(model) {
+      // job_errors has no hypertable_name column, so a model filter joins to the jobs view by job_id.
+      const rel = model === undefined ? undefined : resolveRelationName(model);
+      const params: unknown[] = [];
+      let from = "timescaledb_information.job_errors e";
+      let where = "";
+      if (rel) {
+        from += " JOIN timescaledb_information.jobs j ON j.job_id = e.job_id";
+        params.push(rel.name);
+        where = "WHERE j.hypertable_name = $1";
+        if (rel.schema !== undefined) {
+          params.push(rel.schema);
+          where += " AND j.hypertable_schema = $2";
+        }
+      }
+      const rows = await client.$queryRawUnsafe<
+        {
+          job_id: number;
+          proc_name: string | null;
+          start_time: Date | null;
+          finish_time: Date | null;
+          sqlerrcode: string | null;
+          err_message: string | null;
+        }[]
+      >(
+        [
+          "SELECT e.job_id, e.proc_name, e.start_time, e.finish_time, e.sqlerrcode, e.err_message",
+          `FROM ${from}`,
+          where,
+          "ORDER BY e.start_time DESC NULLS LAST",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        ...params,
+      );
+      return rows.map((r) => ({
+        jobId: Number(r.job_id),
+        procName: r.proc_name,
+        startTime: r.start_time,
+        finishTime: r.finish_time,
+        sqlerrcode: r.sqlerrcode,
+        message: r.err_message,
+      }));
+    },
+
+    async alterJob(jobId, options) {
+      const id = jobIdLiteral(jobId);
+      const args: string[] = [];
+      const params: unknown[] = [];
+      const interval = (key: string, value: Interval | undefined): void => {
+        if (value === undefined) return;
+        assertInterval(value);
+        args.push(`${key} => INTERVAL ${quoteLiteral(value)}`);
+      };
+      interval("schedule_interval", options.scheduleInterval);
+      interval("max_runtime", options.maxRuntime);
+      interval("retry_period", options.retryPeriod);
+      if (options.maxRetries !== undefined) {
+        if (!Number.isInteger(options.maxRetries) || options.maxRetries < 0) {
+          throw new Error(
+            `alterJob: maxRetries must be a non-negative integer (got ${JSON.stringify(options.maxRetries)}).`,
+          );
+        }
+        args.push(`max_retries => ${options.maxRetries}`);
+      }
+      if (options.scheduled !== undefined) args.push(`scheduled => ${options.scheduled ? "TRUE" : "FALSE"}`);
+      if (options.nextStart !== undefined) {
+        params.push(options.nextStart);
+        args.push(`next_start => $${params.length}`);
+      }
+      if (options.config !== undefined) {
+        params.push(JSON.stringify(options.config));
+        args.push(`config => $${params.length}::jsonb`);
+      }
+      if (args.length === 0) {
+        throw new Error("alterJob: specify at least one option to change.");
+      }
+      // if_exists => TRUE makes altering an already-removed job a no-op instead of an error.
+      await client.$executeRawUnsafe(`SELECT alter_job(${id}, ${args.join(", ")}, if_exists => TRUE)`, ...params);
+    },
+
+    async deleteJob(jobId) {
+      await client.$executeRawUnsafe(`SELECT delete_job(${jobIdLiteral(jobId)})`);
+    },
+
+    async runJob(jobId) {
+      // run_job is a PROCEDURE — CALL it; it runs the job synchronously on this connection.
+      await client.$executeRawUnsafe(`CALL run_job(${jobIdLiteral(jobId)})`);
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,15 @@
 // generator binary, and the runtime must not depend on it (CLAUDE.md resilience rule).
 export { timescaledb } from "./client/index.js";
 export type { TimescaleConfig } from "./client/index.js";
+// Management namespace types ($timescale), so callers can name the return shapes.
+export type {
+  TimescaleManage,
+  RefreshRange,
+  TimescaleJob,
+  JobStats,
+  JobError,
+  AlterJobOptions,
+} from "./client/index.js";
 
 // Re-export the core types + SQL builders for convenience (also available at "./core").
 export type {

--- a/test/integration/jobs.test.ts
+++ b/test/integration/jobs.test.ts
@@ -2,6 +2,11 @@
 // jobStats / jobErrors / alterJob / runJob / deleteJob. The schema declares a retention policy
 // (job -> SensorReading) and a cagg refresh policy (job -> SensorHourly), so we can exercise both
 // the model filter (hypertable vs cagg) and the full job lifecycle.
+//
+// Runtime-only feature (these $timescale methods emit no migration SQL), so — like the other
+// runtime $timescale tests (cagg-policy, chunk-helpers, set-chunk-interval) — it uses migrate deploy
+// without a migrate-reset assertion. Reset-safety of the underlying retention/cagg refresh policies
+// is covered by retention.test.ts / reset-safety.test.ts.
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";

--- a/test/integration/jobs.test.ts
+++ b/test/integration/jobs.test.ts
@@ -1,0 +1,117 @@
+// Background-job control + introspection at runtime, on real TimescaleDB: $timescale.listJobs /
+// jobStats / jobErrors / alterJob / runJob / deleteJob. The schema declares a retention policy
+// (job -> SensorReading) and a cagg refresh policy (job -> SensorHourly), so we can exercise both
+// the model filter (hypertable vs cagg) and the full job lifecycle.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED jobs.test.ts: Docker is not available. Not verified.\n");
+}
+
+// Default harness columns (time / deviceId / temperature) + a retention policy on the hypertable and
+// a refresh policy on the cagg.
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "90 days")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time", refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" })
+view SensorHourly {
+  bucket   DateTime /// @timescale.bucket
+  deviceId Int      /// @timescale.groupBy
+  avgTemp  Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+
+  @@unique([deviceId, bucket])
+}`;
+
+describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  // deno-lint-ignore no-explicit-any
+  const jobByProc = async (model: string, proc: string): Promise<any> =>
+    (await prisma.$timescale.listJobs(model)).find((j: { procName: string }) => j.procName === proc);
+
+  it("lists jobs and filters by model (hypertable vs continuous aggregate)", async () => {
+    const retention = await jobByProc("SensorReading", "policy_retention");
+    const refresh = await jobByProc("SensorHourly", "policy_refresh_continuous_aggregate");
+    expect(retention).toBeTruthy();
+    expect(retention.hypertableName).toBe("SensorReading");
+    expect(retention.scheduled).toBe(true);
+    expect(refresh).toBeTruthy();
+    expect(refresh.hypertableName).toBe("SensorHourly");
+
+    // The model filter excludes the other relation's jobs and the built-in (relation-less) jobs.
+    const onlyRetention = await prisma.$timescale.listJobs("SensorReading");
+    expect(onlyRetention.every((j: { hypertableName: string }) => j.hypertableName === "SensorReading")).toBe(true);
+  });
+
+  it("alterJob pauses, resumes, and reschedules a policy", async () => {
+    const before = await jobByProc("SensorReading", "policy_retention");
+
+    await prisma.$timescale.alterJob(before.jobId, { scheduled: false });
+    expect((await jobByProc("SensorReading", "policy_retention")).scheduled).toBe(false);
+
+    await prisma.$timescale.alterJob(before.jobId, { scheduled: true, scheduleInterval: "2 days" });
+    const after = await jobByProc("SensorReading", "policy_retention");
+    expect(after.scheduled).toBe(true);
+    expect(after.scheduleInterval).toBe("2 days");
+  });
+
+  it("runJob runs a job synchronously and jobStats returns bigint counts", async () => {
+    const retention = await jobByProc("SensorReading", "policy_retention");
+    // Retention on recent/empty data is a safe no-op; it must not throw.
+    await prisma.$timescale.runJob(retention.jobId);
+
+    const [stats] = await prisma.$timescale.jobStats("SensorReading");
+    expect(stats.jobId).toBe(retention.jobId);
+    expect(typeof stats.totalRuns).toBe("bigint");
+    // jobErrors is queryable (no failures expected) and returns an array.
+    expect(Array.isArray(await prisma.$timescale.jobErrors("SensorReading"))).toBe(true);
+  });
+
+  it("deleteJob removes a job", async () => {
+    const retention = await jobByProc("SensorReading", "policy_retention");
+    await prisma.$timescale.deleteJob(retention.jobId);
+    expect(await jobByProc("SensorReading", "policy_retention")).toBeUndefined();
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -2,7 +2,7 @@
 // A name argument is constrained to the registered model names, so a typo fails to compile.
 import { timescaledb } from "../../src/index.js";
 import type { CaggModelNames, HypertableModelNames, NamesOrString } from "../../src/client/index.js";
-import type { TimescaleManage } from "../../src/client/manage.js";
+import type { TimescaleManage, TimescaleJob, JobStats, JobError } from "../../src/client/manage.js";
 
 type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -87,6 +87,27 @@ m.setChunkInterval("SensorRead", "1 day");
 // @ts-expect-error - `interval` must be a valid interval (branded template)
 m.setChunkInterval("SensorReading", "1 fortnight");
 loose.setChunkInterval("anything", "1 day"); // ok — string fallback
+
+// jobs: introspection takes a hypertable OR cagg model (or nothing); control takes a numeric job id
+const _jobs: Promise<TimescaleJob[]> = m.listJobs();
+m.listJobs("SensorReading"); // ok (hypertable)
+m.listJobs("SensorHourly"); // ok (cagg)
+const _stats: Promise<JobStats[]> = m.jobStats("DeviceLog");
+const _errs: Promise<JobError[]> = m.jobErrors();
+void _jobs;
+void _stats;
+void _errs;
+// @ts-expect-error - "Nope" is not a registered model
+m.listJobs("Nope");
+m.alterJob(1000, { scheduled: false }); // ok
+m.alterJob(1000, { scheduleInterval: "6 hours", config: { drop_after: "60 days" } }); // ok
+// @ts-expect-error - scheduleInterval must be a valid interval (branded template)
+m.alterJob(1000, { scheduleInterval: "1 fortnight" });
+// @ts-expect-error - a job id is a number, not a string
+m.deleteJob("1000");
+m.runJob(1002); // ok
+loose.listJobs("anything"); // ok — string fallback
+loose.alterJob(1, { scheduled: true }); // ok
 
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -406,3 +406,137 @@ describe("makeManage chunk interval", () => {
     await expect(makeManage(fakeClient().client).setChunkInterval("bad name", "1 day")).rejects.toThrow(/Invalid/);
   });
 });
+
+describe("makeManage job introspection", () => {
+  const jobRow = {
+    job_id: 1000,
+    proc_name: "policy_retention",
+    hypertable_name: "Sensor",
+    schedule_interval: "1 day",
+    scheduled: true,
+    config: { drop_after: "30 days" },
+    next_start: new Date("2030-01-01T00:00:00Z"),
+  };
+
+  it("listJobs() reads the jobs view (no filter) and maps rows to camelCase", async () => {
+    const { client, queries } = fakeClient([jobRow]);
+    const jobs = await makeManage(client).listJobs();
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toContain("FROM timescaledb_information.jobs");
+    expect(queries[0]!.sql).toContain("schedule_interval::text AS schedule_interval");
+    expect(queries[0]!.sql).not.toContain("WHERE");
+    expect(queries[0]!.sql.endsWith("ORDER BY job_id")).toBe(true);
+    expect(queries[0]!.params).toEqual([]);
+    expect(jobs[0]).toEqual({
+      jobId: 1000,
+      procName: "policy_retention",
+      hypertableName: "Sensor",
+      scheduleInterval: "1 day",
+      scheduled: true,
+      config: { drop_after: "30 days" },
+      nextStart: new Date("2030-01-01T00:00:00Z"),
+    });
+  });
+
+  it("listJobs(model) filters by hypertable_name as a bound param", async () => {
+    const { client, queries } = fakeClient([]);
+    await makeManage(client).listJobs("SensorReading");
+    expect(queries[0]!.sql).toContain("WHERE hypertable_name = $1");
+    expect(queries[0]!.params).toEqual(["SensorReading"]);
+  });
+
+  it("resolves a model's @@map table + @@schema for the filter (two params)", async () => {
+    const { client, queries } = fakeClient([]);
+    const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+    await makeManage(client, new Map(), { hypertableByModel }).listJobs("SensorReading");
+    expect(queries[0]!.sql).toContain("WHERE hypertable_name = $1 AND hypertable_schema = $2");
+    expect(queries[0]!.params).toEqual(["sensor_readings", "metrics"]);
+  });
+
+  it("a continuous-aggregate model resolves to its view name (cagg jobs key on the view)", async () => {
+    const { client, queries } = fakeClient([]);
+    const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly" }]]);
+    await makeManage(client, viewByModel).listJobs("SensorHourly");
+    expect(queries[0]!.params).toEqual(["sensor_hourly"]);
+  });
+
+  it("jobStats() coalesces null counts to 0n and returns bigint totals", async () => {
+    const { client, queries } = fakeClient([
+      { job_id: 1000, total_runs: 5n, total_successes: 4n, total_failures: 1n },
+      { job_id: 1001, total_runs: null, total_successes: null, total_failures: null },
+    ]);
+    const stats = await makeManage(client).jobStats();
+    expect(queries[0]!.sql).toContain("FROM timescaledb_information.job_stats");
+    expect(queries[0]!.sql).toContain("COALESCE(total_runs, 0)::bigint AS total_runs");
+    expect(stats[0]!.totalRuns).toBe(5n);
+    expect(stats[1]!.totalRuns).toBe(0n);
+    expect(stats[1]!.totalFailures).toBe(0n);
+  });
+
+  it("jobErrors() reads job_errors directly; jobErrors(model) joins to jobs for the filter", async () => {
+    const { client, queries } = fakeClient([]);
+    const m = makeManage(client);
+    await m.jobErrors();
+    expect(queries[0]!.sql).toContain("FROM timescaledb_information.job_errors e");
+    expect(queries[0]!.sql).not.toContain("JOIN");
+    await m.jobErrors("SensorReading");
+    expect(queries[1]!.sql).toContain("JOIN timescaledb_information.jobs j ON j.job_id = e.job_id");
+    expect(queries[1]!.sql).toContain("WHERE j.hypertable_name = $1");
+    expect(queries[1]!.params).toEqual(["SensorReading"]);
+  });
+
+  it("jobErrors(model) adds the @@schema clause and maps the @@map table", async () => {
+    const { client, queries } = fakeClient([]);
+    const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+    await makeManage(client, new Map(), { hypertableByModel }).jobErrors("SensorReading");
+    expect(queries[0]!.sql).toContain("WHERE j.hypertable_name = $1 AND j.hypertable_schema = $2");
+    expect(queries[0]!.params).toEqual(["sensor_readings", "metrics"]);
+  });
+});
+
+describe("makeManage job control", () => {
+  it("alterJob pause emits scheduled => FALSE with if_exists", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).alterJob(1000, { scheduled: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toBe("SELECT alter_job(1000, scheduled => FALSE, if_exists => TRUE)");
+    expect(calls[0]!.params).toEqual([]);
+  });
+
+  it("alterJob builds interval/int literals and binds nextStart + config (jsonb)", async () => {
+    const { client, calls } = fakeClient();
+    const next = new Date("2030-01-01T00:00:00Z");
+    await makeManage(client).alterJob(1000, {
+      scheduleInterval: "6 hours",
+      maxRetries: 3,
+      nextStart: next,
+      config: { drop_after: "60 days" },
+    });
+    expect(calls[0]!.sql).toBe(
+      "SELECT alter_job(1000, schedule_interval => INTERVAL '6 hours', max_retries => 3, next_start => $1, config => $2::jsonb, if_exists => TRUE)",
+    );
+    expect(calls[0]!.params).toEqual([next, '{"drop_after":"60 days"}']);
+  });
+
+  it("alterJob rejects an empty option set, a bad job id, a bad interval, and a bad maxRetries", async () => {
+    const m = makeManage(fakeClient().client);
+    await expect(m.alterJob(1000, {})).rejects.toThrow(/at least one option/);
+    await expect(m.alterJob(-1, { scheduled: false })).rejects.toThrow(/Invalid job id/);
+    await expect(m.alterJob(1.5, { scheduled: false })).rejects.toThrow(/Invalid job id/);
+    await expect(m.alterJob(1000, { scheduleInterval: "1 fortnight" as never })).rejects.toThrow(/Invalid interval/);
+    await expect(m.alterJob(1000, { maxRetries: -1 })).rejects.toThrow(/non-negative integer/);
+  });
+
+  it("deleteJob and runJob emit the right SQL (run_job via CALL)", async () => {
+    const { client, calls } = fakeClient();
+    const m = makeManage(client);
+    await m.deleteJob(1000);
+    expect(calls[0]!.sql).toBe("SELECT delete_job(1000)");
+    await m.runJob(1002);
+    expect(calls[1]!.sql).toBe("CALL run_job(1002)");
+  });
+
+  it("runJob rejects a non-integer job id", async () => {
+    await expect(makeManage(fakeClient().client).runJob(1.5)).rejects.toThrow(/Invalid job id/);
+  });
+});


### PR DESCRIPTION
## What

Adds runtime management + introspection for the TimescaleDB **background jobs** behind the package's policies (retention, compression, cagg refresh) — the day-2-ops layer (Tier 1 of the post-0.5.0 gap analysis).

```ts
// Inspect (filter by hypertable OR continuous-aggregate model, or omit for all)
const jobs  = await prisma.$timescale.listJobs("SensorReading");
const stats = await prisma.$timescale.jobStats("SensorReading");   // counts are bigint
const errs  = await prisma.$timescale.jobErrors("SensorReading");  // newest first

// Control (by numeric job id)
await prisma.$timescale.alterJob(jobId, { scheduled: false });                 // pause
await prisma.$timescale.alterJob(jobId, { scheduled: true, scheduleInterval: "2 days" });
await prisma.$timescale.runJob(jobId);     // run now, synchronously
await prisma.$timescale.deleteJob(jobId);
```

## Design notes (empirically verified vs timescaledb 2.27.2)

- **`run_job` is a PROCEDURE** → `CALL run_job(id)` (runs inline); `alter_job`/`delete_job` are functions (`SELECT`).
- **Model filter spans hypertables *and* caggs:** a cagg refresh job's `hypertable_name` is the *view* name (e.g. `SensorHourly`), so `listJobs(model)` resolves the model to its table or view name and filters `hypertable_name`. `job_errors` has no `hypertable_name`, so the model filter joins to `jobs` by `job_id`.
- **Counts are `bigint`** (via adapter-pg) and `NULL` until the scheduler first tracks a job → coalesced to `0n`.
- **`alterJob`** changes only the fields you pass, with `if_exists => TRUE` (no-op if the job's gone). Intervals are validated typed literals; `nextStart`/`config` are bound params (`config` as `::jsonb`). Job ids are validated non-negative integers (inlined — injection-safe).
- New result types (`TimescaleJob`/`JobStats`/`JobError`/`AlterJobOptions`) are exported from the package root.

## Tests
- **Unit:** SQL shape for all six methods, `@map`/`@@schema` filter resolution, cagg-name resolution, `bigint`/`COALESCE`, `alterJob` arg+param building (literals vs bound), and guards (empty options, bad job id, bad interval, bad maxRetries).
- **Type-level:** model arg is the hypertable∪cagg union; numeric job id; branded interval; loose `string` fallback.
- **Integration:** full lifecycle on real TimescaleDB — list + model filter (hypertable vs cagg), pause/resume/reschedule, `runJob` synchronous, `jobStats` bigint, `jobErrors`, `deleteJob`.

Local gates green: build, unit (215), test:types, attw 🟢, coverage (94.6/89.2/92.8/95.6), integration (38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added background job management APIs for TimescaleDB: `listJobs()`, `jobStats()`, `jobErrors()`, `alterJob()`, `deleteJob()`, and `runJob()`.
  * Exposed the related job/stat/error types and options for improved type safety.

* **Documentation**
  * Added a new guide explaining how to inspect and control TimescaleDB background jobs, including data sources and key behavior notes.

* **Tests**
  * Added integration and unit coverage for job listing, introspection, control operations, and type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->