### PR TITLE
feat: timeBucket orderBy + limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,36 @@ Aggregate columns are checked against the model's scalar fields **at compile tim
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`, and
 [`first` / `last`](#earliest--latest-value-first--last).
 
+#### Ordering & limiting (`orderBy` / `limit`)
+
+By default rows come back ordered by the bucket ascending. Use `orderBy` + `limit` for the common
+"latest N buckets" and "top N buckets by value" shapes:
+
+```ts
+// latest 24 buckets, newest first
+await prisma.sensorReading.timeBucket({
+  bucket: "1 hour", range: { start, end },
+  aggregate: { avgTemp: { avg: "temperature" } },
+  orderBy: { bucket: "desc" },
+  limit: 24,
+});
+
+// the 10 buckets with the highest average — order by an aggregate, with a multi-key tiebreak
+await prisma.sensorReading.timeBucket({
+  bucket: "1 hour", range: { start, end },
+  groupBy: ["deviceId"],
+  aggregate: { avgTemp: { avg: "temperature" } },
+  orderBy: [{ avgTemp: "desc" }, { bucket: "asc" }],   // array = precedence
+  limit: 10,
+});
+```
+
+`orderBy` keys are **type-checked** to the orderable columns — `"bucket"`, a `groupBy` column, or an
+aggregate result name — so a typo or a bad direction fails to compile. A single object orders by one
+(or more) keys; an array gives explicit multi-key precedence. `limit` is a positive integer (SQL
+`LIMIT`), applied after ordering. Ordering composes with `gapfill` (e.g. `orderBy: { bucket: "desc" }`
+with `locf` still carries values forward correctly).
+
 #### Relation filters (`some` / `none` / `every` / `is` / `isNot`)
 
 Filter a hypertable by a **related** model's fields. The generator reads your schema's relations

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -105,6 +105,8 @@ export interface TimeBucketArgs<R, W = unknown> {
   origin?: Date;
   /** Shift bucket boundaries by this interval (TimescaleDB `time_bucket(..., offset => ...)`). */
   offset?: Interval;
+  /** Cap the number of returned rows (SQL `LIMIT`) — a positive integer, applied after `orderBy`. */
+  limit?: number;
 }
 
 type GroupByOf<A> = A extends { groupBy: ReadonlyArray<infer G> } ? G : never;
@@ -120,9 +122,32 @@ export type TimeBucketRow<R, A extends TimeBucketArgs<R, unknown>> = Prettify<
   }
 >;
 
+/** Sort direction for `orderBy`. */
+export type SortDir = "asc" | "desc";
+
+/** Keys a timeBucket result can be ordered by: the bucket, a selected groupBy column, or an
+ * aggregate result name (the output aliases). Derived from the args `A` so a typo fails to compile. */
+type TimeBucketOrderKey<R, A extends TimeBucketArgs<R, unknown>> =
+  | "bucket"
+  | Extract<GroupByOf<A>, keyof R>
+  | (keyof A["aggregate"] & string);
+
+/** `orderBy` spec: map orderable keys -> direction. A single object, or an array for multi-key
+ * precedence (Prisma-style). */
+export type TimeBucketOrderBy<R, A extends TimeBucketArgs<R, unknown>> =
+  | { readonly [K in TimeBucketOrderKey<R, A>]?: SortDir }
+  | ReadonlyArray<{ readonly [K in TimeBucketOrderKey<R, A>]?: SortDir }>;
+
 /** The generic call signature installed on every model as `.timeBucket(...)`. */
 export interface TimeBucketMethod {
-  <T, const A extends TimeBucketArgs<ScalarRow<T>, WhereInput<T>>>(
+  <
+    T,
+    const A extends TimeBucketArgs<ScalarRow<T>, WhereInput<T>> & {
+      /** Order the result rows; default is the bucket ascending. Map orderable keys -> `"asc"`/`"desc"`,
+       * or pass an array for multi-key precedence. Keys: `"bucket"`, a `groupBy` column, or an aggregate name. */
+      orderBy?: TimeBucketOrderBy<ScalarRow<T>, A>;
+    },
+  >(
     this: T,
     args: A,
   ): Promise<Array<TimeBucketRow<ScalarRow<T>, A>>>;
@@ -169,6 +194,8 @@ export interface TimeBucketRuntimeArgs {
   timezone?: string;
   origin?: Date;
   offset?: string;
+  orderBy?: Record<string, SortDir> | ReadonlyArray<Record<string, SortDir>>;
+  limit?: number;
 }
 
 // IANA timezone names: letters/digits and `_ + - /` (e.g. "Europe/Stockholm", "UTC", "Etc/GMT+5").
@@ -376,6 +403,34 @@ export function buildTimeBucketQuery(
   if (whereSql) where += ` AND (${whereSql})`;
 
   const groupBy = [`"bucket"`, ...groupCols.map((g) => quoteIdent(g))].join(", ");
-  const sql = `SELECT ${select.join(", ")} FROM ${qualifiedIdent(table, schema)} WHERE ${where} GROUP BY ${groupBy} ORDER BY "bucket"`;
+
+  // ORDER BY: default to the bucket ascending; otherwise the caller's spec over the output aliases
+  // (the bucket, a groupBy column, or an aggregate name). An array gives multi-key precedence.
+  const orderable = new Set<string>(["bucket", ...groupCols, ...aggregateEntries.map(([name]) => name)]);
+  const orderSpecs = args.orderBy === undefined ? [] : Array.isArray(args.orderBy) ? args.orderBy : [args.orderBy];
+  const orderTerms: string[] = [];
+  for (const spec of orderSpecs) {
+    for (const [key, dir] of Object.entries(spec)) {
+      if (dir === undefined) continue;
+      if (!orderable.has(key)) {
+        throw new Error(
+          `timeBucket: orderBy key ${JSON.stringify(key)} must be "bucket", a groupBy column, or an aggregate (one of: ${[...orderable].join(", ")}).`,
+        );
+      }
+      if (dir !== "asc" && dir !== "desc") {
+        throw new Error(`timeBucket: orderBy direction for ${JSON.stringify(key)} must be "asc" or "desc" (got ${JSON.stringify(dir)}).`);
+      }
+      orderTerms.push(`${quoteIdent(key)} ${dir === "desc" ? "DESC" : "ASC"}`);
+    }
+  }
+  const orderBy = orderTerms.length > 0 ? orderTerms.join(", ") : `"bucket"`;
+
+  let sql = `SELECT ${select.join(", ")} FROM ${qualifiedIdent(table, schema)} WHERE ${where} GROUP BY ${groupBy} ORDER BY ${orderBy}`;
+  if (args.limit !== undefined) {
+    if (!Number.isInteger(args.limit) || args.limit < 1) {
+      throw new Error(`timeBucket: limit must be a positive integer (got ${JSON.stringify(args.limit)}).`);
+    }
+    sql += ` LIMIT ${args.limit}`;
+  }
   return { sql, params };
 }

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -410,6 +410,10 @@ export function buildTimeBucketQuery(
   const orderSpecs = args.orderBy === undefined ? [] : Array.isArray(args.orderBy) ? args.orderBy : [args.orderBy];
   const orderTerms: string[] = [];
   for (const spec of orderSpecs) {
+    // Guard non-TS callers: a null / non-object entry would throw a raw TypeError in Object.entries.
+    if (spec === null || typeof spec !== "object") {
+      throw new Error(`timeBucket: each orderBy entry must be an object (got ${JSON.stringify(spec)}).`);
+    }
     for (const [key, dir] of Object.entries(spec)) {
       if (dir === undefined) continue;
       if (!orderable.has(key)) {

--- a/test/integration/order-limit.test.ts
+++ b/test/integration/order-limit.test.ts
@@ -1,0 +1,100 @@
+// timeBucket orderBy + limit, end-to-end on real TimescaleDB: order by the bucket (asc/desc) or by
+// an aggregate, and cap rows with limit — i.e. "latest N buckets" and "top N buckets by value".
+// Three hourly buckets with distinct averages make the ordering unambiguous.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED order-limit.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T03:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket orderBy + limit (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Bucket 00:00 -> avg 10; 01:00 -> avg 30 (highest); 02:00 -> avg 20.
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:30:00Z"), temperature: 10 },
+        { deviceId: 1, time: new Date("2026-06-15T01:30:00Z"), temperature: 30 },
+        { deviceId: 1, time: new Date("2026-06-15T02:30:00Z"), temperature: 20 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  const agg = { aggregate: { avgTemp: { avg: "temperature" } } } as const;
+
+  it("defaults to bucket ascending", async () => {
+    const rows = await prisma.sensorReading.timeBucket({ bucket: "1 hour", range, ...agg });
+    expect(rows.map((r: { avgTemp: number }) => r.avgTemp)).toEqual([10, 30, 20]);
+  });
+
+  it("orderBy bucket desc + limit returns the latest N buckets, newest first", async () => {
+    const rows = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      ...agg,
+      orderBy: { bucket: "desc" },
+      limit: 2,
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].avgTemp).toBe(20); // 02:00 bucket (latest)
+    expect(rows[1].avgTemp).toBe(30); // 01:00 bucket
+    expect(rows[0].bucket.getTime()).toBeGreaterThan(rows[1].bucket.getTime());
+  });
+
+  it("orderBy an aggregate desc + limit returns the top buckets by value", async () => {
+    const rows = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      ...agg,
+      orderBy: { avgTemp: "desc" },
+      limit: 1,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].avgTemp).toBe(30); // the 01:00 bucket has the highest average
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -1,7 +1,7 @@
 // Type-level tests for model.timeBucket (BUILD_PLAN M4 gate). Checked by
 // `npm run test:types` (tsc -p tsconfig.types.json). No runtime assertions here:
 // success == it type-checks, and each `@ts-expect-error` must actually error.
-import type { TimeBucketArgs, TimeBucketRow } from "../../src/client/timeBucket.js";
+import type { TimeBucketArgs, TimeBucketRow, TimeBucketOrderBy } from "../../src/client/timeBucket.js";
 
 // Exact type-equality assertion (dependency-free).
 type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
@@ -19,8 +19,10 @@ interface Where {
   label?: string;
 }
 
-// Mirrors the real method's generic signature, pinned to Row/Where.
-declare function timeBucket<const A extends TimeBucketArgs<Row, Where>>(args: A): Array<TimeBucketRow<Row, A>>;
+// Mirrors the real method's generic signature, pinned to Row/Where (incl. the orderBy intersection).
+declare function timeBucket<
+  const A extends TimeBucketArgs<Row, Where> & { orderBy?: TimeBucketOrderBy<Row, A> },
+>(args: A): Array<TimeBucketRow<Row, A>>;
 
 const start = new Date();
 const end = new Date();
@@ -225,6 +227,51 @@ timeBucket({
   bucket: "1 fortnight",
   range: { start, end },
   aggregate: { x: { avg: "temperature" } },
+});
+
+// --- orderBy / limit ---
+// order by the bucket, a groupBy column, or an aggregate; single object or array; + limit
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  groupBy: ["deviceId"],
+  aggregate: { avgTemp: { avg: "temperature" } },
+  orderBy: { bucket: "desc" },
+  limit: 10,
+});
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  groupBy: ["deviceId"],
+  aggregate: { avgTemp: { avg: "temperature" } },
+  orderBy: [{ deviceId: "asc" }, { avgTemp: "desc" }],
+});
+
+// invalid sort direction
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { avgTemp: { avg: "temperature" } },
+  // @ts-expect-error - direction must be "asc" | "desc"
+  orderBy: { bucket: "up" },
+});
+
+// orderBy a key that is neither the bucket, a groupBy column, nor an aggregate
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { avgTemp: { avg: "temperature" } },
+  // @ts-expect-error - "nope" is not an orderable key
+  orderBy: { nope: "asc" },
+});
+
+// limit must be a number
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { avgTemp: { avg: "temperature" } },
+  // @ts-expect-error - limit must be a number
+  limit: "10",
 });
 
 export {};

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -280,4 +280,49 @@ describe("buildTimeBucketQuery", () => {
       /must be a valid Date/,
     );
   });
+
+  it("defaults to ORDER BY bucket ascending with no LIMIT (unchanged)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", base);
+    expect(sql.endsWith(`ORDER BY "bucket"`)).toBe(true);
+    expect(sql).not.toContain("LIMIT");
+  });
+
+  it("orderBy a single key sets the direction over the output alias", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: { bucket: "desc" } });
+    expect(sql).toContain(`GROUP BY "bucket" ORDER BY "bucket" DESC`);
+  });
+
+  it("orderBy an aggregate + limit builds top-N (LIMIT inlined as an integer)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: { avgTemp: "desc" }, limit: 5 });
+    expect(sql).toContain(`ORDER BY "avgTemp" DESC LIMIT 5`);
+  });
+
+  it("orderBy a groupBy column and an array gives multi-key precedence", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      groupBy: ["deviceId"],
+      orderBy: [{ deviceId: "asc" }, { bucket: "desc" }],
+    });
+    expect(sql).toContain(`ORDER BY "deviceId" ASC, "bucket" DESC`);
+  });
+
+  it("limit alone keeps the default bucket ordering", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, limit: 10 });
+    expect(sql).toContain(`ORDER BY "bucket" LIMIT 10`);
+  });
+
+  it("rejects an unknown orderBy key, a bad direction, and a non-positive/non-integer limit", () => {
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: { nope: "asc" } })).toThrow(
+      /orderBy key "nope" must be/,
+    );
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: { bucket: "up" as never } }),
+    ).toThrow(/must be "asc" or "desc"/);
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, limit: 0 })).toThrow(
+      /limit must be a positive integer/,
+    );
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, limit: 2.5 })).toThrow(
+      /limit must be a positive integer/,
+    );
+  });
 });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -325,4 +325,10 @@ describe("buildTimeBucketQuery", () => {
       /limit must be a positive integer/,
     );
   });
+
+  it("rejects a malformed (non-object) orderBy entry with a structured error, not a raw TypeError", () => {
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: [null as never] })).toThrow(
+      /each orderBy entry must be an object/,
+    );
+  });
 });


### PR DESCRIPTION
## What

Adds result-shaping to the `timeBucket` query helper — the biggest ergonomic gap from the timeBucket-focused gap analysis (nearly every TigerData `time_bucket` example ends in `ORDER BY … LIMIT`).

```ts
// latest 24 buckets, newest first
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  aggregate: { avgTemp: { avg: "temperature" } },
  orderBy: { bucket: "desc" }, limit: 24,
});

// top 10 buckets by average (order by an aggregate, multi-key tiebreak)
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end }, groupBy: ["deviceId"],
  aggregate: { avgTemp: { avg: "temperature" } },
  orderBy: [{ avgTemp: "desc" }, { bucket: "asc" }], limit: 10,
});
```

- **`orderBy`** — order by the bucket, a `groupBy` column, or an aggregate result name (the output aliases). A single object or an array for multi-key precedence. Keys + direction are **type-checked** against the args via an F-bounded generic, so a typo'd key or a non-`"asc"`/`"desc"` direction fails to compile (verified with `@ts-expect-error`, incl. the unknown-key case).
- **`limit`** — cap rows (SQL `LIMIT`), a positive integer applied after ordering.

Default behavior is unchanged (`ORDER BY bucket` ascending, no `LIMIT`).

## Design notes (probe-verified on 2.27.2)

- Ordering by output aliases (bucket / groupBy / aggregate) works in Postgres — no expression repetition.
- **Composes with gapfill:** confirmed `locf` still carries values forward correctly under `ORDER BY bucket DESC` + `LIMIT` (the `locf` computation is independent of the final display ordering), so no special guards were needed.
- Runtime validates keys against the selected set with a clear error; `limit` is an inlined validated integer (injection-safe).

## Tests
- **Unit:** SQL for default / single-key / array / order-by-aggregate / limit, plus guards (unknown key, bad direction, non-positive/non-integer limit).
- **Type-level:** orderable-key + direction + numeric-`limit` constraints (incl. `@ts-expect-error` for an unknown key — the precise typing catches it).
- **Integration:** latest-N (`bucket` desc + limit), top-N by aggregate, and the unchanged default ascending order.

Local gates green: build, unit (227), test:types, attw 🟢, coverage (94.7/89.6/93.1/95.7), integration (43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added caller-defined result ordering for timebucket queries via `orderBy` (supports single or multi-key precedence).
  * Added optional row limiting via `limit`.
  * Default ordering is `bucket` ascending when no ordering is specified; ordering works with `gapfill`.

* **Documentation**
  * Updated runtime usage docs for `orderBy` (including aggregate/bucket ordering and multi-key examples) and `limit`.

* **Tests**
  * Added integration and type/unit coverage for ordering and limiting behavior and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->