### PR TITLE
feat: timeBucket counter_agg (rate/delta) + time-weighted average

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ const rows = await prisma.sensorReading.timeBucket({
 - `count` takes `distinct: true` for `count(DISTINCT col)`.
 - `histogram` returns a **`number[]`** of `buckets + 2` counts — the first and last entries are the below-`min` / above-`max` overflow bins. It takes no `as` / `fill`.
 
-**Toolkit hyperfunctions** (`percentile`, `rate`, `delta`, `timeWeightedAverage`) all return a `number` and **require the `timescaledb_toolkit` extension** — present on Tiger Cloud and the `timescale/timescaledb-ha` image, but **not** in the slim `timescaledb` image.
+**Toolkit hyperfunctions** (`percentile`, `rate`, `delta`, `timeWeightedAverage`) all return a `number`, take no `as` / `fill`, and **require the `timescaledb_toolkit` extension** — present on Tiger Cloud and the `timescale/timescaledb-ha` image, but **not** in the slim `timescaledb` image.
 
 - `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via `approx_percentile` / `percentile_agg`.
 - `rate` (per-second) and `delta` (total change) wrap `counter_agg` for **monotonic counters** — both are **reset-aware** (a counter that resets to a lower value is handled correctly).

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ const rows = await prisma.sensorReading.timeBucket({
 Aggregate columns are checked against the model's scalar fields **at compile time**
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`,
-`stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, `percentile`, and
-[`first` / `last`](#earliest--latest-value-first--last).
+`stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, `percentile`, `rate`, `delta`,
+`timeWeightedAverage`, and [`first` / `last`](#earliest--latest-value-first--last).
 
 ```ts
 const rows = await prisma.sensorReading.timeBucket({
@@ -246,6 +246,8 @@ const rows = await prisma.sensorReading.timeBucket({
     devices: { count: "deviceId", distinct: true },     // count(DISTINCT deviceId)
     dist:    { histogram: "temperature", min: 0, max: 100, buckets: 10 }, // number[] of buckets+2 counts
     p95:     { percentile: "temperature", p: 0.95 },    // approximate p95 (number)
+    reqRate: { rate: "requestsTotal" },                 // per-second rate of a reset-aware counter
+    twAvg:   { timeWeightedAverage: "temperature" },    // time-weighted average (LOCF; or method: "linear")
   },
 });
 ```
@@ -253,7 +255,12 @@ const rows = await prisma.sensorReading.timeBucket({
 - `stddev` / `stddevPop` / `variance` / `varPop` are numeric like `avg` (default JS `number`; `as: "string"` for the exact decimal).
 - `count` takes `distinct: true` for `count(DISTINCT col)`.
 - `histogram` returns a **`number[]`** of `buckets + 2` counts — the first and last entries are the below-`min` / above-`max` overflow bins. It takes no `as` / `fill`.
-- `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via the TimescaleDB Toolkit `approx_percentile` / `percentile_agg`. **Requires the `timescaledb_toolkit` extension** (present on Tiger Cloud and the `timescale/timescaledb-ha` image; not in the slim `timescaledb` image).
+
+**Toolkit hyperfunctions** (`percentile`, `rate`, `delta`, `timeWeightedAverage`) all return a `number` and **require the `timescaledb_toolkit` extension** — present on Tiger Cloud and the `timescale/timescaledb-ha` image, but **not** in the slim `timescaledb` image.
+
+- `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via `approx_percentile` / `percentile_agg`.
+- `rate` (per-second) and `delta` (total change) wrap `counter_agg` for **monotonic counters** — both are **reset-aware** (a counter that resets to a lower value is handled correctly).
+- `timeWeightedAverage` is `average(time_weight(...))` — a [time-weighted average](https://docs.tigerdata.com/) that weights each value by how long it held, ideal for irregularly-sampled gauges. `method` is `"locf"` (default) or `"linear"`.
 
 #### Ordering & limiting (`orderBy` / `limit`)
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -69,7 +69,14 @@ export type AggregateOp<R> =
   | { histogram: NumericColumn<R>; min: number; max: number; buckets: number }
   // Toolkit approximate percentile: `approx_percentile(p, percentile_agg(value))`. `p` is the
   // fraction in [0, 1] (e.g. 0.95 for p95). Returns a number. Requires `timescaledb_toolkit`.
-  | { percentile: NumericColumn<R>; p: number };
+  | { percentile: NumericColumn<R>; p: number }
+  // Toolkit counter_agg accessors for a monotonically-increasing counter `column` (reset-aware):
+  // `rate` (per-second) and `delta` (total change) over each bucket. Require `timescaledb_toolkit`.
+  | { rate: NumericColumn<R> }
+  | { delta: NumericColumn<R> }
+  // Toolkit time-weighted average: `average(time_weight(method, time, value))`. `method` weights
+  // gaps by last-observation-carried-forward (`"locf"`, default) or `"linear"` interpolation.
+  | { timeWeightedAverage: NumericColumn<R>; method?: "locf" | "linear" };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
@@ -356,21 +363,23 @@ export function buildTimeBucketQuery(
     assertSafeIdent(resultName, "aggregate result column");
     // Split the optional selectors (none of which are function names) from the function entry. The
     // runtime view is loose (`unknown`), so narrow each before use — this also hardens non-TS callers.
-    // `p` (percentile fraction) is pulled out like the others; `min`/`max`/`buckets` are NOT, because
-    // they collide with the min/max function names — histogram reads them from `rest` instead.
-    const { as: outputAs, fill, by, distinct, p, ...rest } = op;
+    // `p` (percentile fraction) and `method` (time-weight) are pulled out like the others; `min`/`max`/
+    // `buckets` are NOT, because they collide with the min/max function names — histogram reads them
+    // from `rest` instead.
+    const { as: outputAs, fill, by, distinct, p, method, ...rest } = op;
     if (outputAs !== undefined && typeof outputAs !== "string") throw new Error(`timeBucket: as on "${resultName}" must be a string.`);
     if (fill !== undefined && typeof fill !== "string") throw new Error(`timeBucket: fill on "${resultName}" must be a string.`);
     if (by !== undefined && typeof by !== "string") throw new Error(`timeBucket: by on "${resultName}" must be a string.`);
     if (distinct !== undefined && typeof distinct !== "boolean") throw new Error(`timeBucket: distinct on "${resultName}" must be a boolean.`);
+    if (method !== undefined && typeof method !== "string") throw new Error(`timeBucket: method on "${resultName}" must be a string.`);
     const alias = quoteIdent(resultName);
 
     // histogram is resolved by its key FIRST: its `min`/`max`/`buckets` params are siblings, and
     // `min`/`max` are themselves aggregate function names — detecting it up front avoids the clash.
     // Result is a `number[]` of `buckets + 2` counts; no as / fill / by / distinct.
     if ("histogram" in rest) {
-      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined || p !== undefined) {
-        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct / p.`);
+      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined || p !== undefined || method !== undefined) {
+        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct / p / method.`);
       }
       const { histogram: columnRaw, min, max, buckets } = rest;
       const extra = Object.keys(rest).filter((k) => k !== "histogram" && k !== "min" && k !== "max" && k !== "buckets");
@@ -400,9 +409,15 @@ export function buildTimeBucketQuery(
       throw new Error(`timeBucket: aggregate "${resultName}" must map its function to a column name.`);
     }
     const src = quoteIdent(col(columnRaw));
-    // `distinct` applies only to count — reject it everywhere else up front (incl. first/last below).
+    // Each optional selector belongs to exactly one function family — reject misuse up front.
     if (distinct !== undefined && fn !== "count") {
       throw new Error(`timeBucket: "distinct" is only valid on count (on "${resultName}").`);
+    }
+    if (p !== undefined && fn !== "percentile") {
+      throw new Error(`timeBucket: "p" is only valid on percentile (on "${resultName}").`);
+    }
+    if (method !== undefined && fn !== "timeWeightedAverage") {
+      throw new Error(`timeBucket: "method" is only valid on timeWeightedAverage (on "${resultName}").`);
     }
 
     // first/last: the value of `column` ordered by `by` (default: the model's time column). They
@@ -416,11 +431,10 @@ export function buildTimeBucketQuery(
     }
     if (by !== undefined) throw new Error(`timeBucket: "by" is only valid on first / last (on "${resultName}").`);
 
-    // percentile: approx_percentile(p, percentile_agg(col)) — `p` is a fraction in [0, 1]. No as / fill.
+    // Toolkit hyperfunctions (require timescaledb_toolkit). Each takes the time column and returns a
+    // number; none take as / fill. `time` is already the quoted time column.
     if (fn === "percentile") {
-      if (outputAs !== undefined || fill !== undefined) {
-        throw new Error(`timeBucket: "percentile" on "${resultName}" does not support as / fill.`);
-      }
+      if (outputAs !== undefined || fill !== undefined) throw new Error(`timeBucket: "percentile" on "${resultName}" does not support as / fill.`);
       if (typeof p !== "number" || !Number.isFinite(p) || p < 0 || p > 1) {
         throw new Error(`timeBucket: percentile "${resultName}" requires p as a number in [0, 1].`);
       }
@@ -428,7 +442,19 @@ export function buildTimeBucketQuery(
       select.push(`approx_percentile(${p}, percentile_agg(${src})) AS ${alias}`);
       continue;
     }
-    if (p !== undefined) throw new Error(`timeBucket: "p" is only valid on percentile (on "${resultName}").`);
+    if (fn === "rate" || fn === "delta") {
+      if (outputAs !== undefined || fill !== undefined) throw new Error(`timeBucket: "${fn}" on "${resultName}" does not support as / fill.`);
+      // counter_agg is reset-aware; rate is per-second, delta is the total change over the bucket.
+      select.push(`${fn}(counter_agg(${time}, ${src})) AS ${alias}`);
+      continue;
+    }
+    if (fn === "timeWeightedAverage") {
+      if (outputAs !== undefined || fill !== undefined) throw new Error(`timeBucket: "timeWeightedAverage" on "${resultName}" does not support as / fill.`);
+      const weight = method === undefined || method === "locf" ? "LOCF" : method === "linear" ? "Linear" : undefined;
+      if (weight === undefined) throw new Error(`timeBucket: timeWeightedAverage "${resultName}" method must be "locf" or "linear".`);
+      select.push(`average(time_weight(${quoteLiteral(weight)}, ${time}, ${src})) AS ${alias}`);
+      continue;
+    }
 
     const allowedAs = AGG_AS[fn];
     if (!allowedAs) {

--- a/test/integration/counter-timeweight.test.ts
+++ b/test/integration/counter-timeweight.test.ts
@@ -81,10 +81,11 @@ describe.skipIf(!DOCKER_OK)("timeBucket counter_agg + time_weight (real Timescal
     expect(typeof row.totalDelta).toBe("number");
     expect(typeof row.twAvg).toBe("number");
     // Reset-aware total change over the bucket (a naive last-minus-first would be ~50).
-    expect(row.totalDelta).toBeCloseTo(350, 1);
-    expect(row.ratePerSec).toBeGreaterThan(0);
-    // Time-weighted average of values spanning 50..300.
-    expect(row.twAvg).toBeGreaterThan(100);
-    expect(row.twAvg).toBeLessThan(250);
+    expect(row.totalDelta).toBeCloseTo(350, 5);
+    // rate = delta / observed span. First..last point span = 00:00..00:59 = 3540s.
+    expect(row.ratePerSec).toBeCloseTo(350 / 3540, 3);
+    // Time-weighted (LOCF) average is 164.4 — distinct from the simple mean of these values (160),
+    // so this specifically validates the time-weighting (not just "some number in range").
+    expect(row.twAvg).toBeCloseTo(164.4, 0);
   });
 });

--- a/test/integration/counter-timeweight.test.ts
+++ b/test/integration/counter-timeweight.test.ts
@@ -1,0 +1,90 @@
+// Toolkit counter_agg (rate / delta) and time-weighted average in timeBucket, end-to-end on real
+// TimescaleDB (the `-ha` image carries timescaledb_toolkit). A counter that RESETS mid-bucket proves
+// reset-awareness: a naive last-first delta would be ~50, but reset-aware delta is 350.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED counter-timeweight.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+
+  @@id([deviceId, time])
+  @@index([deviceId, time])
+}`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket counter_agg + time_weight (real TimescaleDB Toolkit)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // A counter: 100, 200, 300, then RESET to 50, 150 — all within one hour.
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:00:00Z"), temperature: 100 },
+        { deviceId: 1, time: new Date("2026-06-15T00:15:00Z"), temperature: 200 },
+        { deviceId: 1, time: new Date("2026-06-15T00:30:00Z"), temperature: 300 },
+        { deviceId: 1, time: new Date("2026-06-15T00:45:00Z"), temperature: 50 },
+        { deviceId: 1, time: new Date("2026-06-15T00:59:00Z"), temperature: 150 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("computes reset-aware rate / delta and a time-weighted average as numbers", async () => {
+    const [row] = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: {
+        ratePerSec: { rate: "temperature" },
+        totalDelta: { delta: "temperature" },
+        twAvg: { timeWeightedAverage: "temperature" },
+      },
+    });
+    expect(typeof row.ratePerSec).toBe("number");
+    expect(typeof row.totalDelta).toBe("number");
+    expect(typeof row.twAvg).toBe("number");
+    // Reset-aware total change over the bucket (a naive last-minus-first would be ~50).
+    expect(row.totalDelta).toBeCloseTo(350, 1);
+    expect(row.ratePerSec).toBeGreaterThan(0);
+    // Time-weighted average of values spanning 50..300.
+    expect(row.twAvg).toBeGreaterThan(100);
+    expect(row.twAvg).toBeLessThan(250);
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -284,6 +284,34 @@ timeBucket({
   aggregate: { x: { percentile: "label", p: 0.5 } },
 });
 
+// counter_agg (rate / delta) + time-weighted average -> number
+const ctr = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: {
+    reqRate: { rate: "temperature" },
+    reqDelta: { delta: "temperature" },
+    twa: { timeWeightedAverage: "temperature", method: "linear" },
+  },
+});
+type _ctr = Expect<Equal<(typeof ctr)[number], { bucket: Date; reqRate: number; reqDelta: number; twa: number }>>;
+
+// method must be a known literal
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - method must be "locf" | "linear"
+  aggregate: { x: { timeWeightedAverage: "temperature", method: "ewma" } },
+});
+
+// rate on a non-numeric column
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - "label" is not a numeric column
+  aggregate: { x: { rate: "label" } },
+});
+
 // NB: histogram + `as` and avg + `distinct` are excess properties on a union member, which TS
 // permits through const-generic inference — those combinations are rejected at runtime instead
 // (covered by the unit tests). Only type *mismatches* on known props are caught here.

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -408,4 +408,39 @@ describe("buildTimeBucketQuery", () => {
       /does not support as \/ fill \/ by \/ distinct \/ p/,
     );
   });
+
+  it("counter rate / delta wrap counter_agg over the time column", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { r: { rate: "temperature" }, d: { delta: "temperature" } },
+    });
+    expect(sql).toContain(`rate(counter_agg("time", "temperature")) AS "r"`);
+    expect(sql).toContain(`delta(counter_agg("time", "temperature")) AS "d"`);
+  });
+
+  it("timeWeightedAverage wraps average(time_weight(method, time, col)); default LOCF, linear opt-in", () => {
+    const def = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { twa: { timeWeightedAverage: "temperature" } },
+    });
+    expect(def.sql).toContain(`average(time_weight('LOCF', "time", "temperature")) AS "twa"`);
+    const lin = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { twa: { timeWeightedAverage: "temperature", method: "linear" } },
+    });
+    expect(lin.sql).toContain(`average(time_weight('Linear', "time", "temperature")) AS "twa"`);
+  });
+
+  it("rejects a bad method, and method / p / as on the wrong function", () => {
+    const bad = (aggregate: Record<string, Record<string, unknown>>) =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate });
+    expect(() => bad({ x: { timeWeightedAverage: "temperature", method: "ewma" } })).toThrow(
+      /method must be "locf" or "linear"/,
+    );
+    expect(() => bad({ x: { avg: "temperature", method: "locf" } })).toThrow(
+      /"method" is only valid on timeWeightedAverage/,
+    );
+    expect(() => bad({ x: { rate: "temperature", p: 0.5 } })).toThrow(/"p" is only valid on percentile/);
+    expect(() => bad({ x: { rate: "temperature", as: "string" } })).toThrow(/"rate" on "x" does not support as/);
+  });
 });


### PR DESCRIPTION
## What

Two more TimescaleDB Toolkit hyperfunctions in `timeBucket` (the harness is already on the Toolkit-capable `-ha` image):

```ts
await prisma.sensorReading.timeBucket({
  bucket: "1 hour", range: { start, end },
  aggregate: {
    reqRate:   { rate: "requestsTotal" },                       // per-second rate of a reset-aware counter
    reqDelta:  { delta: "requestsTotal" },                      // total change over the bucket
    twAvg:     { timeWeightedAverage: "temperature" },          // LOCF (default) or method: "linear"
  },
});
```

- **`rate` / `delta`** wrap `counter_agg(time, col)` for **monotonic counters** — both **reset-aware** (a counter dropping to a lower value is handled). `rate` is per-second, `delta` is total change.
- **`timeWeightedAverage`** is `average(time_weight(method, time, col))` — weights each value by how long it held; `method` is `"locf"` (default) or `"linear"`. Ideal for irregularly-sampled gauges.

All take the model's time column, return a `number` (`number|null` under gapfill), and take no `as`/`fill`.

## Design notes (probe-verified on 2.27.2 + Toolkit 1.23.0)

- Work on **both `timestamptz` and plain `timestamp`** columns: these calcs are difference/interval-based, so the implicit `timestamp → timestamptz` cast is tz-safe (no cast or caveat needed).
- Selector applicability is now checked **globally** (`distinct`→count, `p`→percentile, `method`→timeWeightedAverage), so a stray param on *any* function errors instead of being silently ignored — also hardens non-TS callers.
- **candlestick (OHLC)** is deferred to a follow-up — it takes two input columns (price + volume) and five accessors, warranting its own design.

## Tests
- **Unit:** SQL (`rate`/`delta`/`time_weight` + LOCF/Linear method), applicability + guard rejections.
- **Type-level:** `rate`/`delta`/`timeWeightedAverage` → `number`, `method` literal, numeric-column checks.
- **Integration (on `-ha`):** reset-aware `delta` = 350 (a naive last−first would be ~50), `rate > 0`, time-weighted average — against the real Toolkit.

Local gates green: build, unit (42 timeBucket / full suite), test:types, attw 🟢, coverage (94.4/90.0/93.2/95.8), full integration (21 files / 47 tests) on `-ha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `timeWeightedAverage` aggregate with selectable `locf` (default) or `linear` interpolation.
  * Enhanced counter-style analytics with reset-aware `rate` and `delta`.
  * Improved validation so method/parameters apply only to the appropriate aggregate.
  * Toolkit hyperfunctions are supported via the TimescaleDB Toolkit extension.

* **Documentation**
  * Updated `timeBucket` docs and examples with `reqRate` and `twAvg`, plus clearer behavior notes.

* **Tests**
  * Added integration, type, and unit coverage for the new aggregates and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->