### PR TITLE
feat(generator): validate the time column is in every PK / unique constraint

### DIFF
--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -557,10 +557,12 @@ function assertInEveryUniqueKey(model: DMMF.Model, fieldName: string, what: stri
     ...model.uniqueIndexes.map((u) => u.fields),
     ...model.fields.filter((f) => f.isUnique).map((f) => [f.name]), // single-field @unique
   ];
-  const missingFrom = keyFieldSets.find((fields) => !fields.includes(fieldName));
-  if (missingFrom) {
+  // Report every offending constraint at once, not just the first — a model with several bad
+  // unique indexes should be fixable in one pass, not one error per regenerate.
+  const missing = keyFieldSets.filter((fields) => !fields.includes(fieldName));
+  if (missing.length > 0) {
     throw new Error(
-      `${ctx}: ${what} must be included in every primary key / unique constraint (TimescaleDB requires all partitioning columns in unique indexes); it is missing from [${missingFrom.join(", ")}].`,
+      `${ctx}: ${what} must be included in every primary key / unique constraint (TimescaleDB requires all partitioning columns in unique indexes); it is missing from: ${missing.map((fields) => `[${fields.join(", ")}]`).join(", ")}.`,
     );
   }
 }

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -211,6 +211,7 @@ function buildHypertable(
       `${ctx}: column "${column}" has type ${field.type}; the partitioning column must be a DateTime field (integer time columns are not supported yet).`,
     );
   }
+  assertInEveryUniqueKey(model, column, `column "${column}"`, ctx);
   if (chunkInterval !== undefined) assertInterval(chunkInterval);
 
   const columns = columnMap(model);
@@ -374,22 +375,7 @@ function buildSpacePartition(
   if (!field) {
     throw new Error(`${ctx}: partitionColumn "${partitionColumn}" is not a scalar field on the model.`);
   }
-  // TimescaleDB requires every PK / unique index to include all partitioning columns, so a
-  // partitionColumn outside them fails at `migrate` ("cannot create a unique index without the
-  // column …"). Reject it at generation time with a clear error instead. Field names below are
-  // Prisma names, matching `partitionColumn`.
-  const keyFieldSets: (readonly string[])[] = [
-    ...(model.primaryKey?.fields ? [model.primaryKey.fields] : []),
-    ...model.fields.filter((f) => f.isId).map((f) => [f.name]), // single-field @id
-    ...model.uniqueIndexes.map((u) => u.fields),
-    ...model.fields.filter((f) => f.isUnique).map((f) => [f.name]), // single-field @unique
-  ];
-  const missingFrom = keyFieldSets.find((fields) => !fields.includes(partitionColumn));
-  if (missingFrom) {
-    throw new Error(
-      `${ctx}: partitionColumn "${partitionColumn}" must be included in every primary key / unique constraint (TimescaleDB requires all partitioning columns in unique indexes); it is missing from [${missingFrom.join(", ")}].`,
-    );
-  }
+  assertInEveryUniqueKey(model, partitionColumn, `partitionColumn "${partitionColumn}"`, ctx);
   const partitions = Number(partitionsRaw);
   if (!Number.isInteger(partitions) || partitions < 1) {
     throw new Error(`${ctx}: partitions must be a positive integer (got ${JSON.stringify(partitionsRaw)}).`);
@@ -556,6 +542,27 @@ function buildRefresh(ann: ReturnType<typeof parseAnnotations>[number], ctx: str
     endOffset: endOffset as Interval,
     scheduleInterval: scheduleInterval as Interval,
   };
+}
+
+/**
+ * TimescaleDB requires every PK / unique index to include ALL partitioning columns (the time
+ * column and any hash space-partition column), so one outside them passes generation and then
+ * fails `migrate deploy` with the opaque "cannot create a unique index without the column …".
+ * Reject at generation time with a clear error instead. Field names are Prisma names.
+ */
+function assertInEveryUniqueKey(model: DMMF.Model, fieldName: string, what: string, ctx: string): void {
+  const keyFieldSets: (readonly string[])[] = [
+    ...(model.primaryKey?.fields ? [model.primaryKey.fields] : []),
+    ...model.fields.filter((f) => f.isId).map((f) => [f.name]), // single-field @id
+    ...model.uniqueIndexes.map((u) => u.fields),
+    ...model.fields.filter((f) => f.isUnique).map((f) => [f.name]), // single-field @unique
+  ];
+  const missingFrom = keyFieldSets.find((fields) => !fields.includes(fieldName));
+  if (missingFrom) {
+    throw new Error(
+      `${ctx}: ${what} must be included in every primary key / unique constraint (TimescaleDB requires all partitioning columns in unique indexes); it is missing from [${missingFrom.join(", ")}].`,
+    );
+  }
 }
 
 /** Find a scalar (non-relation) field by name on a model. */

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -94,9 +94,10 @@ view SensorHourly {
 describe("extractTimescaleSchema — hypertable errors", () => {
   const htModel = (ann: string) => `/// ${ann}
 model M {
-  id    Int      @id
+  id    Int
   time  DateTime
   label String
+  @@id([id, time])
 }`;
 
   it("missing column arg", async () => {
@@ -744,10 +745,11 @@ describe("extractTimescaleSchema — relations", () => {
 /// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {
   time     DateTime
-  id       Int     @id
+  id       Int
   deviceId Int?
   device   Device? @relation(fields: [deviceId], references: [id])
   tags     Tag[]
+  @@id([id, time])
 }
 model Device {
   id       Int       @id
@@ -755,21 +757,22 @@ model Device {
   readings Reading[]
 }
 model Tag {
-  id        Int     @id
-  label     String
-  readingId Int
-  reading   Reading @relation(fields: [readingId], references: [id])
+  id          Int      @id
+  label       String
+  readingId   Int
+  readingTime DateTime
+  reading     Reading  @relation(fields: [readingId, readingTime], references: [id, time])
 }
 `);
     expect(result.hypertables[0]?.relations).toEqual([
       { field: "device", targetModel: "Device", table: "Device", list: false, on: [{ related: "id", outer: "deviceId" }], fk: ["deviceId"] },
-      { field: "tags", targetModel: "Tag", table: "Tag", list: true, on: [{ related: "readingId", outer: "id" }] },
+      { field: "tags", targetModel: "Tag", table: "Tag", list: true, on: [{ related: "readingId", outer: "id" }, { related: "readingTime", outer: "time" }] },
     ]);
     // Non-hypertable models' relations are emitted under relationsByModel (keyed by Prisma name),
     // so timeBucket where can resolve relation filters nested through them.
     expect(result.relationsByModel).toEqual({
       Device: [{ field: "readings", targetModel: "Reading", table: "Reading", list: true, on: [{ related: "deviceId", outer: "id" }] }],
-      Tag: [{ field: "reading", targetModel: "Reading", table: "Reading", list: false, on: [{ related: "id", outer: "readingId" }], fk: ["readingId"] }],
+      Tag: [{ field: "reading", targetModel: "Reading", table: "Reading", list: false, on: [{ related: "id", outer: "readingId" }, { related: "time", outer: "readingTime" }], fk: ["readingId", "readingTime"] }],
     });
   });
 
@@ -778,9 +781,10 @@ model Tag {
 /// @timescale.hypertable(column: "time")
 model Reading {
   time     DateTime
-  id       Int     @id
+  id       Int
   deviceId Int?
   device   Device? @relation(fields: [deviceId], references: [id])
+  @@id([id, time])
 }
 model Device {
   id       Int       @id @map("device_id")
@@ -932,5 +936,62 @@ model SensorReading {
   @@id([deviceId, time])
 }`),
     ).rejects.toThrow(/@timescale\.groupBy is a field-level annotation/);
+  });
+});
+
+describe("extractTimescaleSchema — time column must be in every PK / unique constraint", () => {
+  // TimescaleDB requires ALL partitioning columns in every unique index; a time column outside the
+  // PK passes generation but fails `migrate deploy` with an opaque "cannot create a unique index
+  // without the column ...". Space partitions already got this guard — the time column now does too.
+
+  it("rejects a time column missing from the primary key", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int      @id
+}`),
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[deviceId\]/s);
+  });
+
+  it("rejects a time column present in @@id but missing from a @@unique", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  serial   String
+  @@id([deviceId, time])
+  @@unique([serial])
+}`),
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[serial\]/s);
+  });
+
+  it("rejects a time column missing from a single-field @unique", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  serial   String   @unique
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[serial\]/s);
+  });
+
+  it("accepts a time column included in every constraint", async () => {
+    const { hypertables } = await extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  serial   String
+  @@id([deviceId, time])
+  @@unique([serial, time])
+}`);
+    expect(hypertables).toHaveLength(1);
   });
 });

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -952,7 +952,7 @@ model SensorReading {
   time     DateTime
   deviceId Int      @id
 }`),
-    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[deviceId\]/s);
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from: \[deviceId\]/s);
   });
 
   it("rejects a time column present in @@id but missing from a @@unique", async () => {
@@ -966,7 +966,7 @@ model SensorReading {
   @@id([deviceId, time])
   @@unique([serial])
 }`),
-    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[serial\]/s);
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from: \[serial\]/s);
   });
 
   it("rejects a time column missing from a single-field @unique", async () => {
@@ -979,7 +979,23 @@ model SensorReading {
   serial   String   @unique
   @@id([deviceId, time])
 }`),
-    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from \[serial\]/s);
+    ).rejects.toThrow(/column "time" must be included in every primary key \/ unique constraint.*missing from: \[serial\]/s);
+  });
+
+  it("reports every offending constraint at once, not just the first", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  serial   String
+  mac      String
+  @@id([deviceId, time])
+  @@unique([serial])
+  @@unique([mac])
+}`),
+    ).rejects.toThrow(/missing from: \[serial\], \[mac\]/);
   });
 
   it("accepts a time column included in every constraint", async () => {

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -342,9 +342,10 @@ datasource db {
 /// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {
   time     DateTime
-  id       Int     @id
+  id       Int
   deviceId Int?
   device   Device? @relation(fields: [deviceId], references: [id])
+  @@id([id, time])
 }
 model Device {
   id       Int       @id


### PR DESCRIPTION
> **Stacked on #61** — merge that first; GitHub will retarget this PR to `main` automatically when the base branch is deleted on merge.

## Problem

TimescaleDB requires **all** partitioning columns to be part of every PK / unique index. The hash space-partition column already gets a clear generation-time error, but the time column itself was never checked:

```prisma
/// @timescale.hypertable(column: "time")
model SensorReading {
  time     DateTime
  deviceId Int      @id     // time not in the key
}
```

passed `prisma generate` and failed later at `migrate deploy` with the opaque `cannot create a unique index without the column "time"`.

## Fix

The existing space-partition guard is extracted into `assertInEveryUniqueKey` and applied to the time column too — same clear error message, pointing at the exact constraint the column is missing from. Checks the compound `@@id`, single-field `@id`, `@@unique`, and single-field `@unique`.

## Tests (TDD — written first, red → green)

- 4 new unit cases: missing from PK, present in `@@id` but missing from a `@@unique`, missing from a single-field `@unique`, and the fully-valid accept case.
- The new guard caught **4 existing test fixtures** whose hypertables were keyed by a plain `id` — schemas that cannot exist on real TimescaleDB (exactly what the review predicted: "every test schema *happens* to include the time column" — these didn't). Fixed to compound keys; the `Tag → Reading` FK fixture now references the compound key, the only shape a real hypertable FK can take.
- Full run: 267 unit, type tests, and the complete integration suite (27 files / 62 tests, rebuilt generator) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for TimescaleDB schemas so time partition columns must be included in every primary key and unique constraint.
  * Relation handling now supports compound identifiers and multi-column joins more reliably.
  * Added coverage for common schema validation errors involving partitioning and uniqueness rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->