### PR TITLE
feat: timeBucket stddev/variance, count(distinct), histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,25 @@ const rows = await prisma.sensorReading.timeBucket({
 
 Aggregate columns are checked against the model's scalar fields **at compile time**
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
-`groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`, and
+`groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`,
+`stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, and
 [`first` / `last`](#earliest--latest-value-first--last).
+
+```ts
+const rows = await prisma.sensorReading.timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: {
+    spread:  { stddev: "temperature" },                 // sample stddev (number); stddevPop / variance / varPop too
+    devices: { count: "deviceId", distinct: true },     // count(DISTINCT deviceId)
+    dist:    { histogram: "temperature", min: 0, max: 100, buckets: 10 }, // number[] of buckets+2 counts
+  },
+});
+```
+
+- `stddev` / `stddevPop` / `variance` / `varPop` are numeric like `avg` (default JS `number`; `as: "string"` for the exact decimal).
+- `count` takes `distinct: true` for `count(DISTINCT col)`.
+- `histogram` returns a **`number[]`** of `buckets + 2` counts — the first and last entries are the below-`min` / above-`max` overflow bins. It takes no `as` / `fill`.
 
 #### Ordering & limiting (`orderBy` / `limit`)
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -357,6 +357,7 @@ export function buildTimeBucketQuery(
     if (outputAs !== undefined && typeof outputAs !== "string") throw new Error(`timeBucket: as on "${resultName}" must be a string.`);
     if (fill !== undefined && typeof fill !== "string") throw new Error(`timeBucket: fill on "${resultName}" must be a string.`);
     if (by !== undefined && typeof by !== "string") throw new Error(`timeBucket: by on "${resultName}" must be a string.`);
+    if (distinct !== undefined && typeof distinct !== "boolean") throw new Error(`timeBucket: distinct on "${resultName}" must be a boolean.`);
     const alias = quoteIdent(resultName);
 
     // histogram is resolved by its key FIRST: its `min`/`max`/`buckets` params are siblings, and
@@ -367,6 +368,10 @@ export function buildTimeBucketQuery(
         throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct.`);
       }
       const { histogram: columnRaw, min, max, buckets } = rest;
+      const extra = Object.keys(rest).filter((k) => k !== "histogram" && k !== "min" && k !== "max" && k !== "buckets");
+      if (extra.length > 0) {
+        throw new Error(`timeBucket: histogram "${resultName}" has unexpected key(s): ${extra.join(", ")}.`);
+      }
       if (typeof columnRaw !== "string") throw new Error(`timeBucket: histogram "${resultName}" must map to a column name.`);
       if (typeof min !== "number" || !Number.isFinite(min)) throw new Error(`timeBucket: histogram "${resultName}" requires a finite numeric min.`);
       if (typeof max !== "number" || !Number.isFinite(max)) throw new Error(`timeBucket: histogram "${resultName}" requires a finite numeric max.`);
@@ -390,6 +395,10 @@ export function buildTimeBucketQuery(
       throw new Error(`timeBucket: aggregate "${resultName}" must map its function to a column name.`);
     }
     const src = quoteIdent(col(columnRaw));
+    // `distinct` applies only to count — reject it everywhere else up front (incl. first/last below).
+    if (distinct !== undefined && fn !== "count") {
+      throw new Error(`timeBucket: "distinct" is only valid on count (on "${resultName}").`);
+    }
 
     // first/last: the value of `column` ordered by `by` (default: the model's time column). They
     // return the value column's own type, so they take no `as`/`fill`.
@@ -401,9 +410,6 @@ export function buildTimeBucketQuery(
       continue;
     }
     if (by !== undefined) throw new Error(`timeBucket: "by" is only valid on first / last (on "${resultName}").`);
-    if (distinct !== undefined && fn !== "count") {
-      throw new Error(`timeBucket: "distinct" is only valid on count (on "${resultName}").`);
-    }
 
     const allowedAs = AGG_AS[fn];
     if (!allowedAs) {

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -56,9 +56,17 @@ export type AggregateOp<R> =
   | { avg: NumericColumn<R>; as?: AvgAs; fill?: Fill }
   | { min: NumericColumn<R>; fill?: Fill }
   | { max: NumericColumn<R>; fill?: Fill }
-  | { count: AnyColumn<R>; as?: CountAs; fill?: Fill }
+  | { count: AnyColumn<R>; distinct?: boolean; as?: CountAs; fill?: Fill }
+  // Sample (`stddev`/`variance`) and population (`stddevPop`/`varPop`) statistics; numeric, like `avg`.
+  | { stddev: NumericColumn<R>; as?: AvgAs; fill?: Fill }
+  | { stddevPop: NumericColumn<R>; as?: AvgAs; fill?: Fill }
+  | { variance: NumericColumn<R>; as?: AvgAs; fill?: Fill }
+  | { varPop: NumericColumn<R>; as?: AvgAs; fill?: Fill }
   | { first: AnyColumn<R>; by?: AnyColumn<R> }
-  | { last: AnyColumn<R>; by?: AnyColumn<R> };
+  | { last: AnyColumn<R>; by?: AnyColumn<R> }
+  // TimescaleDB `histogram(value, min, max, buckets)` -> a `number[]` of `buckets + 2` counts (the
+  // first/last are the below-min / above-max overflow bins). No `as` / `fill`.
+  | { histogram: NumericColumn<R>; min: number; max: number; buckets: number };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
@@ -70,13 +78,15 @@ export type AggOutput<R, Op> = Op extends { first: infer C extends keyof R }
   ? R[C]
   : Op extends { last: infer C extends keyof R }
     ? R[C]
-    : Op extends { fill: Fill }
-      ? number
-      : Op extends { as: "bigint" }
-        ? bigint
-        : Op extends { as: "string" }
-          ? string
-          : number;
+    : Op extends { histogram: unknown }
+      ? number[]
+      : Op extends { fill: Fill }
+        ? number
+        : Op extends { as: "bigint" }
+          ? bigint
+          : Op extends { as: "string" }
+            ? string
+            : number;
 
 /** Arguments to `timeBucket`. `R` is the model's scalar row, `W` its where input. */
 export interface TimeBucketArgs<R, W = unknown> {
@@ -165,7 +175,14 @@ const AGG_AS: Record<string, ReadonlySet<string>> = {
   min: new Set(["number"]),
   max: new Set(["number"]),
   count: new Set(["number", "bigint"]),
+  stddev: new Set(["number", "string"]),
+  stddevPop: new Set(["number", "string"]),
+  variance: new Set(["number", "string"]),
+  varPop: new Set(["number", "string"]),
 };
+
+/** Map an aggregate op key to its SQL function name (identity unless the JS name differs). */
+const SQL_FN: Record<string, string> = { stddevPop: "stddev_pop", varPop: "var_pop" };
 
 /**
  * SQL cast that controls the JS type Prisma returns for an aggregate — the cast IS the type
@@ -175,11 +192,15 @@ const AGG_AS: Record<string, ReadonlySet<string>> = {
  * (JS `number`, loses precision past 2^53), `min`/`max` -> native (already a number for the
  * numeric column types those accept). Callers are validated against AGG_AS first.
  */
+// SQL function names (post SQL_FN mapping) whose result we cast to double precision so Prisma
+// returns a JS number — incl. stddev/variance over integer columns, which are otherwise `numeric`.
+const DOUBLE_FNS = new Set(["sum", "avg", "stddev", "stddev_pop", "variance", "var_pop"]);
+
 function castFor(fn: string, outputAs: string | undefined): string {
   if (outputAs === "bigint") return "::bigint";
   if (outputAs === "string") return "::text";
   if (fn === "count") return "::int";
-  if (fn === "sum" || fn === "avg") return "::double precision";
+  if (DOUBLE_FNS.has(fn)) return "::double precision";
   return ""; // min/max keep the column type
 }
 
@@ -189,7 +210,9 @@ export interface TimeBucketRuntimeArgs {
   range: { start: Date; end: Date };
   where?: Record<string, unknown>;
   groupBy?: readonly string[];
-  aggregate: Record<string, Record<string, string>>;
+  // Values are mostly the column name (string), plus the optional selectors: `as`/`fill`/`by`
+  // (string), `distinct` (boolean), and histogram's `min`/`max`/`buckets` (number) — hence `unknown`.
+  aggregate: Record<string, Record<string, unknown>>;
   gapfill?: boolean;
   timezone?: string;
   origin?: Date;
@@ -264,16 +287,18 @@ function aggregateExpr(
   fill: string | undefined,
   gapfill: boolean,
   resultName: string,
+  distinct = false,
 ): string {
-  if (fill === undefined) return `${fn}(${src})${castFor(fn, outputAs)}`;
+  const arg = distinct ? `DISTINCT ${src}` : src; // count(DISTINCT col)
+  if (fill === undefined) return `${fn}(${arg})${castFor(fn, outputAs)}`;
   if (!gapfill) {
     throw new Error(`timeBucket: aggregate "${resultName}" sets fill: ${JSON.stringify(fill)} but requires gapfill: true.`);
   }
   if (outputAs !== undefined) {
     throw new Error(`timeBucket: aggregate "${resultName}" cannot combine fill with as — a filled value is a JS number.`);
   }
-  if (fill === "locf") return `locf(${fn}(${src})${castFor(fn, undefined)})`;
-  if (fill === "interpolate") return `interpolate(${fn}(${src})::double precision)`;
+  if (fill === "locf") return `locf(${fn}(${arg})${castFor(fn, undefined)})`;
+  if (fill === "interpolate") return `interpolate(${fn}(${arg})::double precision)`;
   throw new Error(`timeBucket: invalid fill ${JSON.stringify(fill)} on "${resultName}" (expected "locf" or "interpolate").`);
 }
 
@@ -326,13 +351,45 @@ export function buildTimeBucketQuery(
   }
   for (const [resultName, op] of aggregateEntries) {
     assertSafeIdent(resultName, "aggregate result column");
-    // Split the optional `as` / `fill` / `by` selectors from the single function entry ({ sum: "x", as: "bigint" }).
-    const { as: outputAs, fill, by, ...fnPart } = op;
-    const entry = Object.entries(fnPart)[0];
-    if (!entry) throw new Error(`timeBucket: aggregate "${resultName}" must specify a function.`);
-    const [fn, column] = entry;
-    const src = quoteIdent(col(column));
+    // Split the optional selectors (none of which are function names) from the function entry. The
+    // runtime view is loose (`unknown`), so narrow each before use — this also hardens non-TS callers.
+    const { as: outputAs, fill, by, distinct, ...rest } = op;
+    if (outputAs !== undefined && typeof outputAs !== "string") throw new Error(`timeBucket: as on "${resultName}" must be a string.`);
+    if (fill !== undefined && typeof fill !== "string") throw new Error(`timeBucket: fill on "${resultName}" must be a string.`);
+    if (by !== undefined && typeof by !== "string") throw new Error(`timeBucket: by on "${resultName}" must be a string.`);
     const alias = quoteIdent(resultName);
+
+    // histogram is resolved by its key FIRST: its `min`/`max`/`buckets` params are siblings, and
+    // `min`/`max` are themselves aggregate function names — detecting it up front avoids the clash.
+    // Result is a `number[]` of `buckets + 2` counts; no as / fill / by / distinct.
+    if ("histogram" in rest) {
+      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined) {
+        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct.`);
+      }
+      const { histogram: columnRaw, min, max, buckets } = rest;
+      if (typeof columnRaw !== "string") throw new Error(`timeBucket: histogram "${resultName}" must map to a column name.`);
+      if (typeof min !== "number" || !Number.isFinite(min)) throw new Error(`timeBucket: histogram "${resultName}" requires a finite numeric min.`);
+      if (typeof max !== "number" || !Number.isFinite(max)) throw new Error(`timeBucket: histogram "${resultName}" requires a finite numeric max.`);
+      if (typeof buckets !== "number" || !Number.isInteger(buckets) || buckets < 1) {
+        throw new Error(`timeBucket: histogram "${resultName}" buckets must be a positive integer.`);
+      }
+      if (min >= max) throw new Error(`timeBucket: histogram "${resultName}" requires min < max.`);
+      // min/max/buckets are validated numbers — safe to inline directly.
+      select.push(`histogram(${quoteIdent(col(columnRaw))}, ${min}, ${max}, ${buckets}) AS ${alias}`);
+      continue;
+    }
+
+    // Every other op maps exactly one function name to a column.
+    const fnKeys = Object.keys(rest);
+    if (fnKeys.length !== 1) {
+      throw new Error(`timeBucket: aggregate "${resultName}" must specify exactly one function.`);
+    }
+    const fn = fnKeys[0]!;
+    const columnRaw = rest[fn];
+    if (typeof columnRaw !== "string") {
+      throw new Error(`timeBucket: aggregate "${resultName}" must map its function to a column name.`);
+    }
+    const src = quoteIdent(col(columnRaw));
 
     // first/last: the value of `column` ordered by `by` (default: the model's time column). They
     // return the value column's own type, so they take no `as`/`fill`.
@@ -344,6 +401,9 @@ export function buildTimeBucketQuery(
       continue;
     }
     if (by !== undefined) throw new Error(`timeBucket: "by" is only valid on first / last (on "${resultName}").`);
+    if (distinct !== undefined && fn !== "count") {
+      throw new Error(`timeBucket: "distinct" is only valid on count (on "${resultName}").`);
+    }
 
     const allowedAs = AGG_AS[fn];
     if (!allowedAs) {
@@ -354,8 +414,9 @@ export function buildTimeBucketQuery(
         `timeBucket: as: ${JSON.stringify(outputAs)} is not valid for "${fn}" on "${resultName}" (allowed: ${[...allowedAs].join(", ")}).`,
       );
     }
-    // `aggregateExpr` applies `fill` (gapfill-only locf/interpolate) or the `as` cast.
-    select.push(`${aggregateExpr(fn, src, outputAs, fill, gapfill, resultName)} AS ${alias}`);
+    // Map to the SQL function name (stddevPop -> stddev_pop, …); aggregateExpr applies `fill`
+    // (gapfill-only locf/interpolate), the `as` cast, and DISTINCT for count.
+    select.push(`${aggregateExpr(SQL_FN[fn] ?? fn, src, outputAs, fill, gapfill, resultName, distinct === true)} AS ${alias}`);
   }
 
   // Relation-filter lookup (some/none/every/is/isNot -> EXISTS). Precompute every model's

--- a/test/integration/aggregates.test.ts
+++ b/test/integration/aggregates.test.ts
@@ -1,0 +1,102 @@
+// Standard aggregates in timeBucket, end-to-end on real TimescaleDB: stddev / variance (+ pop),
+// count(distinct), and histogram. Verifies both the computed values and the JS return shapes
+// (numbers for the stats, a real number[] for histogram) through @prisma/adapter-pg.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED aggregates.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket standard aggregates (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // One bucket: temps [10, 20, 30]; devices {1, 2} (2 distinct).
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:10:00Z"), temperature: 10 },
+        { deviceId: 2, time: new Date("2026-06-15T00:20:00Z"), temperature: 20 },
+        { deviceId: 2, time: new Date("2026-06-15T00:30:00Z"), temperature: 30 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("computes stddev / variance (+ pop) and count(distinct) as numbers", async () => {
+    const [row] = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: {
+        sd: { stddev: "temperature" },
+        v: { variance: "temperature" },
+        sdp: { stddevPop: "temperature" },
+        vp: { varPop: "temperature" },
+        devices: { count: "deviceId", distinct: true },
+        n: { count: "deviceId" },
+      },
+    });
+    // [10,20,30]: sample sd=10, sample var=100, pop var=200/3, pop sd=sqrt(200/3).
+    expect(row.sd).toBeCloseTo(10, 6);
+    expect(row.v).toBeCloseTo(100, 6);
+    expect(row.vp).toBeCloseTo(200 / 3, 6);
+    expect(row.sdp).toBeCloseTo(Math.sqrt(200 / 3), 6);
+    expect(typeof row.sd).toBe("number");
+    expect(row.devices).toBe(2); // distinct devices {1,2}
+    expect(row.n).toBe(3); // total rows
+  });
+
+  it("returns histogram as a JS number[] of buckets+2 counts", async () => {
+    const [row] = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: { h: { histogram: "temperature", min: 0, max: 60, buckets: 3 } },
+    });
+    // 3 buckets of width 20 over [0,60): 10->b0, 20->b1, 30->b1; plus below/above overflow bins.
+    expect(Array.isArray(row.h)).toBe(true);
+    expect(row.h).toEqual([0, 1, 2, 0, 0]);
+    expect(row.h.every((n: unknown) => typeof n === "number")).toBe(true);
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -229,6 +229,65 @@ timeBucket({
   aggregate: { x: { avg: "temperature" } },
 });
 
+// --- new aggregates: stddev/variance (+ pop), count distinct, histogram ---
+const stats = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: {
+    sd: { stddev: "temperature" }, // number
+    sdp: { stddevPop: "temperature" }, // number
+    v: { variance: "temperature" }, // number
+    vp: { varPop: "temperature" }, // number
+    sdExact: { stddev: "temperature", as: "string" }, // string
+    u: { count: "label", distinct: true }, // number
+    uBig: { count: "label", distinct: true, as: "bigint" }, // bigint
+    h: { histogram: "temperature", min: 0, max: 100, buckets: 5 }, // number[]
+  },
+});
+type _stats = Expect<
+  Equal<
+    (typeof stats)[number],
+    { bucket: Date; sd: number; sdp: number; v: number; vp: number; sdExact: string; u: number; uBig: bigint; h: number[] }
+  >
+>;
+
+// histogram is nullable under gapfill (like every aggregate)
+const hg = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  gapfill: true,
+  aggregate: { h: { histogram: "temperature", min: 0, max: 10, buckets: 4 } },
+});
+type _hg = Expect<Equal<(typeof hg)[number], { bucket: Date; h: number[] | null }>>;
+
+// NB: histogram + `as` and avg + `distinct` are excess properties on a union member, which TS
+// permits through const-generic inference — those combinations are rejected at runtime instead
+// (covered by the unit tests). Only type *mismatches* on known props are caught here.
+
+// histogram requires its numeric params
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - histogram requires min / max / buckets
+  aggregate: { h: { histogram: "temperature" } },
+});
+
+// stddev cannot be "bigint" (it is fractional, like avg)
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - stddev does not accept as: "bigint"
+  aggregate: { x: { stddev: "temperature", as: "bigint" } },
+});
+
+// stddev on a non-numeric column
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "label" is not a numeric column
+  aggregate: { x: { stddev: "label" } },
+});
+
 // --- orderBy / limit ---
 // order by the bucket, a groupBy column, or an aggregate; single object or array; + limit
 timeBucket({

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -331,4 +331,55 @@ describe("buildTimeBucketQuery", () => {
       /each orderBy entry must be an object/,
     );
   });
+
+  it("stddev / variance (+ pop variants) cast to double precision; as: string keeps the exact decimal", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: {
+        sd: { stddev: "temperature" },
+        sdp: { stddevPop: "temperature" },
+        v: { variance: "temperature" },
+        vp: { varPop: "temperature" },
+        exact: { stddev: "temperature", as: "string" },
+      },
+    });
+    expect(sql).toContain(`stddev("temperature")::double precision AS "sd"`);
+    expect(sql).toContain(`stddev_pop("temperature")::double precision AS "sdp"`);
+    expect(sql).toContain(`variance("temperature")::double precision AS "v"`);
+    expect(sql).toContain(`var_pop("temperature")::double precision AS "vp"`);
+    expect(sql).toContain(`stddev("temperature")::text AS "exact"`);
+  });
+
+  it("count distinct emits count(DISTINCT col)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { u: { count: "deviceId", distinct: true }, n: { count: "deviceId" } },
+    });
+    expect(sql).toContain(`count(DISTINCT "deviceId")::int AS "u"`);
+    expect(sql).toContain(`count("deviceId")::int AS "n"`);
+  });
+
+  it("histogram emits histogram(col, min, max, buckets) with inlined numeric params", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { h: { histogram: "temperature", min: 0, max: 100, buckets: 5 } },
+    });
+    expect(sql).toContain(`histogram("temperature", 0, 100, 5) AS "h"`);
+  });
+
+  it("rejects invalid stat / distinct / histogram combinations", () => {
+    const bad = (aggregate: Record<string, Record<string, unknown>>) =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate });
+    expect(() => bad({ h: { histogram: "temperature", min: 0, max: 1, buckets: 2, as: "string" } })).toThrow(
+      /"histogram" on "h" does not support as/,
+    );
+    expect(() => bad({ x: { avg: "temperature", distinct: true } })).toThrow(/"distinct" is only valid on count/);
+    expect(() => bad({ h: { histogram: "temperature", min: 0, max: 1, buckets: 0 } })).toThrow(
+      /buckets must be a positive integer/,
+    );
+    expect(() => bad({ h: { histogram: "temperature", min: 5, max: 5, buckets: 2 } })).toThrow(/requires min < max/);
+    // `min` is itself a function name, so a stray histogram param on another fn reads as two functions.
+    expect(() => bad({ x: { avg: "temperature", min: 0 } })).toThrow(/exactly one function/);
+    expect(() => bad({ x: { stddev: "temperature", as: "bigint" } })).toThrow(/is not valid for "stddev"/);
+  });
 });

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -381,5 +381,11 @@ describe("buildTimeBucketQuery", () => {
     // `min` is itself a function name, so a stray histogram param on another fn reads as two functions.
     expect(() => bad({ x: { avg: "temperature", min: 0 } })).toThrow(/exactly one function/);
     expect(() => bad({ x: { stddev: "temperature", as: "bigint" } })).toThrow(/is not valid for "stddev"/);
+    // a non-boolean distinct, distinct on a non-count, and an extra key in a histogram spec
+    expect(() => bad({ x: { count: "deviceId", distinct: "yes" } })).toThrow(/distinct on "x" must be a boolean/);
+    expect(() => bad({ x: { first: "temperature", distinct: true } })).toThrow(/"distinct" is only valid on count/);
+    expect(() => bad({ h: { histogram: "temperature", min: 0, max: 1, buckets: 2, sum: "temperature" } })).toThrow(
+      /unexpected key/,
+    );
   });
 });


### PR DESCRIPTION
## What

Extends the `timeBucket` aggregate set with standard SQL that needs no extension (next timeBucket gap from the focused analysis):

```ts
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  aggregate: {
    spread:  { stddev: "temperature" },                  // sample stddev (number)
    devices: { count: "deviceId", distinct: true },      // count(DISTINCT deviceId)
    dist:    { histogram: "temperature", min: 0, max: 100, buckets: 10 }, // number[]
  },
});
```

- **`stddev` / `stddevPop` / `variance` / `varPop`** — numeric like `avg` (default JS `number` via `::double precision` so integer-column stats don't return as `numeric` strings; `as: "string"` for the exact decimal). `stddevPop`/`varPop` → `stddev_pop`/`var_pop`.
- **`count` gains `distinct?: boolean`** → `count(DISTINCT col)` (unique users/devices per bucket).
- **`histogram(value, min, max, buckets)`** → a **`number[]`** of `buckets + 2` counts (first/last = below-`min` / above-`max` overflow bins); no `as`/`fill`.

## Design notes (probe-verified on 2.27.2)

- `histogram` is resolved **by its key before** the generic one-function path, because its `min`/`max` params share names with the `min`/`max` aggregate functions — detecting it up front avoids the clash (and a stray `min`/`max` on another fn reads as "more than one function").
- Result inference: stats → `number` (`string` under `as`), count-distinct → `number`/`bigint`, histogram → `number[]` (`number[]|null` under gapfill).
- Numeric params validated (finite `min < max`, positive-integer `buckets`) and inlined (injection-safe); runtime narrows the loose op and hardens non-TS callers.

## Tests
- **Unit:** SQL for every fn + casts + all guards.
- **Type-level:** result-row inference; numeric-column / `as`-mismatch / missing-`histogram`-param compile errors. (histogram-`as` and avg-`distinct` are *excess* props on a union member — TS permits them through const-generic inference, so they're enforced at runtime and unit-tested; noted in the type test.)
- **Integration:** computed `stddev`/`variance`/pop + `count(distinct)` as numbers, and `histogram` as a real `number[]` (`[0,1,2,0,0]`) through adapter-pg.

Local gates green: build, unit (232), test:types, attw 🟢, coverage (94.3/89.5/93.1/95.7), integration (45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for standard deviation and variance aggregates (sample and population variants)
  * Added support for `count(DISTINCT ...)` with `distinct` options
  * Added `histogram` aggregates with `min`/`max`/`buckets` and typed `number[]` results
* **Documentation**
  * Expanded README `timeBucket` `groupBy`/`aggregate` examples, including `stddev*`, `count` distinct behavior, and histogram output shape
* **Tests**
  * Added integration, type, and unit test coverage for new aggregates and validation rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->