### PR TITLE
docs: add CONTRIBUTING.md and OpenSSF Best Practices badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing
+
+Thanks for your interest in improving **prisma-extension-timescaledb**! This guide covers
+how to report issues, set up a dev environment, and the standards a change needs to meet.
+
+## Reporting bugs & requesting features
+
+- **Bugs / features:** open a [GitHub issue](https://github.com/Krister-Johansson/prisma-extension-timescaledb/issues).
+  For bugs, include the Prisma version, the relevant schema annotation, and the generated SQL
+  or error where possible.
+- **Security vulnerabilities:** please **do not** open a public issue — follow
+  [`SECURITY.md`](./SECURITY.md) (private reporting via GitHub Security Advisories).
+
+## Development setup
+
+Prerequisites: **Node ≥ 18.18** and **Docker** (the integration suite spins up a real
+TimescaleDB via [Testcontainers](https://testcontainers.com/) — without Docker those tests
+are skipped).
+
+```bash
+git clone https://github.com/Krister-Johansson/prisma-extension-timescaledb
+cd prisma-extension-timescaledb
+npm install
+```
+
+Useful scripts:
+
+| Command | What it does |
+| ------- | ------------ |
+| `npm run build` | Bundle ESM + CJS with `tsup` |
+| `npm test` | Unit tests (vitest) |
+| `npm run test:types` | Type-level tests (`tsc`) |
+| `npm run test:integration` | Integration tests against real TimescaleDB (needs Docker) |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run coverage` | Unit tests + coverage thresholds |
+| `npm run attw` | Validate published types (`@arethetypeswrong/cli`) |
+
+The package is a single package with internal modules: `src/core`, `src/generator`
+(the Prisma generator), and `src/client` (the Client Extension).
+
+## Coding standards
+
+- **TypeScript, `strict: true`, `module`/`moduleResolution: NodeNext`.** Code must typecheck
+  with no errors and no new warnings.
+- **Match the surrounding code** — naming, comment density, and idioms. Keep changes focused.
+- DMMF / `@prisma/generator-helper` access stays isolated in `src/generator/dmmf.ts`.
+
+## Testing policy
+
+**New functionality and bug fixes must come with tests.** Choose the level that fits:
+
+- **Unit** (`test/unit`) for pure logic — SQL building, type inference, config parsing.
+- **Type-level** (`test:types`) when the change affects the public type surface.
+- **Integration** (`test/integration`) for anything that touches the database or migrations.
+
+Any change to emitted migration SQL **must preserve reset-safety** (a fresh DB +
+`prisma migrate reset` + `migrate deploy` reproduces all hypertables and continuous
+aggregates with zero manual steps) and be covered by an integration test.
+
+## Commit messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) — `release-please`
+derives versions and the changelog from them. Use `feat:`, `fix:`, `docs:`, `chore:`,
+`ci:`, `refactor:`, `test:`, etc. Example: `feat(timeBucket): add gap-filling support`.
+
+## Pull requests
+
+1. Branch off `main`.
+2. Make sure CI passes locally: `npm run build && npm run typecheck && npm test && npm run test:types && npm run attw` (and `npm run test:integration` if Docker is available).
+3. Open the PR with a clear description. CI (build, unit/type tests, and the real-TimescaleDB
+   integration suite) must be green before merge.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's
+[MIT license](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![codecov](https://codecov.io/gh/Krister-Johansson/prisma-extension-timescaledb/branch/main/graph/badge.svg)](https://codecov.io/gh/Krister-Johansson/prisma-extension-timescaledb)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/prisma-extension-timescaledb)](https://socket.dev/npm/package/prisma-extension-timescaledb)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Krister-Johansson/prisma-extension-timescaledb/badge)](https://scorecard.dev/viewer/?uri=github.com/Krister-Johansson/prisma-extension-timescaledb)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13331/badge)](https://www.bestpractices.dev/projects/13331)
 
 Type-safe **[TimescaleDB](https://www.tigerdata.com/) / TigerData** time-series support for
 Prisma — **reset-safe migrations**, hypertables, continuous aggregates, and typed query helpers.


### PR DESCRIPTION
Supports the OpenSSF Best Practices badge ([project 13331](https://www.bestpractices.dev/projects/13331)).

## `CONTRIBUTING.md`
Documents the contribution process, dev setup, coding standards (TypeScript `strict`), commit conventions (Conventional Commits → release-please), and the **testing policy** — new functionality/fixes require tests, and DB/migration changes must preserve reset-safety with an integration test.

This satisfies the badge's `contribution_requirements` and `tests_documented_added` criteria (the only ones that needed a repo artifact; everything else is a form answer).

## README
Adds the OpenSSF Best Practices badge to the quality/security row. It'll show "in progress" until the self-certification form is completed, then flip to "passing" — which also nudges the Scorecard `CII-Best-Practices` check up.

Docs-only; no source or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced comprehensive contribution guidelines covering development prerequisites, setup instructions, testing requirements, coding standards, and commit message conventions.
  * Added OpenSSF Best Practices badge to showcase the project's commitment to security and quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->