### PR TITLE
feat: timeBucket percentile (Toolkit approx_percentile) + Toolkit-capable test image

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ const rows = await prisma.sensorReading.timeBucket({
 Aggregate columns are checked against the model's scalar fields **at compile time**
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`,
-`stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, and
+`stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, `percentile`, and
 [`first` / `last`](#earliest--latest-value-first--last).
 
 ```ts
@@ -245,6 +245,7 @@ const rows = await prisma.sensorReading.timeBucket({
     spread:  { stddev: "temperature" },                 // sample stddev (number); stddevPop / variance / varPop too
     devices: { count: "deviceId", distinct: true },     // count(DISTINCT deviceId)
     dist:    { histogram: "temperature", min: 0, max: 100, buckets: 10 }, // number[] of buckets+2 counts
+    p95:     { percentile: "temperature", p: 0.95 },    // approximate p95 (number)
   },
 });
 ```
@@ -252,6 +253,7 @@ const rows = await prisma.sensorReading.timeBucket({
 - `stddev` / `stddevPop` / `variance` / `varPop` are numeric like `avg` (default JS `number`; `as: "string"` for the exact decimal).
 - `count` takes `distinct: true` for `count(DISTINCT col)`.
 - `histogram` returns a **`number[]`** of `buckets + 2` counts — the first and last entries are the below-`min` / above-`max` overflow bins. It takes no `as` / `fill`.
+- `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via the TimescaleDB Toolkit `approx_percentile` / `percentile_agg`. **Requires the `timescaledb_toolkit` extension** (present on Tiger Cloud and the `timescale/timescaledb-ha` image; not in the slim `timescaledb` image).
 
 #### Ordering & limiting (`orderBy` / `limit`)
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -66,7 +66,10 @@ export type AggregateOp<R> =
   | { last: AnyColumn<R>; by?: AnyColumn<R> }
   // TimescaleDB `histogram(value, min, max, buckets)` -> a `number[]` of `buckets + 2` counts (the
   // first/last are the below-min / above-max overflow bins). No `as` / `fill`.
-  | { histogram: NumericColumn<R>; min: number; max: number; buckets: number };
+  | { histogram: NumericColumn<R>; min: number; max: number; buckets: number }
+  // Toolkit approximate percentile: `approx_percentile(p, percentile_agg(value))`. `p` is the
+  // fraction in [0, 1] (e.g. 0.95 for p95). Returns a number. Requires `timescaledb_toolkit`.
+  | { percentile: NumericColumn<R>; p: number };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
@@ -353,7 +356,9 @@ export function buildTimeBucketQuery(
     assertSafeIdent(resultName, "aggregate result column");
     // Split the optional selectors (none of which are function names) from the function entry. The
     // runtime view is loose (`unknown`), so narrow each before use — this also hardens non-TS callers.
-    const { as: outputAs, fill, by, distinct, ...rest } = op;
+    // `p` (percentile fraction) is pulled out like the others; `min`/`max`/`buckets` are NOT, because
+    // they collide with the min/max function names — histogram reads them from `rest` instead.
+    const { as: outputAs, fill, by, distinct, p, ...rest } = op;
     if (outputAs !== undefined && typeof outputAs !== "string") throw new Error(`timeBucket: as on "${resultName}" must be a string.`);
     if (fill !== undefined && typeof fill !== "string") throw new Error(`timeBucket: fill on "${resultName}" must be a string.`);
     if (by !== undefined && typeof by !== "string") throw new Error(`timeBucket: by on "${resultName}" must be a string.`);
@@ -364,8 +369,8 @@ export function buildTimeBucketQuery(
     // `min`/`max` are themselves aggregate function names — detecting it up front avoids the clash.
     // Result is a `number[]` of `buckets + 2` counts; no as / fill / by / distinct.
     if ("histogram" in rest) {
-      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined) {
-        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct.`);
+      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined || p !== undefined) {
+        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct / p.`);
       }
       const { histogram: columnRaw, min, max, buckets } = rest;
       const extra = Object.keys(rest).filter((k) => k !== "histogram" && k !== "min" && k !== "max" && k !== "buckets");
@@ -410,6 +415,20 @@ export function buildTimeBucketQuery(
       continue;
     }
     if (by !== undefined) throw new Error(`timeBucket: "by" is only valid on first / last (on "${resultName}").`);
+
+    // percentile: approx_percentile(p, percentile_agg(col)) — `p` is a fraction in [0, 1]. No as / fill.
+    if (fn === "percentile") {
+      if (outputAs !== undefined || fill !== undefined) {
+        throw new Error(`timeBucket: "percentile" on "${resultName}" does not support as / fill.`);
+      }
+      if (typeof p !== "number" || !Number.isFinite(p) || p < 0 || p > 1) {
+        throw new Error(`timeBucket: percentile "${resultName}" requires p as a number in [0, 1].`);
+      }
+      // p is a validated number — safe to inline directly.
+      select.push(`approx_percentile(${p}, percentile_agg(${src})) AS ${alias}`);
+      continue;
+    }
+    if (p !== undefined) throw new Error(`timeBucket: "p" is only valid on percentile (on "${resultName}").`);
 
     const allowedAs = AGG_AS[fn];
     if (!allowedAs) {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -13,8 +13,10 @@ import { GenericContainer, type StartedTestContainer } from "testcontainers";
 export const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const PRISMA_BIN = join(REPO_ROOT, "node_modules", ".bin", "prisma");
 const GENERATOR_PROVIDER = join(REPO_ROOT, "dist", "generator", "index.js");
-// Pinned to an immutable version tag for reproducible CI (not `latest-pg17`).
-const IMAGE = "timescale/timescaledb:2.27.2-pg17";
+// Pinned to an immutable version tag for reproducible CI (not a rolling tag). The `-ha` image
+// carries the same TimescaleDB 2.27.2 PLUS the `timescaledb_toolkit` extension (hyperfunctions),
+// which the slim `timescaledb` image lacks — needed for the percentile / hyperfunction tests.
+const IMAGE = "timescale/timescaledb-ha:pg17.10-ts2.27.2";
 
 // Prisma 7 blocks destructive commands from AI agents without explicit consent; the user
 // granted it for this build (their message: "yes"). Required so reset runs unattended.

--- a/test/integration/percentile.test.ts
+++ b/test/integration/percentile.test.ts
@@ -1,0 +1,87 @@
+// Approximate percentiles in timeBucket, end-to-end on real TimescaleDB (Toolkit hyperfunctions):
+// { percentile: col, p } -> approx_percentile(p, percentile_agg(col)). Requires the
+// timescaledb_toolkit extension, which the test harness's `-ha` image provides. Values 1..100 in one
+// bucket make p50/p95 predictable (approximate, so asserted within a tolerance).
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED percentile.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket approximate percentiles (real TimescaleDB Toolkit)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // 100 readings (temperatures 1..100) within a single daily bucket.
+    await prisma.sensorReading.createMany({
+      data: Array.from({ length: 100 }, (_, i) => ({
+        deviceId: 1,
+        time: new Date(range.start.getTime() + i * 60_000),
+        temperature: i + 1,
+      })),
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("computes approximate p50 / p95 as numbers", async () => {
+    const [row] = await prisma.sensorReading.timeBucket({
+      bucket: "1 day",
+      range,
+      aggregate: {
+        p50: { percentile: "temperature", p: 0.5 },
+        p95: { percentile: "temperature", p: 0.95 },
+      },
+    });
+    expect(typeof row.p50).toBe("number");
+    expect(typeof row.p95).toBe("number");
+    // Approximate (uddsketch): p50 ~ 50, p95 ~ 95 over 1..100. Generous tolerance for the sketch.
+    expect(row.p50).toBeGreaterThan(45);
+    expect(row.p50).toBeLessThan(56);
+    expect(row.p95).toBeGreaterThan(90);
+    expect(row.p95).toBeLessThan(99);
+    expect(row.p95).toBeGreaterThan(row.p50);
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -260,6 +260,30 @@ const hg = timeBucket({
 });
 type _hg = Expect<Equal<(typeof hg)[number], { bucket: Date; h: number[] | null }>>;
 
+// percentile -> number; `p` is required and the column must be numeric
+const pct = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { p95: { percentile: "temperature", p: 0.95 } },
+});
+type _pct = Expect<Equal<(typeof pct)[number], { bucket: Date; p95: number }>>;
+
+// percentile requires `p`
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - percentile requires `p`
+  aggregate: { x: { percentile: "temperature" } },
+});
+
+// percentile on a non-numeric column
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "label" is not a numeric column
+  aggregate: { x: { percentile: "label", p: 0.5 } },
+});
+
 // NB: histogram + `as` and avg + `distinct` are excess properties on a union member, which TS
 // permits through const-generic inference — those combinations are rejected at runtime instead
 // (covered by the unit tests). Only type *mismatches* on known props are caught here.

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -388,4 +388,24 @@ describe("buildTimeBucketQuery", () => {
       /unexpected key/,
     );
   });
+
+  it("percentile emits approx_percentile(p, percentile_agg(col))", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { p95: { percentile: "temperature", p: 0.95 } },
+    });
+    expect(sql).toContain(`approx_percentile(0.95, percentile_agg("temperature")) AS "p95"`);
+  });
+
+  it("rejects a bad/missing percentile p, p on a non-percentile, and as/fill on percentile", () => {
+    const bad = (aggregate: Record<string, Record<string, unknown>>) =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate });
+    expect(() => bad({ x: { percentile: "temperature", p: 1.5 } })).toThrow(/p as a number in \[0, 1\]/);
+    expect(() => bad({ x: { percentile: "temperature" } })).toThrow(/p as a number in \[0, 1\]/); // missing p
+    expect(() => bad({ x: { avg: "temperature", p: 0.5 } })).toThrow(/"p" is only valid on percentile/);
+    expect(() => bad({ x: { percentile: "temperature", p: 0.5, as: "string" } })).toThrow(/does not support as/);
+    expect(() => bad({ h: { histogram: "temperature", min: 0, max: 1, buckets: 2, p: 0.5 } })).toThrow(
+      /does not support as \/ fill \/ by \/ distinct \/ p/,
+    );
+  });
 });


### PR DESCRIPTION
## What

The first **TimescaleDB Toolkit hyperfunction** exposed through `timeBucket` — approximate percentiles, the flagship time-series analytic (p95/p99):

```ts
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  aggregate: {
    p95: { percentile: "latency", p: 0.95 },   // approx_percentile(0.95, percentile_agg(latency))
    p50: { percentile: "latency", p: 0.5 },
  },
});
```

- `{ percentile: col, p }` → `approx_percentile(p, percentile_agg(col))`. `p` is the fraction in `[0, 1]`; result is a `number` (`number|null` under gapfill). No `as`/`fill`.
- `p` validated in `[0,1]` and inlined (it's a number — injection-safe); rejected on non-percentile ops, and percentile rejects `as`/`fill`.

## Test harness → Toolkit-capable image

Toolkit is a separate extension **absent from the slim `timescaledb` image**, so the Testcontainers harness now uses **`timescale/timescaledb-ha:pg17.10-ts2.27.2`** — the *same* TimescaleDB **2.27.2** plus `timescaledb_toolkit` **1.23.0** (and pgvector/pgvectorscale, for any future vector work).

- Verified the **entire existing integration suite (19 files) passes unchanged** on `-ha` — it's a clean superset, so no per-test image override was needed.
- ⚠️ **CI note:** the integration job now pulls the larger `-ha` image (~1.5 GB vs ~0.4 GB), so that job will be somewhat slower. Net pull is still lower than running two images (slim + `-ha`).

## Tests
- **Unit:** SQL output + `p` / `as` / `fill` / applicability guards.
- **Type-level:** `percentile` → `number`, `p` required, numeric-column check.
- **Integration:** approximate p50/p95 over values 1..100 against the real Toolkit (on `-ha`).

Local gates green: build, unit (234), test:types, attw 🟢, coverage (94.5/89.8/93.2/95.8), full integration (20 files / 46 tests) on the `-ha` image.

Follow-ups (other hyperfunctions) once this lands: `counter_agg` (rate/delta), `time_weight`, `candlestick` (OHLC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `percentile` aggregate function to `timeBucket` for approximate percentile calculations with parameter `p` in [0, 1].

* **Documentation**
  * Updated documentation with `percentile` aggregate examples and extension requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->