### PR TITLE
fix(ci): scorecard caller permissions map + shared-configs v1.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
+    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@aee270c33b8c3d957f818a22b8f3fa1f6b987e9d # v1.1.3
     with:
       post-test-scripts: "test:types attw"
       upload-coverage-artifact: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   codeql:
-    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
+    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@aee270c33b8c3d957f818a22b8f3fa1f6b987e9d # v1.1.3
     permissions:
       security-events: write # upload results to code scanning
       actions: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
+    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@aee270c33b8c3d957f818a22b8f3fa1f6b987e9d # v1.1.3
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,11 +18,12 @@ on:
 # Least-privilege by default; the reusable workflow's job elevates what it needs.
 # Do NOT add top-level env/defaults/write permissions — the Scorecard publish API
 # rejects workflows that have them.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   scorecard:
-    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@d3f276e6ea20fdfe5faa202d06c83d4435e101f0 # v1.1.1
+    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@aee270c33b8c3d957f818a22b8f3fa1f6b987e9d # v1.1.3
     permissions:
       contents: read # job permissions replace read-all; the scan needs repo reads
       security-events: write # SARIF upload to code scanning


### PR DESCRIPTION
Closes #65

The push-triggered Scorecard run failed at startup (`startup_failure`, 'workflow file issue'): the `permissions: read-all` shorthand on a workflow involved in a reusable call fails validation when the job elevates to `security-events: write` / `id-token: write`. The release-please and CodeQL callers elevate over an explicit `contents: read` map and work — scorecard now does the same, and all shared-configs pins move to [v1.1.3](https://github.com/Krister-Johansson/shared-configs/releases/tag/v1.1.3) which carries the same fix in the called workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automated workflows to newer pinned versions of shared CI, release, CodeQL, and Scorecard configurations.
  * Tightened workflow permissions for Scorecard to use a more limited read-only access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->