### PR TITLE
feat: timeBucket candlestick (OHLC + vwap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Aggregate columns are checked against the model's scalar fields **at compile tim
 (avg/sum/min/max require numeric columns), and the result row type is inferred from
 `groupBy` + `aggregate`. Supported functions: `avg`, `sum`, `min`, `max`, `count`,
 `stddev`, `stddevPop`, `variance`, `varPop`, `histogram`, `percentile`, `rate`, `delta`,
-`timeWeightedAverage`, and [`first` / `last`](#earliest--latest-value-first--last).
+`timeWeightedAverage`, `candlestick`, and [`first` / `last`](#earliest--latest-value-first--last).
 
 ```ts
 const rows = await prisma.sensorReading.timeBucket({
@@ -248,6 +248,7 @@ const rows = await prisma.sensorReading.timeBucket({
     p95:     { percentile: "temperature", p: 0.95 },    // approximate p95 (number)
     reqRate: { rate: "requestsTotal" },                 // per-second rate of a reset-aware counter
     twAvg:   { timeWeightedAverage: "temperature" },    // time-weighted average (LOCF; or method: "linear")
+    candle:  { candlestick: "price", volume: "volume" },// -> { open, high, low, close, vwap } object
   },
 });
 ```
@@ -256,11 +257,12 @@ const rows = await prisma.sensorReading.timeBucket({
 - `count` takes `distinct: true` for `count(DISTINCT col)`.
 - `histogram` returns a **`number[]`** of `buckets + 2` counts — the first and last entries are the below-`min` / above-`max` overflow bins. It takes no `as` / `fill`.
 
-**Toolkit hyperfunctions** (`percentile`, `rate`, `delta`, `timeWeightedAverage`) all return a `number`, take no `as` / `fill`, and **require the `timescaledb_toolkit` extension** — present on Tiger Cloud and the `timescale/timescaledb-ha` image, but **not** in the slim `timescaledb` image.
+**Toolkit hyperfunctions** (`percentile`, `rate`, `delta`, `timeWeightedAverage`, `candlestick`) take no `as` / `fill` and **require the `timescaledb_toolkit` extension** — present on Tiger Cloud and the `timescale/timescaledb-ha` image, but **not** in the slim `timescaledb` image.
 
 - `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via `approx_percentile` / `percentile_agg`.
 - `rate` (per-second) and `delta` (total change) wrap `counter_agg` for **monotonic counters** — both are **reset-aware** (a counter that resets to a lower value is handled correctly).
-- `timeWeightedAverage` is `average(time_weight(...))` — a [time-weighted average](https://docs.tigerdata.com/) that weights each value by how long it held, ideal for irregularly-sampled gauges. `method` is `"locf"` (default) or `"linear"`.
+- `timeWeightedAverage` is `average(time_weight(...))` — a time-weighted average that weights each value by how long it held, ideal for irregularly-sampled gauges. `method` is `"locf"` (default) or `"linear"`.
+- `candlestick` (`candlestick_agg`) returns an **object** `{ open, high, low, close, vwap }` per bucket — takes a price (`candlestick`) and a `volume` column. Not combinable with `gapfill`. (`percentile`/`rate`/`delta`/`timeWeightedAverage` return a `number`.)
 
 #### Ordering & limiting (`orderBy` / `limit`)
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ const rows = await prisma.sensorReading.timeBucket({
     p95:     { percentile: "temperature", p: 0.95 },    // approximate p95 (number)
     reqRate: { rate: "requestsTotal" },                 // per-second rate of a reset-aware counter
     twAvg:   { timeWeightedAverage: "temperature" },    // time-weighted average (LOCF; or method: "linear")
-    candle:  { candlestick: "price", volume: "volume" },// -> { open, high, low, close, vwap } object
   },
 });
 ```
@@ -262,7 +261,17 @@ const rows = await prisma.sensorReading.timeBucket({
 - `percentile` is an **approximate** percentile (`p` is the fraction in `[0, 1]`, e.g. `0.95` for p95), via `approx_percentile` / `percentile_agg`.
 - `rate` (per-second) and `delta` (total change) wrap `counter_agg` for **monotonic counters** — both are **reset-aware** (a counter that resets to a lower value is handled correctly).
 - `timeWeightedAverage` is `average(time_weight(...))` — a time-weighted average that weights each value by how long it held, ideal for irregularly-sampled gauges. `method` is `"locf"` (default) or `"linear"`.
-- `candlestick` (`candlestick_agg`) returns an **object** `{ open, high, low, close, vwap }` per bucket — takes a price (`candlestick`) and a `volume` column. Not combinable with `gapfill`. (`percentile`/`rate`/`delta`/`timeWeightedAverage` return a `number`.)
+- `candlestick` (`candlestick_agg`) returns an **object** `{ open, high, low, close, vwap }` per bucket — takes a price (`candlestick`) and a `volume` column (so it suits a model that has both). Not combinable with `gapfill`. (`percentile`/`rate`/`delta`/`timeWeightedAverage` return a `number`.)
+
+```ts
+// on a Trade model with `time`, `price`, and `volume` columns:
+const candles = await prisma.trade.timeBucket({
+  bucket: "1 day",
+  range: { start, end },
+  aggregate: { ohlc: { candlestick: "price", volume: "volume" } },
+});
+// candles[i].ohlc -> { open, high, low, close, vwap }
+```
 
 #### Ordering & limiting (`orderBy` / `limit`)
 

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -76,7 +76,10 @@ export type AggregateOp<R> =
   | { delta: NumericColumn<R> }
   // Toolkit time-weighted average: `average(time_weight(method, time, value))`. `method` weights
   // gaps by last-observation-carried-forward (`"locf"`, default) or `"linear"` interpolation.
-  | { timeWeightedAverage: NumericColumn<R>; method?: "locf" | "linear" };
+  | { timeWeightedAverage: NumericColumn<R>; method?: "locf" | "linear" }
+  // Toolkit `candlestick_agg(time, price, volume)` -> OHLC + vwap as one object per bucket. Needs a
+  // price (`candlestick`) and a `volume` column. No as / fill, and not combinable with gapfill.
+  | { candlestick: NumericColumn<R>; volume: NumericColumn<R> };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
@@ -90,7 +93,9 @@ export type AggOutput<R, Op> = Op extends { first: infer C extends keyof R }
     ? R[C]
     : Op extends { histogram: unknown }
       ? number[]
-      : Op extends { fill: Fill }
+      : Op extends { candlestick: unknown }
+        ? { open: number; high: number; low: number; close: number; vwap: number }
+        : Op extends { fill: Fill }
         ? number
         : Op extends { as: "bigint" }
           ? bigint
@@ -366,20 +371,21 @@ export function buildTimeBucketQuery(
     // `p` (percentile fraction) and `method` (time-weight) are pulled out like the others; `min`/`max`/
     // `buckets` are NOT, because they collide with the min/max function names — histogram reads them
     // from `rest` instead.
-    const { as: outputAs, fill, by, distinct, p, method, ...rest } = op;
+    const { as: outputAs, fill, by, distinct, p, method, volume, ...rest } = op;
     if (outputAs !== undefined && typeof outputAs !== "string") throw new Error(`timeBucket: as on "${resultName}" must be a string.`);
     if (fill !== undefined && typeof fill !== "string") throw new Error(`timeBucket: fill on "${resultName}" must be a string.`);
     if (by !== undefined && typeof by !== "string") throw new Error(`timeBucket: by on "${resultName}" must be a string.`);
     if (distinct !== undefined && typeof distinct !== "boolean") throw new Error(`timeBucket: distinct on "${resultName}" must be a boolean.`);
     if (method !== undefined && typeof method !== "string") throw new Error(`timeBucket: method on "${resultName}" must be a string.`);
+    if (volume !== undefined && typeof volume !== "string") throw new Error(`timeBucket: volume on "${resultName}" must be a string.`);
     const alias = quoteIdent(resultName);
 
     // histogram is resolved by its key FIRST: its `min`/`max`/`buckets` params are siblings, and
     // `min`/`max` are themselves aggregate function names — detecting it up front avoids the clash.
     // Result is a `number[]` of `buckets + 2` counts; no as / fill / by / distinct.
     if ("histogram" in rest) {
-      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined || p !== undefined || method !== undefined) {
-        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct / p / method.`);
+      if (outputAs !== undefined || fill !== undefined || by !== undefined || distinct !== undefined || p !== undefined || method !== undefined || volume !== undefined) {
+        throw new Error(`timeBucket: "histogram" on "${resultName}" does not support as / fill / by / distinct / p / method / volume.`);
       }
       const { histogram: columnRaw, min, max, buckets } = rest;
       const extra = Object.keys(rest).filter((k) => k !== "histogram" && k !== "min" && k !== "max" && k !== "buckets");
@@ -419,6 +425,9 @@ export function buildTimeBucketQuery(
     if (method !== undefined && fn !== "timeWeightedAverage") {
       throw new Error(`timeBucket: "method" is only valid on timeWeightedAverage (on "${resultName}").`);
     }
+    if (volume !== undefined && fn !== "candlestick") {
+      throw new Error(`timeBucket: "volume" is only valid on candlestick (on "${resultName}").`);
+    }
 
     // first/last: the value of `column` ordered by `by` (default: the model's time column). They
     // return the value column's own type, so they take no `as`/`fill`.
@@ -453,6 +462,18 @@ export function buildTimeBucketQuery(
       const weight = method === undefined || method === "locf" ? "LOCF" : method === "linear" ? "Linear" : undefined;
       if (weight === undefined) throw new Error(`timeBucket: timeWeightedAverage "${resultName}" method must be "locf" or "linear".`);
       select.push(`average(time_weight(${quoteLiteral(weight)}, ${time}, ${src})) AS ${alias}`);
+      continue;
+    }
+    if (fn === "candlestick") {
+      if (outputAs !== undefined || fill !== undefined) throw new Error(`timeBucket: "candlestick" on "${resultName}" does not support as / fill.`);
+      if (gapfill) throw new Error(`timeBucket: "candlestick" on "${resultName}" cannot be combined with gapfill.`);
+      if (typeof volume !== "string") throw new Error(`timeBucket: candlestick "${resultName}" requires a volume column.`);
+      // candlestick_agg is repeated per accessor but Postgres computes it once (common subexpression);
+      // jsonb_build_object returns OHLC + vwap as one JS object column. `src` is the price column.
+      const cs = `candlestick_agg(${time}, ${src}, ${quoteIdent(col(volume))})`;
+      select.push(
+        `jsonb_build_object('open', open(${cs}), 'high', high(${cs}), 'low', low(${cs}), 'close', close(${cs}), 'vwap', vwap(${cs})) AS ${alias}`,
+      );
       continue;
     }
 

--- a/test/integration/candlestick.test.ts
+++ b/test/integration/candlestick.test.ts
@@ -1,0 +1,93 @@
+// Toolkit candlestick_agg in timeBucket, end-to-end on real TimescaleDB (the `-ha` image carries
+// timescaledb_toolkit). One op returns an OHLC + vwap JS object per bucket (jsonb_build_object over
+// candlestick_agg(time, price, volume)). Three trades make the values predictable.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED candlestick.test.ts: Docker is not available. Not verified.\n");
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Trade {
+  time   DateTime
+  symbol Int
+  price  Float
+  volume Float
+
+  @@id([symbol, time])
+  @@index([symbol, time])
+}`;
+
+const INIT_SQL = `-- CreateTable
+CREATE TABLE "Trade" (
+    "time" TIMESTAMP(3) NOT NULL,
+    "symbol" INTEGER NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "volume" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "Trade_pkey" PRIMARY KEY ("symbol","time")
+);
+
+-- CreateIndex
+CREATE INDEX "Trade_symbol_time_idx" ON "Trade"("symbol", "time");
+`;
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket candlestick / OHLC (real TimescaleDB Toolkit)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Three trades within one hour: prices 10 → 20 → 5, volumes 100 / 200 / 50.
+    await prisma.trade.createMany({
+      data: [
+        { symbol: 1, time: new Date("2026-06-15T00:00:00Z"), price: 10, volume: 100 },
+        { symbol: 1, time: new Date("2026-06-15T00:30:00Z"), price: 20, volume: 200 },
+        { symbol: 1, time: new Date("2026-06-15T00:45:00Z"), price: 5, volume: 50 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("returns an OHLC + vwap object per bucket", async () => {
+    const [row] = await prisma.trade.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: { candle: { candlestick: "price", volume: "volume" } },
+    });
+    // open = first (10), high = 20, low = 5, close = last (5),
+    // vwap = (10*100 + 20*200 + 5*50) / (100+200+50) = 5250/350 = 15.
+    expect(row.candle).toEqual({ open: 10, high: 20, low: 5, close: 5, vwap: 15 });
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -312,6 +312,27 @@ timeBucket({
   aggregate: { x: { rate: "label" } },
 });
 
+// candlestick -> an OHLC + vwap object
+const cs = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { candle: { candlestick: "temperature", volume: "temperature" } },
+});
+type _cs = Expect<
+  Equal<
+    (typeof cs)[number],
+    { bucket: Date; candle: { open: number; high: number; low: number; close: number; vwap: number } }
+  >
+>;
+
+// candlestick requires a volume column
+timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  // @ts-expect-error - candlestick requires `volume`
+  aggregate: { c: { candlestick: "temperature" } },
+});
+
 // NB: histogram + `as` and avg + `distinct` are excess properties on a union member, which TS
 // permits through const-generic inference — those combinations are rejected at runtime instead
 // (covered by the unit tests). Only type *mismatches* on known props are caught here.

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -443,4 +443,30 @@ describe("buildTimeBucketQuery", () => {
     expect(() => bad({ x: { rate: "temperature", p: 0.5 } })).toThrow(/"p" is only valid on percentile/);
     expect(() => bad({ x: { rate: "temperature", as: "string" } })).toThrow(/"rate" on "x" does not support as/);
   });
+
+  it("candlestick emits jsonb_build_object over a single candlestick_agg(time, price, volume)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { c: { candlestick: "price", volume: "vol" } },
+    });
+    expect(sql).toContain(`jsonb_build_object('open', open(candlestick_agg("time", "price", "vol"))`);
+    expect(sql).toContain(`'close', close(candlestick_agg("time", "price", "vol"))`);
+    expect(sql).toContain(`'vwap', vwap(candlestick_agg("time", "price", "vol"))) AS "c"`);
+  });
+
+  it("rejects candlestick without volume, with gapfill, and volume on a non-candlestick", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { c: { candlestick: "price" } } }),
+    ).toThrow(/candlestick "c" requires a volume column/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        gapfill: true,
+        aggregate: { c: { candlestick: "price", volume: "vol" } },
+      }),
+    ).toThrow(/cannot be combined with gapfill/);
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { avg: "temperature", volume: "vol" } } }),
+    ).toThrow(/"volume" is only valid on candlestick/);
+  });
 });


### PR DESCRIPTION
## What

The final Toolkit hyperfunction — **candlestick / OHLC** — returned as a single object per bucket:

```ts
await prisma.trade.timeBucket({
  bucket: "1 hour", range: { start, end },
  aggregate: { candle: { candlestick: "price", volume: "volume" } },
});
// row.candle -> { open, high, low, close, vwap }
```

`{ candlestick: priceCol, volume: volumeCol }` → `candlestick_agg(time, price, volume)`, exposed via **one JS object** `{ open, high, low, close, vwap }`.

## Design notes (probe-verified on 2.27.2 + Toolkit 1.23.0)

- Emitted as **`jsonb_build_object`** over the five accessors, so the DB returns the object directly — **no runtime post-processing** (jsonb → JS object via adapter-pg, confirmed in the integration test).
- The repeated `candlestick_agg(...)` is a **common subexpression Postgres computes once** (EXPLAIN shows a single aggregate), so the 5 accessors cost one aggregation.
- Result-type inference yields the object shape `{ open: number; high: number; low: number; close: number; vwap: number }`.
- Needs a price + a `volume` column; takes no `as`/`fill`; **rejected with `gapfill`** (it would produce an object with null fields rather than a null). `volume` is validated and rejected on any non-candlestick op (global applicability check, alongside `distinct`/`p`/`method`).

## Tests
- **Unit:** `jsonb_build_object` SQL; guards for missing volume, `gapfill`, and `volume` on the wrong function.
- **Type-level:** `candlestick` → OHLC object; `volume` required.
- **Integration (on `-ha`):** prices 10/20/5, volumes 100/200/50 → `{open:10, high:20, low:5, close:5, vwap:15}` — confirming the jsonb object round-trips to a JS object.

Local gates green: build, unit (44 timeBucket / full suite), test:types, attw 🟢, coverage (94.3/89.8/94.0/95.8), full integration (23 files / 49 tests) on `-ha`.

This completes the Toolkit hyperfunction set (percentile, rate/delta, time-weighted average, candlestick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `candlestick` as a new `timeBucket` aggregate operator, returning `open`, `high`, `low`, `close`, and `vwap`.
  * Requires a `volume` input and is incompatible with `gapfill`.

* **Documentation**
  * Updated `timeBucket` documentation to include `candlestick`, its expected inputs, return shape, and example usage.

* **Tests**
  * Added integration, type-level, and unit test coverage validating `candlestick` behavior and option constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->