### PR TITLE
docs(readme): position vs the official @timescaledb ORM packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Prisma can't model TimescaleDB features in its schema language, and the naive se
 > **Scope:** hypertables, continuous aggregates, retention & compression, reset-safe migrations,
 > typed query helpers. Vector / BM25 are out of scope for now.
 
+**Using a different ORM?** TigerData's official [`@timescaledb/*`](https://github.com/timescale/timescaledb-ts)
+packages cover **TypeORM** and **Sequelize** — this is the **Prisma** counterpart, filling the gap left by
+Prisma's inability to model TimescaleDB in its schema language.
+
 ## 📖 Documentation
 
 Full docs live in the **[wiki](https://github.com/Krister-Johansson/prisma-extension-timescaledb/wiki)**:


### PR DESCRIPTION
Adds a one-line positioning note to the README so people comparing options immediately see where this fits.

TigerData's official [`timescaledb-ts`](https://github.com/timescale/timescaledb-ts) ecosystem (`@timescaledb/typeorm`, `@timescaledb/core`, …) covers **TypeORM** and **Sequelize** — there is **no** official Prisma package (not published, not on their roadmap). This package is the Prisma counterpart, and the note makes that explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify the extension's scope and positioning as the Prisma counterpart for modeling TimescaleDB features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->