### PR TITLE
feat(generator): fail loudly on unknown annotations + no-any cleanup + CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# CodeRabbit configuration — tames review volume so a burst of small PRs
+# doesn't hit the hourly review rate limit.
+# Schema/docs: https://docs.coderabbit.ai/configuration/auto-review
+#
+# NOTE: this file takes precedence over the organization UI settings for this
+# repo, so the review profile is restated here.
+reviews:
+  profile: chill
+  # Quieter bot = fewer GitHub notification emails: no "currently reviewing"
+  # status comments and no walkthrough poems. The review findings themselves
+  # are unaffected.
+  review_status: false
+  poem: false
+  auto_review:
+    enabled: true
+    # One auto review when the PR opens. Pushes that address review comments
+    # do NOT re-trigger a review — when the fixes are ready for a re-check,
+    # request one explicitly by commenting "@coderabbitai review".
+    auto_incremental_review: false
+    # Machine-generated PRs with nothing meaningful to review.
+    ignore_title_keywords:
+      - "chore(main): release"
+    ignore_usernames:
+      - "dependabot[bot]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ zero errors. This must be covered by an integration test (`test/integration/`).
 ## Conventions
 
 - Language: TypeScript, `strict: true`, `module`/`moduleResolution`: `NodeNext`.
+- **No explicit `any` unless absolutely necessary.** Prefer `unknown` + narrowing or a real
+  type. Where `any` is genuinely unavoidable, centralize it behind ONE documented alias
+  (see `TestPrismaClient` in `test/integration/harness.ts` — the runtime-generated per-test
+  client has no compile-time types) instead of scattering `any` declarations.
 - Single package with internal modules `src/core`, `src/generator`, `src/client`.
   (Not a monorepo.)
 - `@prisma/client` and `prisma` are **peerDependencies** (`>=7.0.0`), pinned in

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -45,7 +45,10 @@ const AGG_FNS = new Set<AggregateSpec["fn"]>(["avg", "sum", "min", "max", "count
 // no policy, a column missing from the generated view) and only surfaces as a runtime mystery.
 const MODEL_ANNOTATIONS = ["hypertable", "retention", "compression", "continuousAggregate"] as const;
 const FIELD_ANNOTATIONS = ["bucket", "groupBy", "aggregate"] as const;
-const ANNOTATION_ARGS: Record<string, readonly string[]> = {
+type AnnotationName = (typeof MODEL_ANNOTATIONS)[number] | (typeof FIELD_ANNOTATIONS)[number];
+// Keyed by the name union so adding an annotation without its args entry is a COMPILE error
+// (a string-keyed map would fall through to "takes no arguments" at runtime instead).
+const ANNOTATION_ARGS: Record<AnnotationName, readonly string[]> = {
   hypertable: ["column", "chunkInterval", "partitionColumn", "partitions", "chunkSkipping"],
   retention: ["dropAfter"],
   compression: ["after", "segmentBy", "orderBy"],
@@ -64,7 +67,7 @@ function caseSuggestion(name: string, allowed: Iterable<string>): string | undef
 }
 
 /** Reject an unknown annotation name at its level, suggesting the fix (case typo / wrong level). */
-function assertKnownAnnotationName(name: string, level: "model" | "field", ctx: string): void {
+function assertKnownAnnotationName(name: string, level: "model" | "field", ctx: string): asserts name is AnnotationName {
   const known: readonly string[] = level === "model" ? MODEL_ANNOTATIONS : FIELD_ANNOTATIONS;
   if (known.includes(name)) return;
   const other: readonly string[] = level === "model" ? FIELD_ANNOTATIONS : MODEL_ANNOTATIONS;
@@ -114,8 +117,9 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
     // so a typo fails generation instead of silently no-oping (H2 in the review).
     for (const a of annotations) {
       const ctx = `model "${model.name}"`;
-      assertKnownAnnotationName(a.name, "model", ctx);
-      assertKnownArgs(a.name, a.args, ANNOTATION_ARGS[a.name] ?? [], `@timescale.${a.name} on ${ctx}`);
+      const name = a.name;
+      assertKnownAnnotationName(name, "model", ctx);
+      assertKnownArgs(name, a.args, ANNOTATION_ARGS[name], `@timescale.${name} on ${ctx}`);
     }
     const isCagg = findAnnotation(annotations, "continuousAggregate") !== undefined;
     for (const field of model.fields) {
@@ -128,8 +132,9 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
         );
       }
       for (const a of fieldAnns) {
-        assertKnownAnnotationName(a.name, "field", fctx);
-        assertKnownArgs(a.name, a.args, ANNOTATION_ARGS[a.name] ?? [], `@timescale.${a.name} on ${fctx}`);
+        const name = a.name;
+        assertKnownAnnotationName(name, "field", fctx);
+        assertKnownArgs(name, a.args, ANNOTATION_ARGS[name], `@timescale.${name} on ${fctx}`);
       }
     }
 

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -40,6 +40,65 @@ export interface TimescaleSchema {
 const TIME_TYPES = new Set(["DateTime"]);
 const AGG_FNS = new Set<AggregateSpec["fn"]>(["avg", "sum", "min", "max", "count"]);
 
+// The complete annotation surface. Anything outside these sets is a typo the user needs to hear
+// about NOW: an unknown name or argument key silently no-ops otherwise (no hypertable conversion,
+// no policy, a column missing from the generated view) and only surfaces as a runtime mystery.
+const MODEL_ANNOTATIONS = ["hypertable", "retention", "compression", "continuousAggregate"] as const;
+const FIELD_ANNOTATIONS = ["bucket", "groupBy", "aggregate"] as const;
+const ANNOTATION_ARGS: Record<string, readonly string[]> = {
+  hypertable: ["column", "chunkInterval", "partitionColumn", "partitions", "chunkSkipping"],
+  retention: ["dropAfter"],
+  compression: ["after", "segmentBy", "orderBy"],
+  continuousAggregate: ["source", "bucket", "timeColumn", "refresh", "materializedOnly"],
+  bucket: [],
+  groupBy: [],
+  aggregate: ["fn", "column"],
+};
+const REFRESH_ARGS = ["startOffset", "endOffset", "scheduleInterval"] as const;
+
+/** Case-insensitive lookup: the allowed name a typo probably meant, or undefined. */
+function caseSuggestion(name: string, allowed: Iterable<string>): string | undefined {
+  const lower = name.toLowerCase();
+  for (const candidate of allowed) if (candidate.toLowerCase() === lower) return candidate;
+  return undefined;
+}
+
+/** Reject an unknown annotation name at its level, suggesting the fix (case typo / wrong level). */
+function assertKnownAnnotationName(name: string, level: "model" | "field", ctx: string): void {
+  const known: readonly string[] = level === "model" ? MODEL_ANNOTATIONS : FIELD_ANNOTATIONS;
+  if (known.includes(name)) return;
+  const other: readonly string[] = level === "model" ? FIELD_ANNOTATIONS : MODEL_ANNOTATIONS;
+  if (other.includes(name)) {
+    throw new Error(
+      level === "model"
+        ? `${ctx}: @timescale.${name} is a field-level annotation — place it on the ${name === "bucket" ? "view's bucket field" : "view field"} (\`/// @timescale.${name}\`), not the model.`
+        : `${ctx}: @timescale.${name} is a model-level annotation — place it on the model/view, not a field.`,
+    );
+  }
+  const suggestion = caseSuggestion(name, [...known, ...other]);
+  throw new Error(
+    `${ctx}: unknown annotation @timescale.${name}` +
+      (suggestion !== undefined
+        ? ` (did you mean @timescale.${suggestion}?).`
+        : ` (valid ${level}-level annotations: ${known.join(", ")}).`),
+  );
+}
+
+/** Reject unknown argument keys on a known annotation, suggesting the case fix where obvious. */
+function assertKnownArgs(name: string, args: Record<string, unknown>, allowed: readonly string[], ctx: string): void {
+  for (const key of Object.keys(args)) {
+    if (allowed.includes(key)) continue;
+    if (allowed.length === 0) {
+      throw new Error(`${ctx}: @timescale.${name} takes no arguments (got ${JSON.stringify(key)}).`);
+    }
+    const suggestion = caseSuggestion(key, allowed);
+    throw new Error(
+      `${ctx}: unknown argument ${JSON.stringify(key)} for @timescale.${name}` +
+        (suggestion !== undefined ? ` (did you mean ${JSON.stringify(suggestion)}?).` : ` (allowed: ${allowed.join(", ")}).`),
+    );
+  }
+}
+
 /** Extract and validate all TimescaleDB configs from a Prisma DMMF document. */
 export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   const models = dmmf.datamodel.models;
@@ -50,6 +109,30 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
 
   for (const model of models) {
     const annotations = parseAnnotations(model.documentation);
+
+    // Validate the full annotation surface FIRST — names and argument keys, at both levels —
+    // so a typo fails generation instead of silently no-oping (H2 in the review).
+    for (const a of annotations) {
+      const ctx = `model "${model.name}"`;
+      assertKnownAnnotationName(a.name, "model", ctx);
+      assertKnownArgs(a.name, a.args, ANNOTATION_ARGS[a.name] ?? [], `@timescale.${a.name} on ${ctx}`);
+    }
+    const isCagg = findAnnotation(annotations, "continuousAggregate") !== undefined;
+    for (const field of model.fields) {
+      const fieldAnns = parseAnnotations(field.documentation);
+      if (fieldAnns.length === 0) continue;
+      const fctx = `"${model.name}.${field.name}"`;
+      if (!isCagg) {
+        throw new Error(
+          `@timescale.${fieldAnns[0]!.name} on ${fctx}: field-level annotations are only valid on a @timescale.continuousAggregate view.`,
+        );
+      }
+      for (const a of fieldAnns) {
+        assertKnownAnnotationName(a.name, "field", fctx);
+        assertKnownArgs(a.name, a.args, ANNOTATION_ARGS[a.name] ?? [], `@timescale.${a.name} on ${fctx}`);
+      }
+    }
+
     if (findAnnotation(annotations, "hypertable")) {
       hypertables.push(buildHypertable(model, annotations, byName));
     } else {
@@ -456,6 +539,7 @@ function buildRefresh(ann: ReturnType<typeof parseAnnotations>[number], ctx: str
   const obj = optionalObject(ann.args, "refresh", ctx);
   if (!obj) return undefined;
   const rctx = `${ctx} refresh`;
+  assertKnownArgs("continuousAggregate", obj, REFRESH_ARGS, rctx);
   const startOffset = requireString(obj, "startOffset", rctx);
   const endOffset = requireString(obj, "endOffset", rctx);
   const scheduleInterval = requireString(obj, "scheduleInterval", rctx);

--- a/test/integration/aggregates.test.ts
+++ b/test/integration/aggregates.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -35,8 +35,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket standard aggregates (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/bucket-column.test.ts
+++ b/test/integration/bucket-column.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -54,8 +54,7 @@ const INIT_SQL = `CREATE TABLE "Reading" (
 
 describe.skipIf(!DOCKER_OK)("physical `bucket` column (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/bucket-column.test.ts
+++ b/test/integration/bucket-column.test.ts
@@ -63,6 +63,9 @@ describe.skipIf(!DOCKER_OK)("physical `bucket` column (real TimescaleDB)", () =>
     h = await startHarness({ models: MODELS, initSql: INIT_SQL });
     h.prisma(["generate"]);
     h.prisma(["migrate", "deploy"]);
+    // Replay from scratch (idempotent replay): the colliding-column artifacts under test must
+    // also survive the reset cycle, like every other migration-produced artifact.
+    h.prisma(["migrate", "reset", "--force"]);
 
     const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
     const { PrismaPg } = await import("@prisma/adapter-pg");

--- a/test/integration/cagg-policy.test.ts
+++ b/test/integration/cagg-policy.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -32,8 +32,7 @@ const policy = { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: 
 
 describe.skipIf(!DOCKER_OK)("continuous-aggregate refresh policy (runtime)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/candlestick.test.ts
+++ b/test/integration/candlestick.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -50,8 +50,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket candlestick / OHLC (real TimescaleDB Toolkit)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/chunk-helpers.test.ts
+++ b/test/integration/chunk-helpers.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -32,8 +32,7 @@ model SensorReading {
 
 describe.skipIf(!DOCKER_OK)("$timescale chunk + size helpers (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/chunk-ops.test.ts
+++ b/test/integration/chunk-ops.test.ts
@@ -8,7 +8,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -46,8 +46,7 @@ async function compressedChunks(h: Harness): Promise<Set<string>> {
 
 describe.skipIf(!DOCKER_OK)("on-demand chunk operations (runtime)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/chunk-skipping.test.ts
+++ b/test/integration/chunk-skipping.test.ts
@@ -10,7 +10,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -67,8 +67,7 @@ async function skippingColumns(h: Harness): Promise<number> {
 
 describe.skipIf(!DOCKER_OK)("chunk skipping (generated + runtime)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/counter-timeweight.test.ts
+++ b/test/integration/counter-timeweight.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -35,8 +35,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket counter_agg + time_weight (real TimescaleDB Toolkit)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/first-last.test.ts
+++ b/test/integration/first-last.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -43,8 +43,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket first / last (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/gapfill.test.ts
+++ b/test/integration/gapfill.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -36,8 +36,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket gap-filling (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -34,6 +34,15 @@ export interface Harness {
   stop(): Promise<void>;
 }
 
+/**
+ * The extended PrismaClient of a temp test project. Its client is GENERATED at runtime inside the
+ * project dir, so no compile-time types exist for it — this alias is the repo's one sanctioned
+ * explicit `any` (policy: no `any` unless absolutely necessary). Integration tests type their
+ * dynamically imported client with this instead of a local `any`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime-generated client, no static types exist
+export type TestPrismaClient = any;
+
 /** Ensure the package (incl. the generator binary) is built. */
 export function ensureBuilt(): void {
   if (!existsSync(GENERATOR_PROVIDER)) {

--- a/test/integration/jobs.test.ts
+++ b/test/integration/jobs.test.ts
@@ -11,8 +11,9 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
+import type { TimescaleJob } from "../../src/client/manage.js";
 
 const DOCKER_OK = (() => {
   try {
@@ -51,8 +52,7 @@ view SensorHourly {
 
 describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {
@@ -72,9 +72,8 @@ describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
     await h?.stop();
   });
 
-  // deno-lint-ignore no-explicit-any
-  const jobByProc = async (model: string, proc: string): Promise<any> =>
-    (await prisma.$timescale.listJobs(model)).find((j: { procName: string }) => j.procName === proc);
+  const jobByProc = async (model: string, proc: string): Promise<TimescaleJob | undefined> =>
+    (await prisma.$timescale.listJobs(model)).find((j: TimescaleJob) => j.procName === proc);
 
   it("lists jobs and filters by model (hypertable vs continuous aggregate)", async () => {
     const retention = await jobByProc("SensorReading", "policy_retention");

--- a/test/integration/order-limit.test.ts
+++ b/test/integration/order-limit.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -35,8 +35,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket orderBy + limit (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/percentile.test.ts
+++ b/test/integration/percentile.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -36,8 +36,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket approximate percentiles (real TimescaleDB Toolkit)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/relation-filters.test.ts
+++ b/test/integration/relation-filters.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -58,8 +58,7 @@ const t = (m: number) => new Date(`2026-06-15T10:${String(m).padStart(2, "0")}:0
 
 describe.skipIf(!DOCKER_OK)("timeBucket relation filters (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/set-chunk-interval.test.ts
+++ b/test/integration/set-chunk-interval.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -37,8 +37,7 @@ const SIX_HOURS = 21_600;
 
 describe.skipIf(!DOCKER_OK)("set chunk interval (runtime)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -25,8 +25,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket stats_agg / 1-D summary (real TimescaleDB Toolkit)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/timezone.test.ts
+++ b/test/integration/timezone.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -41,8 +41,7 @@ const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-
 
 describe.skipIf(!DOCKER_OK)("timeBucket timezone / offset (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/where-insensitive.test.ts
+++ b/test/integration/where-insensitive.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -43,8 +43,7 @@ const INIT_SQL = `CREATE TABLE "Reading" (
 
 describe.skipIf(!DOCKER_OK)("timeBucket mode: insensitive (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/integration/where-not.test.ts
+++ b/test/integration/where-not.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
 const DOCKER_OK = (() => {
@@ -42,8 +42,7 @@ const INIT_SQL = `CREATE TABLE "Reading" (
 
 describe.skipIf(!DOCKER_OK)("timeBucket nested not (real TimescaleDB)", () => {
   let h: Harness;
-  // deno-lint-ignore no-explicit-any
-  let prisma: any;
+  let prisma: TestPrismaClient;
   let base: { $disconnect(): Promise<void> };
 
   beforeAll(async () => {

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -802,3 +802,135 @@ model Device {
     ]);
   });
 });
+
+describe("extractTimescaleSchema — unknown annotations and arguments fail loudly", () => {
+  // Every case here used to be SILENTLY ignored (verified against the pre-fix generator),
+  // leaving the user without a hypertable / policy / view column and no hint why.
+
+  it("rejects a case-typo'd model annotation with a suggestion", async () => {
+    await expect(
+      extract(`
+/// @timescale.hyperTable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/unknown annotation @timescale\.hyperTable.*did you mean @timescale\.hypertable\?/s);
+  });
+
+  it("rejects a misspelled model annotation, listing the valid names", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+/// @timescale.retension(dropAfter: "30 days")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/unknown annotation @timescale\.retension.*hypertable, retention, compression, continuousAggregate/s);
+  });
+
+  it("rejects unknown argument keys with a case suggestion", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", chunkinterval: "1 day")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/unknown argument "chunkinterval".*did you mean "chunkInterval"\?/s);
+  });
+
+  it("rejects a case-typo'd field annotation on a cagg view", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket   DateTime /// @timescale.bucket
+  deviceId Int      /// @timescale.groupby
+  avgTemp  Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([deviceId, bucket])
+}`),
+    ).rejects.toThrow(/unknown annotation @timescale\.groupby.*did you mean @timescale\.groupBy\?/s);
+  });
+
+  it("rejects unknown cagg arguments (materializedonly) and unknown nested refresh keys", async () => {
+    const cagg = (extraArgs: string) =>
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time"${extraArgs})
+view SensorHourly {
+  bucket  DateTime /// @timescale.bucket
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([bucket])
+}`);
+    await expect(cagg(`, materializedonly: false`)).rejects.toThrow(
+      /unknown argument "materializedonly".*did you mean "materializedOnly"\?/s,
+    );
+    await expect(
+      cagg(`, refresh: { startOffset: "1 month", endOffset: "1 hour", scheduleInterval: "1 hour", schedual: "1 hour" }`),
+    ).rejects.toThrow(/unknown argument "schedual".*startOffset, endOffset, scheduleInterval/s);
+  });
+
+  it("rejects annotations that take no arguments when given any", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket  DateTime /// @timescale.bucket(column: "time")
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([bucket])
+}`),
+    ).rejects.toThrow(/@timescale\.bucket takes no arguments/);
+  });
+
+  it("rejects field-level annotations outside a @timescale.continuousAggregate view", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime /// @timescale.bucket
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/field-level annotations are only valid on a @timescale\.continuousAggregate view/);
+  });
+
+  it("rejects a field-level annotation used at model level with a placement hint", async () => {
+    await expect(
+      extract(`
+/// @timescale.groupBy
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/@timescale\.groupBy is a field-level annotation/);
+  });
+});


### PR DESCRIPTION
> **Stacked on #60** — merge that first; this PR then shows only its own three commits.

## 1. Generator: unknown annotations and argument keys now fail loudly

Previously every typo in the `///` annotation surface was **silently ignored** (all verified against the pre-fix generator):

| Typo | Old behavior |
|---|---|
| `@timescale.hyperTable(...)` | model silently not a hypertable |
| `@timescale.retension(dropAfter: ...)` | no retention policy, data kept forever |
| `chunkinterval: "1 day"` | silently fell back to the 7-day default |
| `/// @timescale.groupby` on a cagg field | column dropped from the view → runtime `findMany` failure |
| `materializedonly: false` | real-time aggregation silently not enabled |

`extractTimescaleSchema` now validates the complete surface up front: unknown names error with a **did-you-mean** for case typos and a placement hint when a field-level annotation lands at model level (or vice versa); unknown argument keys error per annotation including the nested `refresh` object; field-level annotations outside a `@timescale.continuousAggregate` view error; `@timescale.bucket`/`groupBy` reject arguments. TDD: 8 new unit cases covering each formerly-silent scenario, red → green.

## 2. No-`any` policy (also resolves CodeRabbit's nitpick on #60)

- All 19 stale `// deno-lint-ignore no-explicit-any` comments removed (never a Deno project).
- The scattered `let prisma: any` declarations replaced by **one sanctioned, documented alias** — `TestPrismaClient` in the harness (the per-test client is generated at runtime; no compile-time types exist).
- `jobs.test.ts`'s helper now uses the real `TimescaleJob` type.
- `src/` verified free of explicit `any`; the policy is documented in CLAUDE.md conventions.

## 3. `.coderabbit.yaml`

Same config as gqlPrune: chill profile, no status comments/poems, one auto review per PR (re-review on request via `@coderabbitai review`), release-please and dependabot PRs ignored.

## Verification

Unit (263), type tests, typecheck, and the **full integration suite** (27 files / 62 tests on real TimescaleDB, generator rebuilt first) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for Timescale annotations, with clearer errors for unknown names, arguments, and invalid placement.
  * Improved query generation so bucket-based grouping uses the underlying expression and prevents output name collisions.

* **Bug Fixes**
  * Fixed cases where generated SQL could rely on output aliases in `GROUP BY`.
  * Prevented conflicts when a source column or aggregate output overlaps with reserved names like `bucket`.

* **Tests**
  * Expanded unit and integration coverage for validation, SQL generation, and bucket-name collision scenarios.

* **Documentation**
  * Updated contributor guidance to discourage broad `any` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->