### PR TITLE
ci: OpenSSF Scorecard, Codecov, PR coverage comment + README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,29 @@ jobs:
       - run: npm run build
       # ubuntu-latest runners ship Docker, so Testcontainers can run the reset-safety proof.
       - run: npm run test:integration
+
+  coverage-comment:
+    name: coverage comment
+    needs: build-test
+    # PRs only — there's no PR to comment on for pushes to main. Kept as its own job
+    # so the pull-requests:write token never covers a job that runs project code
+    # (build-test stays contents:read). It consumes the coverage artifact only.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: coverage
+          path: coverage
+      - name: Comment coverage summary on the PR
+        uses: davelosert/vitest-coverage-report-action@3c054a2d2e2ca45446417ad5d6d5eb33092af8f1 # v2.12.1
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
           name: coverage
           path: coverage/
           if-no-files-found: error
+      - name: Upload coverage to Codecov
+        if: matrix.node == 20
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Best-effort: never fail CI on an upload hiccup or a not-yet-set token.
+          fail_ci_if_error: false
 
   integration:
     name: integration (real TimescaleDB)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: Scorecard supply-chain security
+
+on:
+  # Re-run when branch-protection rules change (a Scorecard signal).
+  branch_protection_rule:
+  # Weekly, so the published score and README badge stay current.
+  schedule:
+    - cron: "27 7 * * 1"
+  push:
+    branches: [main]
+
+# Least-privilege by default; the analysis job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF result to the code-scanning dashboard.
+      security-events: write
+      # OIDC token used to publish results to the public OpenSSF API (powers the badge).
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF API so the README badge resolves.
+          publish_results: true
+
+      # Retain the SARIF for manual inspection / debugging.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Surface findings under Security → Code scanning.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # prisma-extension-timescaledb
 
 [![npm](https://img.shields.io/npm/v/prisma-extension-timescaledb)](https://www.npmjs.com/package/prisma-extension-timescaledb)
-[![CI](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml/badge.svg)](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml)
-[![Socket Badge](https://socket.dev/api/badge/npm/package/prisma-extension-timescaledb)](https://socket.dev/npm/package/prisma-extension-timescaledb)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/prisma-extension-timescaledb)](https://www.npmjs.com/package/prisma-extension-timescaledb)
+[![node](https://img.shields.io/node/v/prisma-extension-timescaledb)](https://www.npmjs.com/package/prisma-extension-timescaledb)
+[![types](https://img.shields.io/npm/types/prisma-extension-timescaledb)](https://www.npmjs.com/package/prisma-extension-timescaledb)
 ![Prisma](https://img.shields.io/badge/Prisma-%3E%3D7.0.0-2D3748)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+[![CI](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml/badge.svg)](https://github.com/Krister-Johansson/prisma-extension-timescaledb/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Krister-Johansson/prisma-extension-timescaledb/branch/main/graph/badge.svg)](https://codecov.io/gh/Krister-Johansson/prisma-extension-timescaledb)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/prisma-extension-timescaledb)](https://socket.dev/npm/package/prisma-extension-timescaledb)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Krister-Johansson/prisma-extension-timescaledb/badge)](https://scorecard.dev/viewer/?uri=github.com/Krister-Johansson/prisma-extension-timescaledb)
 
 Type-safe **[TimescaleDB](https://www.tigerdata.com/) / TigerData** time-series support for
 Prisma — **reset-safe migrations**, hypertables, continuous aggregates, and typed query helpers.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecov-yaml
+# Coverage is a signal here, not a merge gate: the unit suite already enforces
+# thresholds in vitest (see vitest.config.ts), and much of the runtime is covered
+# by the Docker-backed integration suite that does not feed Codecov.
+coverage:
+  status:
+    project:
+      default:
+        informational: true # report, never fail the check
+    patch:
+      default:
+        informational: true
+
+# Keep PRs uncluttered; the badge + Codecov dashboard are enough.
+comment: false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
     include: ["test/unit/**/*.test.ts"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "text-summary", "html", "lcov"],
+      // json-summary + json feed the PR coverage comment (vitest-coverage-report-action);
+      // lcov feeds Codecov; html/text are for local/CI artifact inspection.
+      reporter: ["text", "text-summary", "html", "lcov", "json-summary", "json"],
       reportsDirectory: "coverage",
       include: ["src/**/*.ts"],
       exclude: [


### PR DESCRIPTION
Adds the five badges discussed, wires up the two that need CI, and posts a coverage summary on every PR.

## README badges (two rows)
- **Package info:** npm version · downloads · node · types · Prisma · MIT
- **Quality & security:** CI · Codecov · Socket · OpenSSF Scorecard

The three zero-setup ones (`downloads`, `node`, `types`) are shields.io reading npm metadata.

## OpenSSF Scorecard — `.github/workflows/scorecard.yml`
Complements Socket (deps) by scanning **repo practices**. `ossf/scorecard-action` v2.4.3, SHA-pinned. Runs on push to `main` / weekly / branch-protection changes (not PRs), publishes results for the badge, uploads SARIF to code scanning.

## Codecov — CI upload + `codecov.yml`
Uploads the already-produced `coverage/lcov.info` (node-20 leg). `codecov-action` v7, SHA-pinned, `fail_ci_if_error: false`. `codecov.yml` makes statuses informational/non-blocking and disables comments.

## PR coverage comment — `coverage-comment` job
A sticky PR comment with the coverage table, via `vitest-coverage-report-action` v2.12.1 (SHA-pinned). Works **immediately, no external setup** (uses `GITHUB_TOKEN`). Isolated in its own job with `pull-requests: write` so that token never covers a job that runs project code — `build-test` stays `contents: read`. vitest now also emits `json-summary` + `json` reports for it. _(You should see its comment appear on this very PR.)_

## ⚠️ Manual follow-ups (only the Codecov/Scorecard **badges** need these)
1. **Codecov:** activate the repo at codecov.io + add a `CODECOV_TOKEN` secret. The PR coverage comment does **not** depend on this.
2. **Scorecard:** badge resolves after the first `main` run post-merge; enabling branch protection on `main` is the biggest score lever.

All actions SHA-pinned. No source or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed README badge lineup to include npm downloads, Node.js compatibility, TypeScript types, Socket security, and OpenSSF Scorecard metrics.

* **Chores**
  * Improved automated code coverage integration with Codecov, including non-blocking status reporting and PR coverage summaries.
  * Added scheduled and on-merge OpenSSF Scorecard supply-chain security scanning with publishing to public reporting.

* **CI**
  * Enhanced test coverage output to support improved reporting and summaries in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->