### PR TITLE
chore: adopt shared-configs reusable workflows and templates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,24 +1,4 @@
-# CodeRabbit configuration — tames review volume so a burst of small PRs
-# doesn't hit the hourly review rate limit.
-# Schema/docs: https://docs.coderabbit.ai/configuration/auto-review
-#
-# NOTE: this file takes precedence over the organization UI settings for this
-# repo, so the review profile is restated here.
-reviews:
-  profile: chill
-  # Quieter bot = fewer GitHub notification emails: no "currently reviewing"
-  # status comments and no walkthrough poems. The review findings themselves
-  # are unaffected.
-  review_status: false
-  poem: false
-  auto_review:
-    enabled: true
-    # One auto review when the PR opens. Pushes that address review comments
-    # do NOT re-trigger a review — when the fixes are ready for a re-check,
-    # request one explicitly by commenting "@coderabbitai review".
-    auto_incremental_review: false
-    # Machine-generated PRs with nothing meaningful to review.
-    ignore_title_keywords:
-      - "chore(main): release"
-    ignore_usernames:
-      - "dependabot[bot]"
+# CodeRabbit — pulls the shared configuration for all Krister-Johansson repos.
+# Shared config: https://github.com/Krister-Johansson/shared-configs/blob/main/.coderabbit.yaml
+remote_config:
+  url: "https://raw.githubusercontent.com/Krister-Johansson/shared-configs/main/.coderabbit.yaml"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug report
+description: Something does not work as documented
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Smallest possible setup (code, config, commands) that shows the bug.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "Node version, OS, relevant tool versions"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Every change starts as an issue (issue-first workflow), so keep blank issues
+# available for anything the forms don't cover.
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Krister-Johansson/prisma-extension-timescaledb/security/advisories/new
+    about: Report vulnerabilities privately via GitHub Security Advisories — never in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose new functionality or an improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that is currently hard or impossible?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should the feature look like? Include an API sketch if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+Closes #<!-- issue number — required; CI fails PRs that don't reference an issue -->
+
+## Checklist
+
+- [ ] An issue exists for this change and is linked above (issue-first workflow)
+- [ ] Tests were written **before** the implementation (TDD) and fail without it
+- [ ] `npm run build && npm run typecheck && npm run coverage` passes locally (plus `lint` if the repo has it)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, ...)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
     with:
       post-test-scripts: "test:types attw"
       upload-coverage-artifact: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
     with:
       post-test-scripts: "test:types attw"
       upload-coverage-artifact: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Build/test matrix comes from the shared reusable workflow in
+# Krister-Johansson/shared-configs (dependabot keeps the pinned version fresh);
+# the integration and coverage-comment jobs are repo-specific and live here.
 name: CI
 
 on:
@@ -5,47 +8,18 @@ on:
     branches: [main]
   pull_request:
 
-# Least-privilege default token; no job here needs write access.
+# Least-privilege default token; jobs elevate only what they need.
 permissions:
   contents: read
 
 jobs:
-  build-test:
-    name: build + unit/type tests (node ${{ matrix.node }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node }}
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-      - run: npm run typecheck
-      - run: npm run coverage      # runs unit tests + enforces coverage thresholds
-      - run: npm run test:types
-      - run: npm run attw
-      - name: Upload coverage report
-        if: matrix.node == 20
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage
-          path: coverage/
-          if-no-files-found: error
-      - name: Upload coverage to Codecov
-        if: matrix.node == 20
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          # Best-effort: never fail CI on an upload hiccup or a not-yet-set token.
-          fail_ci_if_error: false
+  ci:
+    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
+    with:
+      post-test-scripts: "test:types attw"
+      upload-coverage-artifact: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration:
     name: integration (real TimescaleDB)
@@ -67,10 +41,10 @@ jobs:
 
   coverage-comment:
     name: coverage comment
-    needs: build-test
+    needs: ci
     # PRs only — there's no PR to comment on for pushes to main. Kept as its own job
     # so the pull-requests:write token never covers a job that runs project code
-    # (build-test stays contents:read). It consumes the coverage artifact only.
+    # (the build-test matrix stays contents:read). It consumes the coverage artifact only.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,7 @@
+# Thin caller for the shared CodeQL workflow. The triggers must live here
+# (cron cannot be defined in a reusable workflow).
+# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# shared-configs release (see AGENTS.md step 4).
 name: CodeQL
 
 on:
@@ -8,27 +12,13 @@ on:
   schedule:
     - cron: "31 7 * * 2"
 
-# Least-privilege default; the analyze job adds only the write scope it needs.
 permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (JavaScript/TypeScript)
-    runs-on: ubuntu-latest
+  codeql:
+    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
     permissions:
       security-events: write # upload results to code scanning
       actions: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          languages: javascript-typescript
-      # No build step: CodeQL analyzes JS/TS sources directly.
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          category: "/language:javascript-typescript"
+      contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # Thin caller for the shared CodeQL workflow. The triggers must live here
 # (cron cannot be defined in a reusable workflow).
-# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
 # shared-configs release (see AGENTS.md step 4).
 name: CodeQL
 
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   codeql:
-    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
     permissions:
       security-events: write # upload results to code scanning
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   codeql:
-    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
     permissions:
       security-events: write # upload results to code scanning
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 # Thin caller for the shared CodeQL workflow. The triggers must live here
 # (cron cannot be defined in a reusable workflow).
-# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
-# shared-configs release (see AGENTS.md step 4).
+# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
+# the pinned version fresh.
 name: CodeQL
 
 on:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,6 @@
 # Thin caller for the shared release-please + npm publish workflow.
-# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
-# shared-configs release (see AGENTS.md step 4).
+# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
+# the pinned version fresh.
 #
 # publish-strategy 'oidc' needs a one-time Trusted Publisher on npmjs.com
 # (Package → Settings → Trusted Publisher):

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,5 @@
 # Thin caller for the shared release-please + npm publish workflow.
-# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
 # shared-configs release (see AGENTS.md step 4).
 #
 # publish-strategy 'oidc' needs a one-time Trusted Publisher on npmjs.com
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,54 +1,32 @@
+# Thin caller for the shared release-please + npm publish workflow.
+# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# shared-configs release (see AGENTS.md step 4).
+#
+# publish-strategy 'oidc' needs a one-time Trusted Publisher on npmjs.com
+# (Package → Settings → Trusted Publisher):
+#   Provider: GitHub Actions · Organization: Krister-Johansson
+#   Repository: <this repo> · Workflow filename: release-please.yml
 name: release-please
 
 on:
   push:
     branches: [main]
-  # Manual re-publish of the current version on main — e.g. when an auto-publish failed AFTER the
-  # GitHub release was already created (so release_created is no longer true on a re-run). Safe to
-  # re-trigger: npm publish errors out as a no-op if the version is already on the registry.
+  # Manual re-publish of the current version on main — e.g. when an auto-publish
+  # failed AFTER the GitHub release was created. Safe: npm publish fails harmlessly
+  # if the version is already on the registry.
   workflow_dispatch:
 
-# Least-privilege at the top level (satisfies Scorecard's Token-Permissions check); the
-# single release job elevates only what release-please + npm provenance actually need.
 permissions:
   contents: read
 
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
+  release:
+    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR
-      id-token: write # npm provenance (supply-chain attestation) via OIDC
-    env:
-      # Surfaced so the publish steps can gate on its presence. Empty when the secret is
-      # unset, which makes the steps below skip — npm publish stays OFF until you add it.
+      id-token: write # npm Trusted Publishing / provenance
+    with:
+      publish-strategy: oidc # or "npm-token" (then add the NPM_TOKEN secret)
+    secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-        id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Manifest mode: config in release-please-config.json + .release-please-manifest.json.
-          # Maintains a release PR that bumps the version and updates CHANGELOG.md from
-          # Conventional Commits; merging that PR creates the git tag + GitHub release.
-
-      # ── npm publish — runs when a release was just created (or this workflow is manually
-      # dispatched to re-publish the current version on main) AND an NPM_TOKEN secret is configured.
-      # No secret => these steps skip, so publishing stays off until the secret is added.
-      # prepublishOnly (build + tests + attw) runs as the pre-publish gate.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
-        with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
-      - run: npm publish --provenance --access public
-        if: ${{ (steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && env.NPM_TOKEN != '' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,7 @@
 # Thin caller for the shared OpenSSF Scorecard workflow. The triggers must live
 # here (cron cannot be defined in a reusable workflow).
-# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
-# shared-configs release (see AGENTS.md step 4).
+# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
+# the pinned version fresh.
 name: Scorecard supply-chain security
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,8 +22,9 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
     permissions:
+      contents: read # job permissions replace read-all; the scan needs repo reads
       security-events: write # SARIF upload to code scanning
       id-token: write # publish results to the OpenSSF API (badge)
     secrets:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,7 @@
+# Thin caller for the shared OpenSSF Scorecard workflow. The triggers must live
+# here (cron cannot be defined in a reusable workflow).
+# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# shared-configs release (see AGENTS.md step 4).
 name: Scorecard supply-chain security
 
 on:
@@ -8,47 +12,19 @@ on:
     - cron: "27 7 * * 1"
   push:
     branches: [main]
+  # Allow re-scanning on demand (Actions tab → Run workflow).
+  workflow_dispatch:
 
-# Least-privilege by default; the analysis job elevates only what it needs.
+# Least-privilege by default; the reusable workflow's job elevates what it needs.
+# Do NOT add top-level env/defaults/write permissions — the Scorecard publish API
+# rejects workflows that have them.
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+  scorecard:
+    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
     permissions:
-      # Upload the SARIF result to the code-scanning dashboard.
-      security-events: write
-      # OIDC token used to publish results to the public OpenSSF API (powers the badge).
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # A PAT with Administration:read lets Scorecard read branch-protection rules
-          # (the default GITHUB_TOKEN can't, which is why Branch-Protection errors). Falls
-          # back to GITHUB_TOKEN until a SCORECARD_TOKEN secret is added — nothing breaks.
-          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
-          # Publish to the OpenSSF API so the README badge resolves.
-          publish_results: true
-
-      # Retain the SARIF for manual inspection / debugging.
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # Surface findings under Security → Code scanning.
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: results.sarif
+      security-events: write # SARIF upload to code scanning
+      id-token: write # publish results to the OpenSSF API (badge)
+    secrets:
+      SCORECARD_TOKEN: ${{ secrets.SCORECARD_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,6 +1,6 @@
 # Thin caller for the shared OpenSSF Scorecard workflow. The triggers must live
 # here (cron cannot be defined in a reusable workflow).
-# Replace dbbed055bad959646f34cb7b5bee812ee063bfcc / v1.0.0 with the latest
+# Replace 0ecc2e4800d4a489a6fba3170a290cc01b32e286 / v1.0.0 with the latest
 # shared-configs release (see AGENTS.md step 4).
 name: Scorecard supply-chain security
 
@@ -22,7 +22,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@dbbed055bad959646f34cb7b5bee812ee063bfcc # v1.0.0
+    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@0ecc2e4800d4a489a6fba3170a290cc01b32e286 # v1.1.0
     permissions:
       security-events: write # SARIF upload to code scanning
       id-token: write # publish results to the OpenSSF API (badge)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Working in this repository (agents & humans)
+
+This repo follows the shared setup from
+[Krister-Johansson/shared-configs](https://github.com/Krister-Johansson/shared-configs).
+These rules are binding for AI agents working here; CONTRIBUTING.md is the
+human-facing version.
+
+> **Also read [CLAUDE.md](CLAUDE.md)** — it holds the TimescaleDB/Prisma-specific
+> constraints (idempotent DDL, reset-safety, DMMF isolation, ...). Nothing below
+> overrides it.
+
+## Workflow rules
+
+### 1. Issue-first — no code without an issue
+
+Every piece of work starts as a GitHub issue describing the problem or feature.
+If none exists, create one before touching code:
+
+```sh
+gh issue create --title "<imperative summary>" --body "<problem, expected behavior, context>"
+```
+
+Every pull request MUST reference its issue with `Closes #<number>` in the PR
+description. The CI job `linked issue` fails PRs that don't.
+
+### 2. Test-driven development (TDD)
+
+1. Write the test first — unit (`test/unit`), type-level (`test/types`), or
+   integration (`test/integration`, Testcontainers), whichever fits the change.
+2. Run it and **confirm it fails** for the expected reason.
+3. Implement the minimal change that makes it pass.
+4. Refactor with the tests green.
+
+New functionality and bug fixes without accompanying tests are rejected in
+review. Any change to emitted migration SQL must come with an integration test
+proving reset-safety (see CLAUDE.md).
+
+### 3. Conventional Commits
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+(`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`; `!`/`BREAKING CHANGE:` for
+majors). They drive automated releases via release-please — a wrong type means a
+wrong version bump.
+
+### 4. Branch and verify
+
+- Branch from `main`; one issue per branch/PR.
+- Before pushing, run the local CI equivalent:
+  `npm run build && npm run typecheck && npm run coverage && npm run test:types && npm run attw`
+  (integration tests need Docker: `npm run test:integration`).
+- All changes land through PRs — `main` is protected; CI must be green.
+
+## Release model (do not do these manually)
+
+- Versions, tags, CHANGELOG.md, and GitHub releases are managed by release-please.
+  Never bump `version` in package.json or edit CHANGELOG.md by hand.
+- npm publishing happens in CI after the release PR merges.


### PR DESCRIPTION
Closes #63

## Summary

Adopts the shared repo setup from [shared-configs](https://github.com/Krister-Johansson/shared-configs) (pinned to [v1.1.1](https://github.com/Krister-Johansson/shared-configs/releases/tag/v1.1.1); dependabot bumps the pin weekly):

- **CI**: the Node 20/22 build/test matrix (build + typecheck + coverage + `test:types` + `attw` + Codecov) now comes from the shared reusable workflow; the **integration** (Testcontainers/TimescaleDB) and **coverage-comment** jobs stay local in this file.
- **release-please**: same manifest-mode flow, but npm publishing switches from `NPM_TOKEN` to **OIDC Trusted Publishing** — no secret, no 2FA/EOTP pain, provenance automatic.
- **CodeQL / Scorecard**: thin callers, same behavior.
- **CodeRabbit** (net-new): `.coderabbit.yaml` pulls the shared remote config (chill profile, no poems, ignores dependabot/release PRs).
- **New:** issue templates, PR template, and AGENTS.md — every PR must reference an issue (enforced by the new `linked issue` CI job) and development follows TDD. CLAUDE.md keeps the TimescaleDB-specific constraints.

## Before merging

- [x] **Set up npm Trusted Publishing** (required for the new publish flow): npmjs.com → `prisma-extension-timescaledb` → Settings → Trusted Publisher → Provider *GitHub Actions*, Organization *Krister-Johansson*, Repository *prisma-extension-timescaledb*, Workflow filename *release-please.yml*. (Fallback: set `publish-strategy: npm-token` in `.github/workflows/release-please.yml` to keep the old flow.)
- [x] **Install the CodeRabbit GitHub App** on this repo so the new `.coderabbit.yaml` takes effect.
- [ ] Required status checks on `main` reference the old job names (`build + unit/type tests (node XX)`); update to the new contexts shown on this PR's checks (I can do this at merge time). The `NPM_TOKEN` secret can be deleted after the first successful OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for contributors and automated agents, including workflow expectations, testing, and release process notes.
  * Added GitHub issue and pull request templates to standardize bug reports, feature requests, and PR submissions.
  * Added a private security reporting link in the issue template settings.

* **Chores**
  * Updated CI, code scanning, release, scorecard, and review automation to use shared workflows and centralized configuration for more consistent maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

