### PR TITLE
chore: exercise cagg down-migration + tidy refresh quoting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,10 @@ zero errors. This must be covered by an integration test (`test/integration/`).
 - Language: TypeScript, `strict: true`, `module`/`moduleResolution`: `NodeNext`.
 - Single package with internal modules `src/core`, `src/generator`, `src/client`.
   (Not a monorepo.)
-- `@prisma/client` and `prisma` are **peerDependencies** (`>=6.13`), pinned in
-  devDependencies for testing. Bundle nothing from Prisma.
+- `@prisma/client` and `prisma` are **peerDependencies** (`>=7.0.0`), pinned in
+  devDependencies for testing. Bundle nothing from Prisma. (Prisma 7+ only: the documented
+  setup uses a url-less `datasource` block with the URL supplied from `prisma.config.ts`;
+  Prisma 6 rejects that at schema validation with P1012 — verified by a CI probe.)
 - Dual ESM + CJS publish via `tsup`. Validate output with `@arethetypeswrong/cli`.
 - All DB-touching tests use **Testcontainers** with a TimescaleDB image. There is no way
   to test this against a mock; if Docker is unavailable, skip and say so loudly.

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -458,8 +458,10 @@ export function makeManage<HModels extends string = string, CModels extends stri
         params.push(value);
         return `$${params.length}`;
       };
-      const target = qualifiedIdent(ref.name, ref.schema);
-      const sql = `CALL refresh_continuous_aggregate('${target}', ${bound(range?.start)}, ${bound(range?.end)})`;
+      // Route through relationLiteral (like every other $timescale call site) so the
+      // single-quote escaping lives in one place (sql.ts) rather than a hand-built literal.
+      const rel = relationLiteral(ref.name, ref.schema);
+      const sql = `CALL refresh_continuous_aggregate(${rel}, ${bound(range?.start)}, ${bound(range?.end)})`;
       // Retry only on a concurrent policy refresh (55P03), with bounded exponential backoff.
       // Any other error — or exhausting the attempt budget — propagates unchanged.
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/test/integration/down-migrations.test.ts
+++ b/test/integration/down-migrations.test.ts
@@ -59,10 +59,11 @@ describe.skipIf(!DOCKER_OK)("down-migrations (constraint 4: DROP MATERIALIZED VI
 
   it("rejects plain DROP VIEW on a continuous aggregate (the reason constraint 4 exists)", async () => {
     expect(await caggCount(h)).toBe(1);
-    // `IF EXISTS` only suppresses "does not exist" — it does NOT suppress the wrong-object-kind
-    // error, so DROP VIEW still fails on a cagg. This is precisely why `down` can't use DROP VIEW.
+    // TimescaleDB itself blocks DROP VIEW on a cagg ("cannot drop continuous aggregate using
+    // DROP VIEW"), and IF EXISTS does not suppress that — which is exactly why the generated
+    // `down` must use DROP MATERIALIZED VIEW.
     await expect(h.query('DROP VIEW IF EXISTS "SensorHourly"')).rejects.toThrow(
-      /materialized view|not a view/i,
+      /continuous aggregate|materialized view|not a view/i,
     );
     expect(await caggCount(h)).toBe(1); // the rejected drop changed nothing
   });

--- a/test/integration/down-migrations.test.ts
+++ b/test/integration/down-migrations.test.ts
@@ -1,0 +1,82 @@
+// Constraint 4 (CLAUDE.md): a continuous aggregate shows up in the views catalog, but plain
+// `DROP VIEW` errors on it — down-migrations MUST use `DROP MATERIALIZED VIEW`. Because
+// `migrate reset` only replays UP migrations, the generated `down` SQL is otherwise never
+// executed against a real database (it's only asserted as a string snapshot in unit tests).
+// This proves it end to end: `DROP VIEW` is rejected, the generated `DROP MATERIALIZED VIEW`
+// drops the cagg cleanly, and re-running it is an idempotent no-op (constraint 3).
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { createContinuousAggregateSql } from "../../src/core/index.js";
+import type { CaggConfig } from "../../src/core/types.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED: Docker is not available. Down-migration (constraint 4) is NOT verified.\n",
+  );
+}
+
+// Mirrors the harness DEFAULT_MODELS `SensorHourly` cagg. Only `name`/`schema` drive the
+// `down` SQL, but the builder validates the whole config, so it must be well-formed.
+const SENSOR_HOURLY: CaggConfig = {
+  name: "SensorHourly",
+  source: "SensorReading",
+  bucket: "1 hour",
+  timeColumn: "time",
+  bucketColumn: "bucket",
+  aggregates: [{ name: "avgTemp", fn: "avg", column: "temperature" }],
+  groupBy: [{ source: "deviceId", output: "deviceId" }],
+};
+
+async function caggCount(h: Harness): Promise<number> {
+  const [row] = await h.query<{ n: number }>(
+    "SELECT count(*)::int AS n FROM timescaledb_information.continuous_aggregates WHERE view_name = 'SensorHourly'",
+  );
+  return row?.n ?? 0;
+}
+
+describe.skipIf(!DOCKER_OK)("down-migrations (constraint 4: DROP MATERIALIZED VIEW)", () => {
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await startHarness();
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+  });
+
+  afterAll(async () => {
+    await h?.stop();
+  });
+
+  it("rejects plain DROP VIEW on a continuous aggregate (the reason constraint 4 exists)", async () => {
+    expect(await caggCount(h)).toBe(1);
+    // `IF EXISTS` only suppresses "does not exist" — it does NOT suppress the wrong-object-kind
+    // error, so DROP VIEW still fails on a cagg. This is precisely why `down` can't use DROP VIEW.
+    await expect(h.query('DROP VIEW IF EXISTS "SensorHourly"')).rejects.toThrow(
+      /materialized view|not a view/i,
+    );
+    expect(await caggCount(h)).toBe(1); // the rejected drop changed nothing
+  });
+
+  it("drops the cagg with the generated DROP MATERIALIZED VIEW down SQL, idempotently", async () => {
+    const { down } = createContinuousAggregateSql(SENSOR_HOURLY);
+    expect(down).toMatch(/DROP MATERIALIZED VIEW IF EXISTS/);
+    expect(await caggCount(h)).toBe(1);
+
+    await h.query(down);
+    expect(await caggCount(h)).toBe(0);
+
+    // `IF EXISTS` makes a replay / second down-run a no-op rather than an error (constraint 3).
+    await expect(h.query(down)).resolves.toBeDefined();
+    expect(await caggCount(h)).toBe(0);
+  });
+});


### PR DESCRIPTION
Hardening from the post-0.7.0 self-audit. No user-facing behavior change.

## Changes
- **Down-migration integration test** (`test/integration/down-migrations.test.ts`). `migrate reset` only replays *up* migrations, so the generated `DROP MATERIALIZED VIEW` down SQL — constraint 4, the explicit reason this package exists — was only ever asserted as a string snapshot, never executed. This test creates the cagg, proves plain `DROP VIEW` is rejected, runs the generated down SQL against real TimescaleDB, and confirms the cagg drops cleanly and idempotently.
- **`refreshContinuousAggregate` quoting** ([manage.ts](src/client/manage.ts)) — route through `relationLiteral()` like every other `$timescale` call site instead of hand-building `'${qualifiedIdent(...)}'`. It was the single call site that bypassed `sql.ts`'s single-quote escaping. Not exploitable (`assertSafeIdent` blocks quotes); this is a consistency/robustness fix with no behavior change for safe identifiers.
- **`CLAUDE.md` peerDep note** — corrected the stale `>=6.13` to `>=7.0.0` (matches `package.json`) and recorded *why* the package is Prisma 7+ only.

## Prisma 6
A CI probe (separate `ci/prisma6-probe` branch) pinned Prisma 6 and ran the reset-safety suite: it fails at `prisma generate` with **P1012 — "Argument `url` is missing in data source block `db`"**. Prisma 6 still requires `url` in the `datasource` block; Prisma 7 is what allows omitting it and sourcing the URL from `prisma.config.ts` — the setup this package documents. So Prisma 6 is fundamentally incompatible, and `>=7.0.0` is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated minimum required Prisma peer dependency version to **>=7.0.0** (previously **>=6.13**), with added details on the documented Prisma configuration.
* **Bug Fixes**
  * Improved continuous aggregate refresh SQL generation to use the correct relation qualification, aligning with other timescale call sites.
* **Tests**
  * Added/extended an integration test to verify continuous aggregate down-migrations use **`DROP MATERIALIZED VIEW`** (not `DROP VIEW`), are rejected on kind mismatch, and behave idempotently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->