### PR TITLE
chore: Socket.dev integration — README badge + GitHub App config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/prisma-extension-timescaledb)](https://www.npmjs.com/package/prisma-extension-timescaledb)
 [![CI](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml/badge.svg)](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/prisma-extension-timescaledb)](https://socket.dev/npm/package/prisma-extension-timescaledb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 ![Prisma](https://img.shields.io/badge/Prisma-%3E%3D7.0.0-2D3748)
 

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,31 @@
+# Socket.dev configuration — https://docs.socket.dev/docs/socket-yml
+# Takes effect once the Socket GitHub App is installed on this repo.
+#
+# Context: this package's own code carries no Socket "Package Alerts". The
+# dependency alerts shown on socket.dev are inherited from the Prisma trees we
+# declare as peers (prisma, @prisma/client) plus the one runtime dep
+# (@prisma/generator-helper) — i.e. dev/CLI tooling that never ships to
+# consumers. The published surface is `dist/` + `CHANGELOG.md` only, and
+# `npm audit --omit=dev` reports 0 vulnerabilities.
+version: 2
+
+# Only run pull-request alert scans when a dependency manifest actually changes.
+# Socket only ever ingests manifest files (never application source), so
+# docs- or source-only PRs don't need a scan.
+triggerPaths:
+  - "package.json"
+  - "package-lock.json"
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  dependencyOverviewEnabled: true
+  projectReportsEnabled: true
+
+# We deliberately do NOT blanket-disable supply-chain issue types via
+# `issueRules`: that is global per-type and would also hide a genuinely
+# malicious future dependency. Known false positives — e.g. the
+# "AI-detected possible typosquat → ts-deepmerge" hit on `deepmerge-ts`, which
+# is Prisma's own dependency (@prisma/internals → @prisma/config) — should be
+# triaged per-alert with a `@SocketSecurity ignore` pull-request comment:
+#   https://docs.socket.dev/docs/ignoring-pull-request-alerts


### PR DESCRIPTION
Two small Socket.dev additions. Both are additive; no dependency or source changes.

## 1. README badge

Adds the [Socket.dev](https://socket.dev/npm/package/prisma-extension-timescaledb) supply-chain badge to the badge row (npm · CI · **Socket** · License · Prisma).

## 2. `socket.yml` (GitHub App config)

Root `socket.yml` (v2) that takes effect once the Socket GitHub App is installed:

- **`triggerPaths`** scoped to `package.json` / `package-lock.json` — PR alert scans run only when a dependency manifest changes (Socket only ingests manifests anyway, never source).
- **`githubApp`** keeps the app, PR alerts, dependency overview, and project reports enabled.
- **No `issueRules` blanket-disables.** That toggle is global per-alert-type and would also hide a genuinely malicious *future* dependency. Known false positives (e.g. the "AI typosquat → ts-deepmerge" hit on `deepmerge-ts`, which is Prisma's own dependency) are triaged per-alert via `@SocketSecurity ignore` PR comments — documented inline in the file.

## Why this is the whole fix (validation summary)

A Socket scan of `0.8.0` was reviewed end to end:

- **Zero first-party alerts** — the report's "Package Alerts" section (our code) is empty; every alert is a transitive **"Dependency Alert"**.
- **Inherited from the Prisma trees** we declare as peers (`prisma`, `@prisma/client`) + `@prisma/generator-helper`. **3 of the 4 CVEs live in `prisma@7.8.0` — the latest stable** (no `7.9.0` released yet), so only Prisma can patch them; we're already on the newest. The 4th is an `esbuild` dev-server advisory (Windows, low) via `tsup`/`vite`.
- **Consumer-facing tree is clean** — `npm audit --omit=dev` → **0 vulnerabilities**. Published surface is `dist/` + `CHANGELOG.md` only.
- Already publishing with **SLSA provenance** + signatures.

No `overrides` were added: npm ignores a dependency's `overrides` for consumers, the advisories are dev-only/non-shipping, and forcing versions under Prisma's tree adds brittle pins for no downstream benefit. The remaining score signals ("not popular", single maintainer) are not code-fixable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)