### PR TITLE
fix(client): match Prisma semantics for top-level NOT array in timeBucket where

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ coverage/
 
 # integration test temp projects
 .tmp-int-*/
+
+# local working notes
+todo.md

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -62,8 +62,14 @@ export function whereToSql(where: Record<string, unknown> | undefined, ctx: Wher
       const s = combine(asArray(value), ctx, "OR");
       if (s) clauses.push(s);
     } else if (key === "NOT") {
-      const s = combine(asArray(value), ctx, "AND");
-      if (s) clauses.push(`NOT (${s})`);
+      // Prisma semantics: every listed condition must be false — negate each element
+      // individually and AND them (NOT: [A, B] => (NOT A) AND (NOT B), not NOT (A AND B)).
+      const parts = asArray(value)
+        .map((w) => whereToSql(w as Record<string, unknown>, ctx))
+        .filter(Boolean)
+        .map((s) => `NOT (${s})`);
+      if (parts.length === 1) clauses.push(parts[0]!);
+      else if (parts.length > 1) clauses.push(`(${parts.join(" AND ")})`);
     } else {
       const relation = ctx.rel?.get(key);
       const s = relation ? relationClause(key, value, relation, ctx) : fieldClause(key, value, ctx);

--- a/test/integration/where-not.test.ts
+++ b/test/integration/where-not.test.ts
@@ -91,4 +91,13 @@ describe.skipIf(!DOCKER_OK)("timeBucket nested not (real TimescaleDB)", () => {
     // NOT(device >= 2) → device < 2 → device=1 (ids 1,2); device=2 and the NULL row excluded.
     expect(await count({ device: { not: { gte: 2 } } })).toBe(2);
   });
+
+  it("top-level NOT array matches Prisma findMany (every condition must be false)", async () => {
+    // (NOT device=1) AND (NOT device=3) → only device=2 (id 3). The buggy NOT (A AND B)
+    // reading would instead match every non-NULL row (a row can't equal both values).
+    const where = { NOT: [{ device: 1 }, { device: 3 }] };
+    expect(await count(where)).toBe(1);
+    // Parity with Prisma's own engine on the same filter.
+    expect(await count(where)).toBe(await prisma.reading.count({ where }));
+  });
 });

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -96,6 +96,19 @@ describe("whereToSql", () => {
     expect(whereToSql({ NOT: { deviceId: 1 } }, harness().ctx)).toBe(`NOT ("deviceId" = $1)`);
   });
 
+  it("NOT array negates each element and ANDs them (matches Prisma: all must be false)", () => {
+    // Prisma compiles NOT: [A, B] as (NOT A) AND (NOT B) — never NOT (A AND B).
+    expect(whereToSql({ NOT: [{ deviceId: 1 }, { deviceId: 2 }] }, harness().ctx)).toBe(
+      `(NOT ("deviceId" = $1) AND NOT ("deviceId" = $2))`,
+    );
+    // A single-element array is equivalent to the object form.
+    expect(whereToSql({ NOT: [{ deviceId: 1 }] }, harness().ctx)).toBe(`NOT ("deviceId" = $1)`);
+    // Elements that resolve to no constraint drop out instead of producing NOT ().
+    expect(whereToSql({ NOT: [{ deviceId: undefined }, { deviceId: 2 }] }, harness().ctx)).toBe(
+      `NOT ("deviceId" = $1)`,
+    );
+  });
+
   it("empty OR matches nothing (false); empty AND / NOT impose no constraint", () => {
     expect(whereToSql({ OR: [] }, harness().ctx)).toBe("false");
     expect(whereToSql({ AND: [] }, harness().ctx)).toBe("");


### PR DESCRIPTION
## Problem

A top-level `NOT: [array]` in a `timeBucket` `where` was compiled as `NOT (A AND B)`, but Prisma's engine compiles it as `(NOT A) AND (NOT B)` — every listed condition must be false.

The two shapes give silently different results: with rows `status = a / b / c`,

```ts
where: { NOT: [{ status: "a" }, { status: "b" }] }
```

- Prisma `findMany`: 1 row (`c`)
- `timeBucket` (before this fix): **all 3 rows** — a single row can never equal both values, so `NOT (A AND B)` is true for every non-NULL row.

The existing unit test only covered the single-object `NOT`, where the two semantics coincide.

## Fix

Negate each array element individually and AND the results in `whereToSql` (`src/client/where.ts`). Single-object `NOT`, empty `NOT: []` (no constraint), and elements that resolve to no constraint are unchanged.

## Tests (TDD — written first, red → green)

- Unit: array `NOT` emits `(NOT (A) AND NOT (B))`; single-element array ≡ object form; no-constraint elements drop out instead of emitting `NOT ()`.
- Integration (Testcontainers, real TimescaleDB): `NOT: [{device: 1}, {device: 3}]` returns exactly the `device = 2` row **and** is asserted equal to `prisma.reading.count()` on the same filter for engine parity. The old grouping would have returned 3 rows.

Also includes a small chore commit adding local `todo.md` working notes to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of top-level `NOT` filters with multiple conditions so negated criteria are applied consistently and match expected query behavior.
  * Fixed cases where empty or no-op negated conditions are ignored instead of generating invalid output.

* **Tests**
  * Added unit and integration coverage for `NOT` array behavior to verify results against expected query counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->