### PR TITLE
feat(timeBucket): stats_agg 1-D statistical summary op

### DIFF
--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -79,7 +79,12 @@ export type AggregateOp<R> =
   | { timeWeightedAverage: NumericColumn<R>; method?: "locf" | "linear" }
   // Toolkit `candlestick_agg(time, price, volume)` -> OHLC + vwap as one object per bucket. Needs a
   // price (`candlestick`) and a `volume` column. No as / fill, and not combinable with gapfill.
-  | { candlestick: NumericColumn<R>; volume: NumericColumn<R> };
+  | { candlestick: NumericColumn<R>; volume: NumericColumn<R> }
+  // Toolkit `stats_agg(value)` -> a 1-D statistical summary as one object per bucket:
+  // average / sum / numVals / stddev / variance / skewness / kurtosis. `stddev` & `variance` are
+  // POPULATION (the Toolkit default) — i.e. like the `stddevPop`/`varPop` ops, not the sample
+  // `stddev`/`variance` ops. No as / fill, not combinable with gapfill. Requires `timescaledb_toolkit`.
+  | { stats: NumericColumn<R> };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
 export type AggregateInput<R> = Record<string, AggregateOp<R>>;
@@ -95,6 +100,8 @@ export type AggOutput<R, Op> = Op extends { first: infer C extends keyof R }
       ? number[]
       : Op extends { candlestick: unknown }
         ? { open: number; high: number; low: number; close: number; vwap: number }
+        : Op extends { stats: unknown }
+          ? { average: number; sum: number; numVals: number; stddev: number; variance: number; skewness: number; kurtosis: number }
         : Op extends { fill: Fill }
         ? number
         : Op extends { as: "bigint" }
@@ -473,6 +480,18 @@ export function buildTimeBucketQuery(
       const cs = `candlestick_agg(${time}, ${src}, ${quoteIdent(col(volume))})`;
       select.push(
         `jsonb_build_object('open', open(${cs}), 'high', high(${cs}), 'low', low(${cs}), 'close', close(${cs}), 'vwap', vwap(${cs})) AS ${alias}`,
+      );
+      continue;
+    }
+    if (fn === "stats") {
+      if (outputAs !== undefined || fill !== undefined) throw new Error(`timeBucket: "stats" on "${resultName}" does not support as / fill.`);
+      if (gapfill) throw new Error(`timeBucket: "stats" on "${resultName}" cannot be combined with gapfill.`);
+      // stats_agg(value) is repeated per accessor but Postgres computes it once (common
+      // subexpression); jsonb_build_object returns the 1-D summary as one JS object. stddev /
+      // variance are POPULATION (Toolkit default), matching the stddevPop / varPop ops.
+      const sa = `stats_agg(${src})`;
+      select.push(
+        `jsonb_build_object('average', average(${sa}), 'sum', sum(${sa}), 'numVals', num_vals(${sa}), 'stddev', stddev(${sa}), 'variance', variance(${sa}), 'skewness', skewness(${sa}), 'kurtosis', kurtosis(${sa})) AS ${alias}`,
       );
       continue;
     }

--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -82,8 +82,8 @@ export type AggregateOp<R> =
   | { candlestick: NumericColumn<R>; volume: NumericColumn<R> }
   // Toolkit `stats_agg(value)` -> a 1-D statistical summary as one object per bucket:
   // average / sum / numVals / stddev / variance / skewness / kurtosis. `stddev` & `variance` are
-  // POPULATION (the Toolkit default) — i.e. like the `stddevPop`/`varPop` ops, not the sample
-  // `stddev`/`variance` ops. No as / fill, not combinable with gapfill. Requires `timescaledb_toolkit`.
+  // SAMPLE (the Toolkit default), matching the package's sample `stddev`/`variance` ops. No as /
+  // fill, not combinable with gapfill. Requires `timescaledb_toolkit`.
   | { stats: NumericColumn<R> };
 
 /** The `aggregate` spec: result-column name -> aggregate operation. */
@@ -488,7 +488,7 @@ export function buildTimeBucketQuery(
       if (gapfill) throw new Error(`timeBucket: "stats" on "${resultName}" cannot be combined with gapfill.`);
       // stats_agg(value) is repeated per accessor but Postgres computes it once (common
       // subexpression); jsonb_build_object returns the 1-D summary as one JS object. stddev /
-      // variance are POPULATION (Toolkit default), matching the stddevPop / varPop ops.
+      // variance are SAMPLE (Toolkit default), matching the package's sample stddev / variance ops.
       const sa = `stats_agg(${src})`;
       select.push(
         `jsonb_build_object('average', average(${sa}), 'sum', sum(${sa}), 'numVals', num_vals(${sa}), 'stddev', stddev(${sa}), 'variance', variance(${sa}), 'skewness', skewness(${sa}), 'kurtosis', kurtosis(${sa})) AS ${alias}`,

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -66,10 +66,10 @@ describe.skipIf(!DOCKER_OK)("timeBucket stats_agg / 1-D summary (real TimescaleD
     expect(s.sum).toBe(60);
     expect(s.numVals).toBe(3);
     expect(s.average).toBeCloseTo(20, 6);
-    // Population (Toolkit default): variance = ((10-20)^2 + 0 + (30-20)^2) / 3 = 200/3 ≈ 66.667;
-    // stddev = sqrt(200/3) ≈ 8.165. Symmetric data → skewness 0.
-    expect(s.variance).toBeCloseTo(66.667, 2);
-    expect(s.stddev).toBeCloseTo(8.165, 2);
+    // Sample (Toolkit default): variance = ((10-20)^2 + 0 + (30-20)^2) / (3-1) = 200/2 = 100;
+    // stddev = sqrt(100) = 10. Symmetric data → skewness 0.
+    expect(s.variance).toBeCloseTo(100, 4);
+    expect(s.stddev).toBeCloseTo(10, 4);
     expect(s.skewness).toBeCloseTo(0, 5);
     // kurtosis convention (raw vs excess) is a Toolkit detail — just assert it computed.
     expect(typeof s.kurtosis).toBe("number");

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -1,0 +1,78 @@
+// Toolkit stats_agg (1-D) in timeBucket, end-to-end on real TimescaleDB (the `-ha` image carries
+// timescaledb_toolkit). One op returns the 1-D statistical summary as a JS object per bucket
+// (jsonb_build_object over a single stats_agg(value)). Three values make the moments predictable.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn("\n[integration] SKIPPED stats.test.ts: Docker is not available. Not verified.\n");
+}
+
+const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
+
+describe.skipIf(!DOCKER_OK)("timeBucket stats_agg / 1-D summary (real TimescaleDB Toolkit)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    h = await startHarness();
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    // Three readings within one hour: 10, 20, 30 — symmetric, so the moments are exact.
+    await prisma.sensorReading.createMany({
+      data: [
+        { deviceId: 1, time: new Date("2026-06-15T00:00:00Z"), temperature: 10 },
+        { deviceId: 1, time: new Date("2026-06-15T00:30:00Z"), temperature: 20 },
+        { deviceId: 1, time: new Date("2026-06-15T00:45:00Z"), temperature: 30 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  it("returns the 1-D statistical summary as an object per bucket", async () => {
+    const [row] = await prisma.sensorReading.timeBucket({
+      bucket: "1 hour",
+      range,
+      groupBy: ["deviceId"],
+      aggregate: { temp: { stats: "temperature" } },
+    });
+    const s = row.temp;
+    expect(s.sum).toBe(60);
+    expect(s.numVals).toBe(3);
+    expect(s.average).toBeCloseTo(20, 6);
+    // Population (Toolkit default): variance = ((10-20)^2 + 0 + (30-20)^2) / 3 = 200/3 ≈ 66.667;
+    // stddev = sqrt(200/3) ≈ 8.165. Symmetric data → skewness 0.
+    expect(s.variance).toBeCloseTo(66.667, 2);
+    expect(s.stddev).toBeCloseTo(8.165, 2);
+    expect(s.skewness).toBeCloseTo(0, 5);
+    // kurtosis convention (raw vs excess) is a Toolkit detail — just assert it computed.
+    expect(typeof s.kurtosis).toBe("number");
+    expect(Number.isFinite(s.kurtosis)).toBe(true);
+  });
+});

--- a/test/types/timeBucket.test-d.ts
+++ b/test/types/timeBucket.test-d.ts
@@ -333,6 +333,30 @@ timeBucket({
   aggregate: { c: { candlestick: "temperature" } },
 });
 
+// stats -> a 1-D statistical summary object
+const st = timeBucket({
+  bucket: "1 hour",
+  range: { start, end },
+  aggregate: { temp: { stats: "temperature" } },
+});
+type _st = Expect<
+  Equal<
+    (typeof st)[number],
+    {
+      bucket: Date;
+      temp: {
+        average: number;
+        sum: number;
+        numVals: number;
+        stddev: number;
+        variance: number;
+        skewness: number;
+        kurtosis: number;
+      };
+    }
+  >
+>;
+
 // NB: histogram + `as` and avg + `distinct` are excess properties on a union member, which TS
 // permits through const-generic inference — those combinations are rejected at runtime instead
 // (covered by the unit tests). Only type *mismatches* on known props are caught here.

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -469,4 +469,30 @@ describe("buildTimeBucketQuery", () => {
       buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { x: { avg: "temperature", volume: "vol" } } }),
     ).toThrow(/"volume" is only valid on candlestick/);
   });
+
+  it("stats emits jsonb_build_object over a single stats_agg(value)", () => {
+    const { sql } = buildTimeBucketQuery("SensorReading", "time", {
+      ...base,
+      aggregate: { s: { stats: "temperature" } },
+    });
+    expect(sql).toContain(`jsonb_build_object('average', average(stats_agg("temperature"))`);
+    expect(sql).toContain(`'numVals', num_vals(stats_agg("temperature"))`);
+    expect(sql).toContain(`'stddev', stddev(stats_agg("temperature"))`);
+    expect(sql).toContain(`'kurtosis', kurtosis(stats_agg("temperature"))) AS "s"`);
+  });
+
+  it("rejects stats with as / fill and stats + gapfill", () => {
+    const bad = (aggregate: Record<string, Record<string, unknown>>) =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate });
+    expect(() => bad({ s: { stats: "temperature", as: "string" } })).toThrow(
+      /"stats" on "s" does not support as/,
+    );
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        gapfill: true,
+        aggregate: { s: { stats: "temperature" } },
+      }),
+    ).toThrow(/cannot be combined with gapfill/);
+  });
 });


### PR DESCRIPTION
Adds a `stats` aggregate to `timeBucket` — the Toolkit `stats_agg` 1-D summary as one object per bucket.

```ts
const [row] = await prisma.sensorReading.timeBucket({
  bucket: "1 hour",
  range: { start, end },
  aggregate: { tempStats: { stats: "temperature" } },
});
// tempStats: { average, sum, numVals, stddev, variance, skewness, kurtosis }
```

## Notes
- **Pattern** — mirrors candlestick: a single `stats_agg("col")` surfaced via `jsonb_build_object(...)`. Postgres CSE's the repeated aggregate; adapter-pg parses the jsonb to a JS object (no runtime post-processing).
- **Sample, matching the existing ops** — `stddev`/`variance` use the Toolkit **sample** default, identical to the package's standalone `stddev`/`variance` ops, so the summary is consistent with them. (Context7's docs claimed *population*; the real Toolkit 1.23 returns *sample* — caught by the integration test, fixed.)
- **Guards** — rejects `as`/`fill`/`gapfill` (returns an object), requires `timescaledb_toolkit` — same rules as candlestick/percentile.
- **Adds capability** — `skewness`/`kurtosis` have no other path in the package, and `stats_agg` rolls up in continuous aggregates.

## Tests
- Unit: SQL shape + `as`/`fill`/`gapfill` rejection.
- Type-level: output object type.
- Integration (real TimescaleDB Toolkit): values 10/20/30 → variance 100, stddev 10 (sample), skewness 0.

Wiki docs (Aggregates-and-Hyperfunctions) to follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `stats` aggregate operation to timeBucket queries, returning structured per-bucket statistical summaries (average, sum, count, standard deviation, variance, skewness, and kurtosis) with end-to-end TypeScript type inference.

* **Tests**
  * Added unit tests validating query generation and modifier restrictions.
  * Added integration tests for real Toolkit `stats_agg` behavior (auto-skipped when Docker is unavailable).
  * Added type-level tests to confirm correct result and row typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->