### PR TITLE
ci: harden OpenSSF Scorecard (token-perms, dependabot, SAST, security policy)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current — also keeps Scorecard's
+  # Pinned-Dependencies green over time. Grouped into one PR/week to stay low-noise.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+
+  # npm dependencies. Dev and runtime grouped separately; weekly + capped to stay quiet.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-development:
+        dependency-type: development
+      npm-production:
+        dependency-type: production
+    commit-message:
+      prefix: chore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "31 7 * * 2"
+
+# Least-privilege default; the analyze job adds only the write scope it needs.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload results to code scanning
+      actions: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: javascript-typescript
+      # No build step: CodeQL analyzes JS/TS sources directly.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,14 +8,18 @@ on:
   # re-trigger: npm publish errors out as a no-op if the version is already on the registry.
   workflow_dispatch:
 
+# Least-privilege at the top level (satisfies Scorecard's Token-Permissions check); the
+# single release job elevates only what release-please + npm provenance actually need.
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write # npm provenance (supply-chain attestation) via OIDC
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # release commits, tags, and the GitHub release
+      pull-requests: write # maintain the release PR
+      id-token: write # npm provenance (supply-chain attestation) via OIDC
     env:
       # Surfaced so the publish steps can gate on its presence. Empty when the secret is
       # unset, which makes the steps below skip — npm publish stays OFF until you add it.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # A PAT with Administration:read lets Scorecard read branch-protection rules
+          # (the default GITHUB_TOKEN can't, which is why Branch-Protection errors). Falls
+          # back to GITHUB_TOKEN until a SCORECARD_TOKEN secret is added — nothing breaks.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
           # Publish to the OpenSSF API so the README badge resolves.
           publish_results: true
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+`prisma-extension-timescaledb` follows semantic versioning. Security fixes are
+released against the **latest published version** — please upgrade before reporting.
+
+| Version          | Supported |
+| ---------------- | --------- |
+| latest release   | ✅        |
+| older releases   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report vulnerabilities privately through GitHub's
+[**Report a vulnerability**](https://github.com/Krister-Johansson/prisma-extension-timescaledb/security/advisories/new)
+form (repository **Security → Advisories**). This opens a private channel with the
+maintainer.
+
+What to expect:
+
+- An acknowledgement within **5 business days**.
+- If confirmed, a fix and a coordinated-disclosure timeline. Credit is given in the
+  advisory unless you prefer to remain anonymous.
+
+## Scope
+
+This package generates SQL migrations and runs typed queries against TimescaleDB
+through Prisma. The most relevant reports concern **SQL injection in the generated SQL
+or `timeBucket` query helpers**, and unsafe handling of user-supplied identifiers or
+values.
+
+The published package ships only `dist/` and depends on Prisma at runtime — please
+report issues in Prisma itself to the [Prisma project](https://github.com/prisma/prisma/security).


### PR DESCRIPTION
Targets the lowest-scoring OpenSSF Scorecard checks. Current aggregate **4.3**; this should land it around **~7.0** (and ~7.9 once the repo passes 90 days and `Maintained` flips on its own).

## Fixes in this PR

| Check | Was | Fix |
|---|---|---|
| **Token-Permissions** | 0 (High) | `release-please.yml` declared `contents`/`pull-requests`/`id-token: write` at the **top level**; moved to the single job (identical behavior), top-level is now `contents: read`. |
| **Dependency-Update-Tool** | 0 (High) | `.github/dependabot.yml` — github-actions + npm, weekly, grouped & capped to stay quiet. Bonus: keeps SHA-pinned actions fresh. |
| **SAST** | 0 (Medium) | SHA-pinned CodeQL workflow (`javascript-typescript`), runs on push/PR/weekly. |
| **Security-Policy** | 0 (Medium) | `SECURITY.md` with private vulnerability-reporting instructions. |
| **Branch-Protection** | errored | Wired `repo_token` into `scorecard.yml` with a `SCORECARD_TOKEN → GITHUB_TOKEN` fallback (see below). |

All four other workflows stay least-privilege; everything remains SHA-pinned. No source or dependency changes.

## ⚠️ One manual step (for Branch-Protection)

Scorecard's default token can't read protection rules (hence the `internal error`). To fix:

1. Create a **fine-grained PAT** → repo `Krister-Johansson/prisma-extension-timescaledb` only → Repository permissions: **Administration: Read-only** (Metadata read is automatic).
2. Add it as a repo secret named **`SCORECARD_TOKEN`**.

The workflow already falls back to `GITHUB_TOKEN` until then, so merging this is safe with or without the secret.

## Not addressed (and why)
- **Maintained (0):** time-based — auto-resolves at 90 days old. Biggest single future bump.
- **Code-Review (0) / Contributors (3):** structural solo limits (no second reviewer/org); not worth gaming.
- **Vulnerabilities (8):** the 2 are dev-tree only (esbuild + the unpatched-in-7.8 Prisma chain); not worth `overrides`.
- **CII-Best-Practices (0):** optional — register at bestpractices.dev if you want the extra Low-weight points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy defining supported versions and guidelines for privately reporting vulnerabilities.

* **Chores**
  * Configured automated dependency updates with weekly scheduling and consolidated grouping.
  * Implemented security scanning for code analysis.
  * Enhanced workflows with least-privilege permission model for improved security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->