### PR TITLE
fix: group by expressions, not output aliases, in timeBucket and cagg SQL

### DIFF
--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -357,13 +357,31 @@ export function buildTimeBucketQuery(
   const time = quoteIdent(timeColumn);
 
   // The bucketing expression: plain time_bucket, gapfill (bounds inferred from the range WHERE), or
-  // a 3-arg time_bucket with timezone / origin / offset (see bucketExpression).
+  // a 3-arg time_bucket with timezone / origin / offset (see bucketExpression). Kept for the GROUP BY
+  // too: grouping by the "bucket" alias would bind to an INPUT column of that name if the table has
+  // one (Postgres resolves GROUP BY names input-first), breaking every query on such a model.
   const gapfill = args.gapfill === true;
-  const select: string[] = [`${bucketExpression(time, args)} AS "bucket"`];
+  const bucketExpr = bucketExpression(time, args);
+  const select: string[] = [`${bucketExpr} AS "bucket"`];
+
+  // Every output column name must be unique — "bucket" is claimed by the bucket expression, and a
+  // groupBy/aggregate duplicate would silently clobber a result key (or make ORDER BY ambiguous).
+  const outputNames = new Set<string>(["bucket"]);
+  const claimOutput = (name: string, what: string): void => {
+    if (outputNames.has(name)) {
+      throw new Error(
+        name === "bucket"
+          ? `timeBucket: ${what} "bucket" collides with the reserved "bucket" output column.`
+          : `timeBucket: duplicate output column ${JSON.stringify(name)} (${what}).`,
+      );
+    }
+    outputNames.add(name);
+  };
 
   const groupCols = args.groupBy ?? [];
   for (const g of groupCols) {
     assertSafeIdent(g, "groupBy column");
+    claimOutput(g, "groupBy column");
     select.push(`${quoteIdent(col(g))} AS ${quoteIdent(g)}`);
   }
 
@@ -373,6 +391,7 @@ export function buildTimeBucketQuery(
   }
   for (const [resultName, op] of aggregateEntries) {
     assertSafeIdent(resultName, "aggregate result column");
+    claimOutput(resultName, "aggregate result");
     // Split the optional selectors (none of which are function names) from the function entry. The
     // runtime view is loose (`unknown`), so narrow each before use — this also hardens non-TS callers.
     // `p` (percentile fraction) and `method` (time-weight) are pulled out like the others; `min`/`max`/
@@ -554,7 +573,8 @@ export function buildTimeBucketQuery(
   });
   if (whereSql) where += ` AND (${whereSql})`;
 
-  const groupBy = [`"bucket"`, ...groupCols.map((g) => quoteIdent(g))].join(", ");
+  // Group by the bucket EXPRESSION and the source DB columns, never the output aliases (see above).
+  const groupBy = [bucketExpr, ...groupCols.map((g) => quoteIdent(col(g)))].join(", ");
 
   // ORDER BY: default to the bucket ascending; otherwise the caller's spec over the output aliases
   // (the bucket, a groupBy column, or an aggregate name). An array gives multi-key precedence.

--- a/src/core/continuousAggregate.ts
+++ b/src/core/continuousAggregate.ts
@@ -42,14 +42,31 @@ export function createContinuousAggregateSql(config: CaggConfig): MigrationSql {
     assertSafeIdent(agg.column, "aggregate source column");
   }
 
+  // Reject duplicate output columns up front — CREATE MATERIALIZED VIEW would fail at deploy time
+  // with a far less helpful "column specified more than once".
+  const seenOutputs = new Set<string>([bucketColumn]);
+  for (const output of [...groupBy.map((g) => g.output), ...aggregates.map((a) => a.name)]) {
+    if (seenOutputs.has(output)) {
+      throw new Error(
+        `Continuous aggregate "${name}": output column ${JSON.stringify(output)} is declared more than once (the bucket column, groupBy outputs, and aggregate names must be distinct).`,
+      );
+    }
+    seenOutputs.add(output);
+  }
+
   // SELECT: time_bucket first, then group-by passthroughs, then the aggregates.
+  const bucketExpr = `time_bucket(${quoteLiteral(bucket)}, ${quoteIdent(timeColumn)})`;
   const selectLines = [
-    `time_bucket(${quoteLiteral(bucket)}, ${quoteIdent(timeColumn)}) AS ${quoteIdent(bucketColumn)}`,
+    `${bucketExpr} AS ${quoteIdent(bucketColumn)}`,
     ...groupBy.map((g) => `${quoteIdent(g.source)} AS ${quoteIdent(g.output)}`),
     ...aggregates.map((a) => `${a.fn}(${quoteIdent(a.column)}) AS ${quoteIdent(a.name)}`),
   ];
 
-  const groupByCols = [bucketColumn, ...groupBy.map((g) => g.output)].map(quoteIdent).join(", ");
+  // Group by the bucket EXPRESSION and the SOURCE columns, never the output aliases: Postgres
+  // resolves an unqualified GROUP BY name to an input column first, so an alias that matches a
+  // real source-table column (e.g. a physical "bucket" column) would capture the GROUP BY and
+  // fail the CREATE with "must appear in the GROUP BY clause".
+  const groupByCols = [bucketExpr, ...groupBy.map((g) => quoteIdent(g.source))].join(", ");
 
   // `materialized_only` only emitted when set; omitted leaves TimescaleDB's default. `false` =
   // real-time aggregation. The relopt is a bare boolean (no quoting).

--- a/test/integration/bucket-column.test.ts
+++ b/test/integration/bucket-column.test.ts
@@ -1,0 +1,119 @@
+// A hypertable with a physical column named "bucket", end-to-end on real TimescaleDB. Postgres
+// resolves an unqualified GROUP BY name to an INPUT column before an output alias, so grouping by
+// the "bucket" alias used to fail every timeBucket() on such a model with "column ... must appear
+// in the GROUP BY clause" — and the same alias capture broke the cagg CREATE at migrate deploy.
+// Proves both builders group by the expression instead.
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startHarness, type Harness } from "./harness.js";
+import { timescaledb } from "../../src/client/index.js";
+
+const DOCKER_OK = (() => {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!DOCKER_OK) {
+  console.warn(
+    "\n[integration] SKIPPED bucket-column.test.ts: Docker is not available. bucket-column collision is NOT verified.\n",
+  );
+}
+
+const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time   DateTime
+  id     Int
+  bucket Int      // physical column named like the reserved output alias
+  value  Float
+
+  @@id([id, time])
+}
+
+/// @timescale.continuousAggregate(source: "Reading", bucket: "1 hour", timeColumn: "time", refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour" })
+view ReadingHourly {
+  bucket   DateTime /// @timescale.bucket
+  avgValue Float    /// @timescale.aggregate(fn: "avg", column: "value")
+
+  @@unique([bucket])
+}`;
+
+const INIT_SQL = `CREATE TABLE "Reading" (
+    "time" TIMESTAMP(3) NOT NULL,
+    "id" INTEGER NOT NULL,
+    "bucket" INTEGER NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "Reading_pkey" PRIMARY KEY ("id","time")
+);`;
+
+describe.skipIf(!DOCKER_OK)("physical `bucket` column (real TimescaleDB)", () => {
+  let h: Harness;
+  // deno-lint-ignore no-explicit-any
+  let prisma: any;
+  let base: { $disconnect(): Promise<void> };
+
+  beforeAll(async () => {
+    // migrate deploy already exercises the cagg fix: its CREATE MATERIALIZED VIEW groups by the
+    // time_bucket expression over a source table that has a physical "bucket" column.
+    h = await startHarness({ models: MODELS, initSql: INIT_SQL });
+    h.prisma(["generate"]);
+    h.prisma(["migrate", "deploy"]);
+
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+    base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    prisma = (base as { $extends: (e: unknown) => unknown }).$extends(timescaledb(registry));
+
+    await prisma.reading.createMany({
+      data: [
+        { time: new Date("2026-06-15T10:05:00Z"), id: 1, bucket: 7, value: 10 },
+        { time: new Date("2026-06-15T10:25:00Z"), id: 2, bucket: 7, value: 20 },
+        { time: new Date("2026-06-15T10:45:00Z"), id: 3, bucket: 9, value: 30 },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await base?.$disconnect();
+    await h?.stop();
+  });
+
+  const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-16T00:00:00Z") };
+
+  it("timeBucket works on a model with a physical `bucket` column", async () => {
+    const rows = await prisma.reading.timeBucket({
+      bucket: "1 hour",
+      range,
+      aggregate: { avgValue: { avg: "value" } },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].avgValue).toBe(20);
+  });
+
+  it("grouping BY the physical `bucket` column throws the clear reserved-name error", async () => {
+    // The output column "bucket" is claimed by the time_bucket expression, so grouping by a
+    // same-named field must be rejected up front rather than silently clobbering the result key.
+    await expect(
+      prisma.reading.timeBucket({
+        bucket: "1 hour",
+        range,
+        groupBy: ["bucket"],
+        aggregate: { avgValue: { avg: "value" } },
+      }),
+    ).rejects.toThrow(/reserved "bucket"/);
+  });
+
+  it("the cagg over the colliding source refreshes and reads back", async () => {
+    await prisma.$timescale.refreshContinuousAggregate("ReadingHourly");
+    const rows = await prisma.readingHourly.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].avgValue).toBe(20);
+  });
+});

--- a/test/unit/builders.test.ts
+++ b/test/unit/builders.test.ts
@@ -119,7 +119,7 @@ SELECT
   avg("temperature") AS "avgTemp",
   max("temperature") AS "maxTemp"
 FROM "SensorReading"
-GROUP BY "bucket", "deviceId"
+GROUP BY time_bucket('1 hour', "time"), "deviceId"
 WITH NO DATA;
 
 SELECT add_continuous_aggregate_policy('"SensorHourly"',
@@ -153,8 +153,34 @@ SELECT add_continuous_aggregate_policy('"SensorHourly"',
 
   it("supports a cagg with no groupBy columns", () => {
     const { up } = createContinuousAggregateSql({ ...base, groupBy: [] });
-    expect(up).toContain("GROUP BY \"bucket\"");
+    expect(up).toContain(`GROUP BY time_bucket('1 hour', "time")`);
     expect(up).not.toContain('"deviceId"');
+  });
+
+  it("groups by source expressions, never output aliases (a source column named like the alias must not capture it)", () => {
+    // Postgres resolves an unqualified GROUP BY name to an INPUT column before an output alias,
+    // so GROUP BY "bucket" breaks when the source hypertable has a real "bucket" column.
+    const { up } = createContinuousAggregateSql({
+      ...base,
+      groupBy: [{ source: "device_id", output: "deviceId" }],
+    });
+    expect(up).toContain(`GROUP BY time_bucket('1 hour', "time"), "device_id"`);
+    expect(up).not.toContain(`GROUP BY "bucket"`);
+  });
+
+  it("rejects duplicate output columns (bucket / groupBy / aggregate names must be distinct)", () => {
+    expect(() =>
+      createContinuousAggregateSql({
+        ...base,
+        aggregates: [{ name: "bucket", fn: "avg", column: "temperature" }],
+      }),
+    ).toThrow(/output column "bucket"/);
+    expect(() =>
+      createContinuousAggregateSql({
+        ...base,
+        groupBy: [{ source: "deviceId", output: "avgTemp" }],
+      }),
+    ).toThrow(/output column "avgTemp"/);
   });
 
   it("rejects empty aggregates and unsupported functions", () => {

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -111,7 +111,7 @@ describe("emitMigrations", () => {
         avg("temperature") AS "avgTemp",
         max("temperature") AS "maxTemp"
       FROM "SensorReading"
-      GROUP BY "bucket", "deviceId"
+      GROUP BY time_bucket('1 hour', "time"), "deviceId"
       WITH NO DATA;
 
       SELECT add_continuous_aggregate_policy('"SensorHourly"',

--- a/test/unit/timeBucket.test.ts
+++ b/test/unit/timeBucket.test.ts
@@ -16,7 +16,7 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`avg("temperature")::double precision AS "avgTemp"`);
     expect(sql).toContain(`count("temperature")::int AS "n"`);
     expect(sql).toContain(`FROM "SensorReading"`);
-    expect(sql).toContain(`GROUP BY "bucket", "deviceId"`);
+    expect(sql).toContain(`GROUP BY time_bucket($1, "time"), "deviceId"`);
     expect(sql).not.toContain("::regclass");
     expect(params).toEqual(["1 hour", range.start, range.end]);
   });
@@ -95,6 +95,39 @@ describe("buildTimeBucketQuery", () => {
     ).toThrow(/unsupported where operator/);
   });
 
+  it("groups by the bucket expression, never the output alias (a physical `bucket` column must not capture it)", () => {
+    // Postgres resolves an unqualified GROUP BY name to an INPUT column before an output alias,
+    // so GROUP BY "bucket" breaks on any table that has a real column named "bucket".
+    const plain = buildTimeBucketQuery("SensorReading", "time", { ...base, groupBy: ["deviceId"] });
+    expect(plain.sql).toContain(`GROUP BY time_bucket($1, "time"), "deviceId"`);
+    const gap = buildTimeBucketQuery("SensorReading", "time", { ...base, gapfill: true });
+    expect(gap.sql).toContain(`GROUP BY time_bucket_gapfill($1, "time")`);
+    // @map: group by the source DB column, not the Prisma-field alias.
+    const mapped = buildTimeBucketQuery(
+      "sensor_readings",
+      "ts",
+      { ...base, groupBy: ["deviceId"] },
+      { deviceId: "device_id", time: "ts" },
+    );
+    expect(mapped.sql).toContain(`GROUP BY time_bucket($1, "ts"), "device_id"`);
+  });
+
+  it("rejects output-column collisions (reserved bucket name, groupBy/aggregate duplicates)", () => {
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", { ...base, aggregate: { bucket: { avg: "temperature" } } }),
+    ).toThrow(/reserved "bucket"/);
+    expect(() => buildTimeBucketQuery("SensorReading", "time", { ...base, groupBy: ["bucket"] })).toThrow(
+      /reserved "bucket"/,
+    );
+    expect(() =>
+      buildTimeBucketQuery("SensorReading", "time", {
+        ...base,
+        groupBy: ["deviceId"],
+        aggregate: { deviceId: { avg: "temperature" } },
+      }),
+    ).toThrow(/duplicate output column/);
+  });
+
   it("resolves @map columns to DB names while aliasing results to Prisma field names", () => {
     const { sql, params } = buildTimeBucketQuery(
       "sensor_readings",
@@ -107,7 +140,7 @@ describe("buildTimeBucketQuery", () => {
     expect(sql).toContain(`"device_id" AS "deviceId"`); // DB column selected, Prisma name aliased
     expect(sql).toContain(`avg("temperature")::double precision AS "avgTemp"`); // unmapped column = identity
     expect(sql).toContain(`AND ("device_id" = $4)`); // where key resolved to DB column
-    expect(sql).toContain(`GROUP BY "bucket", "deviceId"`); // group by the output alias
+    expect(sql).toContain(`GROUP BY time_bucket($1, "ts"), "device_id"`); // group by the source expression
     expect(params).toEqual(["1 hour", range.start, range.end, 1]);
   });
 
@@ -289,7 +322,7 @@ describe("buildTimeBucketQuery", () => {
 
   it("orderBy a single key sets the direction over the output alias", () => {
     const { sql } = buildTimeBucketQuery("SensorReading", "time", { ...base, orderBy: { bucket: "desc" } });
-    expect(sql).toContain(`GROUP BY "bucket" ORDER BY "bucket" DESC`);
+    expect(sql).toContain(`GROUP BY time_bucket($1, "time") ORDER BY "bucket" DESC`);
   });
 
   it("orderBy an aggregate + limit builds top-N (LIMIT inlined as an integer)", () => {


### PR DESCRIPTION
## Problem

Postgres resolves an unqualified `GROUP BY` name to an **input column** before an output alias. Both SQL builders grouped by output aliases:

- `timeBucket()` emitted `GROUP BY "bucket", ...` — on any model with a physical column named `bucket`, that binds to the real column and **every query on the model fails** with `column "X.time" must appear in the GROUP BY clause` (reproduced in-container).
- The continuous-aggregate builder had the same pattern, so a cagg whose source table has a column matching the bucket/groupBy alias **fails at `migrate deploy`**.

## Fix

Group by the bucketing **expression** (`time_bucket(...)` / `time_bucket_gapfill(...)`) and the **source DB columns** instead of aliases, in both `src/client/timeBucket.ts` and `src/core/continuousAggregate.ts`. `ORDER BY` is intentionally unchanged — Postgres resolves ORDER BY names output-first, so the alias is correct there.

Also new up-front validation with clear errors (previously silent result-key clobbering or an opaque deploy-time failure):

- `groupBy` field or aggregate result named `bucket` → reserved-name error
- duplicate output names between `groupBy` and `aggregate` → duplicate-column error
- duplicate cagg output columns (bucket column / groupBy outputs / aggregate names)

## Tests (TDD — written first, red → green)

- Unit: expression-based `GROUP BY` shape for plain / gapfill / @map queries and the cagg builder (incl. the full-SQL snapshot and generator emit snapshot), plus all new collision errors.
- Integration (new `bucket-column.test.ts`, real TimescaleDB): a hypertable **with a physical `bucket` column** — `timeBucket()` works, the reserved-name error surfaces on `groupBy: ["bucket"]`, and a cagg over that source deploys, refreshes, and reads back. This exact schema failed before the fix.
- Full integration suite run locally: 27 files / 62 tests green, including reset-safety.

Closes out the third finding from the where/SQL-builder review (follows #57, #59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-bucket queries so grouping uses the actual bucket expression, avoiding incorrect matches when a real field is also named `bucket`.
  * Added clearer validation when output names would conflict, preventing confusing query errors and accidental alias collisions.
  * Continuous aggregate queries now generate safer grouping behavior, reducing ambiguity in results.

* **Tests**
  * Expanded coverage for bucket-name collisions, alias conflicts, and grouping behavior across multiple query shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->