### PR TITLE
feat: $timescale on-demand chunk operations (showChunks / compress / decompress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,14 @@ backoff (default: up to 8 attempts); if the contention persists beyond that budg
 #### Inspecting & dropping chunks
 
 ```ts
+// List chunks (relation names), optionally bounded by interval — feeds compress/decompress/drop.
+const chunks = await prisma.$timescale.showChunks("SensorReading");                 // string[]
+const old    = await prisma.$timescale.showChunks("SensorReading", { olderThan: "30 days" });
+
+// Convert a single chunk to/from the columnstore on demand (needs the columnstore enabled).
+await prisma.$timescale.compressChunk(chunks[0]);
+await prisma.$timescale.decompressChunk(chunks[0]);
+
 // On-demand chunk drop (manual retention) — returns the dropped chunk names.
 const dropped = await prisma.$timescale.dropChunks("SensorReading", { olderThan: "30 days" });
 
@@ -421,10 +429,14 @@ const rows   = await prisma.$timescale.approximateRowCount("SensorReading");    
 const stats  = await prisma.$timescale.compressionStats("SensorReading");       // { totalChunks, compressedChunks, beforeTotalBytes, afterTotalBytes }
 ```
 
-`dropChunks` bounds (`olderThan` / `newerThan`) are intervals **relative to now** (combine both for a
-window), matching `@timescale.retention`'s `dropAfter` — absolute-timestamp cutoffs aren't supported.
-The introspection helpers wrap `hypertable_size`, `hypertable_detailed_size`, `approximate_row_count`,
-and `hypertable_columnstore_stats`.
+`showChunks` returns `show_chunks` relation names (e.g. `_timescaledb_internal._hyper_1_2_chunk`) — pass
+one straight to `compressChunk` / `decompressChunk` (`compress_chunk` / `decompress_chunk`, idempotent).
+Compressing a chunk requires the columnstore enabled on the hypertable (via
+[`@timescale.compression`](#data-compression-timescalecompression) or `addCompressionPolicy`).
+`showChunks` / `dropChunks` bounds (`olderThan` / `newerThan`) are intervals **relative to now** (combine
+both for a window), matching `@timescale.retention`'s `dropAfter` — absolute-timestamp cutoffs aren't
+supported. The introspection helpers wrap `hypertable_size`, `hypertable_detailed_size`,
+`approximate_row_count`, and `hypertable_columnstore_stats`.
 
 #### Resizing chunks (`setChunkInterval`)
 

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -299,7 +299,7 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
 
   /**
    * List a hypertable's chunks — `show_chunks` — as relation names (e.g.
-   * `_timescaledb_internal._hyper_1_2_chunk`), newest-bounded by the optional `olderThan` / `newerThan`
+   * `_timescaledb_internal._hyper_1_2_chunk`), optionally bounded by the `olderThan` / `newerThan`
    * intervals (relative to now, like `dropChunks`). The returned names are the handles for
    * `compressChunk` / `decompressChunk`.
    */

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -60,6 +60,14 @@ export interface DropChunksOptions {
   newerThan?: Interval;
 }
 
+/** Optional bounds for `showChunks`; both omitted lists every chunk. Intervals are relative to now (like `dropChunks`). */
+export interface ShowChunksOptions {
+  /** Only chunks whose time range is entirely older than this interval before now. */
+  olderThan?: Interval;
+  /** Only chunks whose time range is entirely newer than this interval before now (combine with `olderThan` for a window). */
+  newerThan?: Interval;
+}
+
 /** Per-component byte sizes of a hypertable (from `hypertable_detailed_size`). */
 export interface HypertableSize {
   tableBytes: bigint;
@@ -288,6 +296,24 @@ export interface TimescaleManage<HModels extends string = string, CModels extend
 
   /** Run a job now, synchronously, regardless of its schedule — `run_job`. */
   runJob(jobId: number): Promise<void>;
+
+  /**
+   * List a hypertable's chunks — `show_chunks` — as relation names (e.g.
+   * `_timescaledb_internal._hyper_1_2_chunk`), newest-bounded by the optional `olderThan` / `newerThan`
+   * intervals (relative to now, like `dropChunks`). The returned names are the handles for
+   * `compressChunk` / `decompressChunk`.
+   */
+  showChunks(model: HModels, options?: ShowChunksOptions): Promise<string[]>;
+
+  /**
+   * Convert a single chunk to the columnstore on demand — `compress_chunk`. Pass a chunk name from
+   * `showChunks`. Requires the columnstore to be enabled on the hypertable (via `@timescale.compression`
+   * or `addCompressionPolicy`). Idempotent: a no-op if the chunk is already compressed (`if_not_compressed`).
+   */
+  compressChunk(chunk: string): Promise<void>;
+
+  /** Convert a single chunk back to the rowstore on demand — `decompress_chunk`. Idempotent if already uncompressed (`if_compressed`). */
+  decompressChunk(chunk: string): Promise<void>;
 }
 
 // SQLSTATE 55P03 (lock_not_available): TimescaleDB raises this when a manual
@@ -381,6 +407,22 @@ export function makeManage<HModels extends string = string, CModels extends stri
       throw new Error(`Invalid job id ${JSON.stringify(jobId)}: expected a non-negative integer.`);
     }
     return String(jobId);
+  };
+
+  /**
+   * Validate a chunk name (an optionally schema-qualified relation, as returned by `showChunks`) and
+   * render it as a quoted string literal for the `regclass` argument of compress/decompress — no
+   * `::regclass` cast (constraint 2); the implicit text->regclass resolution handles the rest. The
+   * per-part identifier check makes embedding the value injection-safe.
+   */
+  const chunkLiteral = (chunk: string): string => {
+    const SAFE_QUALIFIED = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/;
+    if (!SAFE_QUALIFIED.test(chunk)) {
+      throw new Error(
+        `Invalid chunk name ${JSON.stringify(chunk)}: expected an (optionally schema-qualified) relation name from showChunks.`,
+      );
+    }
+    return quoteLiteral(chunk);
   };
 
   /** Resolve a model name to the DB relation name the jobs views key on: a hypertable's table, or a cagg's view name. */
@@ -752,6 +794,33 @@ export function makeManage<HModels extends string = string, CModels extends stri
     async runJob(jobId) {
       // run_job is a PROCEDURE — CALL it; it runs the job synchronously on this connection.
       await client.$executeRawUnsafe(`CALL run_job(${jobIdLiteral(jobId)})`);
+    },
+
+    async showChunks(model, options = {}) {
+      const ref = resolveHypertable(model);
+      const rel = relationLiteral(ref.table, ref.schema);
+      // Bounds are validated Intervals interpolated as typed `INTERVAL '...'` literals (the args are
+      // polymorphic "any" — a bind param would be type-ambiguous, same as dropChunks). Both optional.
+      const bound = (key: string, value: Interval | undefined): string | undefined => {
+        if (value === undefined) return undefined;
+        assertInterval(value);
+        return `${key} => INTERVAL ${quoteLiteral(value)}`;
+      };
+      const args = [rel, bound("older_than", options.olderThan), bound("newer_than", options.newerThan)].filter(
+        (a): a is string => a !== undefined,
+      );
+      const rows = await client.$queryRawUnsafe<{ chunk: string }[]>(
+        `SELECT c::text AS chunk FROM show_chunks(${args.join(", ")}) c ORDER BY c`,
+      );
+      return rows.map((r) => r.chunk);
+    },
+
+    async compressChunk(chunk) {
+      await client.$executeRawUnsafe(`SELECT compress_chunk(${chunkLiteral(chunk)}, if_not_compressed => TRUE)`);
+    },
+
+    async decompressChunk(chunk) {
+      await client.$executeRawUnsafe(`SELECT decompress_chunk(${chunkLiteral(chunk)}, if_compressed => TRUE)`);
     },
   };
 }

--- a/test/integration/chunk-ops.test.ts
+++ b/test/integration/chunk-ops.test.ts
@@ -1,0 +1,100 @@
+// On-demand chunk operations at runtime, on real TimescaleDB: $timescale.showChunks /
+// compressChunk / decompressChunk. The hypertable enables the columnstore (@timescale.compression)
+// so compress_chunk works; we insert two days' worth of data to get two chunks.
+//
+// Runtime-only feature (these $timescale methods emit no migration SQL), so — like the other runtime
+// $timescale tests — it uses migrate deploy without a migrate-reset assertion.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED chunk-ops.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.compression(after: "7 days", segmentBy: "deviceId")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+/** Set of chunk full-names (schema.name) that are currently compressed, for SensorReading. */
+async function compressedChunks(h: Harness): Promise<Set<string>> {
+  const rows = await h.query<{ name: string; compressed: boolean }>(
+    `SELECT (chunk_schema || '.' || chunk_name) AS name, is_compressed AS compressed
+       FROM timescaledb_information.chunks WHERE hypertable_name = 'SensorReading'`,
+  );
+  return new Set(rows.filter((r) => r.compressed).map((r) => r.name));
+}
+
+describe.skipIf(!DOCKER_OK)("on-demand chunk operations (runtime)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Two rows a month apart -> two daily chunks.
+    await h.query(
+      `INSERT INTO "SensorReading" ("time","deviceId","temperature") VALUES ('2026-01-01 00:00:00',1,1.0),('2026-02-01 00:00:00',2,2.0)`,
+    );
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("lists chunks and applies interval bounds", async () => {
+    const chunks: string[] = await prisma.$timescale.showChunks("SensorReading");
+    expect(chunks).toHaveLength(2);
+    expect(chunks.every((c) => c.includes("_hyper_"))).toBe(true);
+
+    // The data is from early 2026; nothing is older than ~27 years before now, so the bound filters all out.
+    expect(await prisma.$timescale.showChunks("SensorReading", { olderThan: "10000 days" })).toHaveLength(0);
+  });
+
+  it("compresses and decompresses a single chunk, idempotently", async () => {
+    const [chunk] = await prisma.$timescale.showChunks("SensorReading");
+    expect(await compressedChunks(h)).not.toContain(chunk);
+
+    await prisma.$timescale.compressChunk(chunk);
+    expect(await compressedChunks(h)).toContain(chunk);
+    // Idempotent: re-compressing an already-compressed chunk is a no-op, not an error.
+    await prisma.$timescale.compressChunk(chunk);
+    expect(await compressedChunks(h)).toContain(chunk);
+
+    await prisma.$timescale.decompressChunk(chunk);
+    expect(await compressedChunks(h)).not.toContain(chunk);
+    // Idempotent the other way too.
+    await prisma.$timescale.decompressChunk(chunk);
+    expect(await compressedChunks(h)).not.toContain(chunk);
+  });
+});

--- a/test/types/manage.test-d.ts
+++ b/test/types/manage.test-d.ts
@@ -109,6 +109,18 @@ m.runJob(1002); // ok
 loose.listJobs("anything"); // ok — string fallback
 loose.alterJob(1, { scheduled: true }); // ok
 
+// chunk ops: showChunks is hypertable-model-checked and returns names; compress/decompress take a chunk name
+const _chunks: Promise<string[]> = m.showChunks("SensorReading");
+m.showChunks("SensorReading", { olderThan: "30 days", newerThan: "1 day" }); // ok
+void _chunks;
+// @ts-expect-error - "Nope" is not a registered hypertable
+m.showChunks("Nope");
+// @ts-expect-error - olderThan must be a valid interval (branded template)
+m.showChunks("SensorReading", { olderThan: "1 fortnight" });
+m.compressChunk("_timescaledb_internal._hyper_1_2_chunk"); // ok (a chunk name string, not a model)
+m.decompressChunk("_timescaledb_internal._hyper_1_2_chunk"); // ok
+loose.showChunks("anything"); // ok — string fallback
+
 // --- 2) name extraction from a const registry (model ?? table / model ?? name) ---
 const mapped = {
   hypertables: [{ model: "SensorReading", table: "sensor_readings" }],

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -503,6 +503,12 @@ describe("makeManage job control", () => {
     expect(calls[0]!.params).toEqual([]);
   });
 
+  it("alterJob resume emits scheduled => TRUE", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).alterJob(1000, { scheduled: true });
+    expect(calls[0]!.sql).toBe("SELECT alter_job(1000, scheduled => TRUE, if_exists => TRUE)");
+  });
+
   it("alterJob builds interval/int literals and binds nextStart + config (jsonb)", async () => {
     const { client, calls } = fakeClient();
     const next = new Date("2030-01-01T00:00:00Z");
@@ -538,5 +544,69 @@ describe("makeManage job control", () => {
 
   it("runJob rejects a non-integer job id", async () => {
     await expect(makeManage(fakeClient().client).runJob(1.5)).rejects.toThrow(/Invalid job id/);
+  });
+});
+
+describe("makeManage chunk operations", () => {
+  it("showChunks() with no bounds lists all chunks and maps the ::text names", async () => {
+    const { client, queries } = fakeClient([
+      { chunk: "_timescaledb_internal._hyper_1_1_chunk" },
+      { chunk: "_timescaledb_internal._hyper_1_2_chunk" },
+    ]);
+    const chunks = await makeManage(client).showChunks("SensorReading");
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toBe(
+      `SELECT c::text AS chunk FROM show_chunks('"SensorReading"') c ORDER BY c`,
+    );
+    expect(chunks).toEqual([
+      "_timescaledb_internal._hyper_1_1_chunk",
+      "_timescaledb_internal._hyper_1_2_chunk",
+    ]);
+  });
+
+  it("showChunks bounds become typed INTERVAL literals (no cast); both combine into a window", async () => {
+    const { client, queries } = fakeClient([]);
+    await makeManage(client).showChunks("SensorReading", { olderThan: "30 days" });
+    expect(queries[0]!.sql).toBe(
+      `SELECT c::text AS chunk FROM show_chunks('"SensorReading"', older_than => INTERVAL '30 days') c ORDER BY c`,
+    );
+    await makeManage(client).showChunks("SensorReading", { olderThan: "1 day", newerThan: "30 days" });
+    expect(queries[1]!.sql).toBe(
+      `SELECT c::text AS chunk FROM show_chunks('"SensorReading"', older_than => INTERVAL '1 day', newer_than => INTERVAL '30 days') c ORDER BY c`,
+    );
+    expect(queries[0]!.sql).not.toContain("::regclass");
+  });
+
+  it("showChunks resolves @@map / @@schema relation and rejects a bad interval", async () => {
+    const { client, queries } = fakeClient([]);
+    const hypertableByModel = new Map([["SensorReading", { table: "sensor_readings", schema: "metrics" }]]);
+    await makeManage(client, new Map(), { hypertableByModel }).showChunks("SensorReading");
+    expect(queries[0]!.sql).toContain(`show_chunks('"metrics"."sensor_readings"')`);
+    await expect(makeManage(client).showChunks("SensorReading", { olderThan: "1 fortnight" as never })).rejects.toThrow(
+      /Invalid interval/,
+    );
+  });
+
+  it("compressChunk / decompressChunk emit idempotent calls with the chunk as a quoted literal", async () => {
+    const { client, calls } = fakeClient();
+    const chunk = "_timescaledb_internal._hyper_1_2_chunk";
+    const m = makeManage(client);
+    await m.compressChunk(chunk);
+    expect(calls[0]!.sql).toBe(
+      `SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk', if_not_compressed => TRUE)`,
+    );
+    expect(calls[0]!.sql).not.toContain("::regclass");
+    await m.decompressChunk(chunk);
+    expect(calls[1]!.sql).toBe(
+      `SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk', if_compressed => TRUE)`,
+    );
+  });
+
+  it("compress/decompress reject an unsafe or malformed chunk name", async () => {
+    const m = makeManage(fakeClient().client);
+    await expect(m.compressChunk("x'; DROP TABLE y; --")).rejects.toThrow(/Invalid chunk name/);
+    await expect(m.compressChunk("a.b.c")).rejects.toThrow(/Invalid chunk name/); // too many parts
+    await expect(m.compressChunk("")).rejects.toThrow(/Invalid chunk name/);
+    await expect(m.decompressChunk("has space")).rejects.toThrow(/Invalid chunk name/);
   });
 });


### PR DESCRIPTION
## What

Completes the Tier-1 chunk-management surface with manual per-chunk operations (`$timescale`):

```ts
const chunks = await prisma.$timescale.showChunks("SensorReading");                 // string[]
const old    = await prisma.$timescale.showChunks("SensorReading", { olderThan: "30 days" });
await prisma.$timescale.compressChunk(chunks[0]);    // -> columnstore
await prisma.$timescale.decompressChunk(chunks[0]);  // -> rowstore
```

- **`showChunks(model, { olderThan?, newerThan? }?)`** → `show_chunks`, returns chunk relation names (`_timescaledb_internal._hyper_1_2_chunk`). Bounds are typed `INTERVAL` literals relative to now (like `dropChunks`), both optional (omit ⇒ all chunks).
- **`compressChunk(chunk)` / `decompressChunk(chunk)`** → `compress_chunk` / `decompress_chunk`, idempotent via `if_not_compressed` / `if_compressed`.

## Design notes (verified on timescaledb 2.27.2)

- A chunk name from `showChunks` feeds straight into compress/decompress. It's passed as a **quoted string literal — no `::regclass` cast** (constraint 2); the implicit text→regclass resolution handles the schema-qualified name (confirmed). Names are validated as an optionally-schema-qualified identifier before embedding (injection-safe).
- `compressChunk` requires the columnstore enabled on the hypertable (via `@timescale.compression` or `addCompressionPolicy`).
- Chose **`compressChunk`/`decompressChunk`** (matching `addCompressionPolicy`'s "compression" vocabulary) over the equivalent `convert_to_columnstore`/`convert_to_rowstore` *procedures* — one clean pair, no redundant aliases.

## Tests
- **Unit:** SQL for all three (incl. `@map`/`@@schema` relation, `INTERVAL` bounds, chunk-literal + injection/format rejection).
- **Type-level:** hypertable-model filter on `showChunks`, branded interval bounds, chunk-name is a plain string, loose fallback.
- **Integration:** list + interval bound, compress/decompress round-trip verified via `is_compressed`, idempotent both ways. Runtime-only (documented; no `migrate reset`, matching the sibling runtime tests).

Local gates green: build, unit (221), test:types, attw 🟢, coverage (94.7/89.3/93.1/95.6), integration (40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chunk discovery via `showChunks` with optional `olderThan`/`newerThan` (relative to now) time bounds.
  * Added `compressChunk` and `decompressChunk` helpers for manual chunk conversion.
* **Documentation**
  * Updated the README “Inspecting & dropping chunks” section with new `showChunks` and on-demand compression/decompression examples and clarified returned relation names and interval behavior.
* **Tests**
  * Added integration and type/unit coverage for chunk operations, filtering, idempotency, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->