### PR TITLE
fix(generator): name the model/field in annotation parse errors

### DIFF
--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -23,6 +23,7 @@ import {
   optionalString,
   parseAnnotations,
   requireString,
+  type ParsedAnnotation,
 } from "./annotations.js";
 
 export interface TimescaleSchema {
@@ -111,7 +112,9 @@ function parseAnnotationsOn(doc: string | null | undefined, where: string): Retu
   try {
     return parseAnnotations(doc);
   } catch (e) {
-    throw new Error(`Invalid @timescale annotation on ${where}: ${e instanceof Error ? e.message : String(e)}`);
+    throw new Error(`Invalid @timescale annotation on ${where}: ${e instanceof Error ? e.message : String(e)}`, {
+      cause: e,
+    });
   }
 }
 
@@ -135,10 +138,14 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
       assertKnownArgs(name, a.args, ANNOTATION_ARGS[name], `@timescale.${name} on ${ctx}`);
     }
     const isCagg = findAnnotation(annotations, "continuousAggregate") !== undefined;
+    // Parsed once here (with location context) and handed to buildCagg below — re-parsing there
+    // would be redundant work and its errors could never fire (this loop already threw).
+    const fieldAnnotations = new Map<string, ParsedAnnotation[]>();
     for (const field of model.fields) {
       const fctx = `"${model.name}.${field.name}"`;
       const fieldAnns = parseAnnotationsOn(field.documentation, fctx);
       if (fieldAnns.length === 0) continue;
+      fieldAnnotations.set(field.name, fieldAnns);
       if (!isCagg) {
         throw new Error(
           `@timescale.${fieldAnns[0]!.name} on ${fctx}: field-level annotations are only valid on a @timescale.continuousAggregate view.`,
@@ -164,7 +171,7 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
       }
     }
     if (findAnnotation(annotations, "continuousAggregate")) {
-      continuousAggregates.push(buildCagg(model, annotations, byName));
+      continuousAggregates.push(buildCagg(model, annotations, byName, fieldAnnotations));
     }
   }
 
@@ -447,6 +454,7 @@ function buildCagg(
   view: DMMF.Model,
   annotations: ReturnType<typeof parseAnnotations>,
   byName: Map<string, DMMF.Model>,
+  fieldAnnotations: ReadonlyMap<string, ParsedAnnotation[]>,
 ): CaggConfig {
   const ctx = `@timescale.continuousAggregate on view "${view.name}"`;
   const ann = findAnnotation(annotations, "continuousAggregate")!;
@@ -479,7 +487,8 @@ function buildCagg(
   const aggregates: AggregateSpec[] = [];
 
   for (const field of view.fields) {
-    const fieldAnns = parseAnnotationsOn(field.documentation, `"${view.name}.${field.name}"`);
+    // Parsed (and syntax-validated, with location context) by the caller's field loop.
+    const fieldAnns = fieldAnnotations.get(field.name) ?? [];
     const fctx = `@timescale field on "${view.name}.${field.name}"`;
 
     if (findAnnotation(fieldAnns, "bucket")) {

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -102,6 +102,19 @@ function assertKnownArgs(name: string, args: Record<string, unknown>, allowed: r
   }
 }
 
+/**
+ * Parse a doc string's annotations, prefixing any parser error with WHERE it happened. The parser
+ * is deliberately DMMF-free, so its errors ("Malformed annotation argument ...") name only the
+ * offending text — useless in a large schema without the model/field it sits on.
+ */
+function parseAnnotationsOn(doc: string | null | undefined, where: string): ReturnType<typeof parseAnnotations> {
+  try {
+    return parseAnnotations(doc);
+  } catch (e) {
+    throw new Error(`Invalid @timescale annotation on ${where}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
 /** Extract and validate all TimescaleDB configs from a Prisma DMMF document. */
 export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   const models = dmmf.datamodel.models;
@@ -111,7 +124,7 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
   const continuousAggregates: CaggConfig[] = [];
 
   for (const model of models) {
-    const annotations = parseAnnotations(model.documentation);
+    const annotations = parseAnnotationsOn(model.documentation, `model "${model.name}"`);
 
     // Validate the full annotation surface FIRST — names and argument keys, at both levels —
     // so a typo fails generation instead of silently no-oping (H2 in the review).
@@ -123,9 +136,9 @@ export function extractTimescaleSchema(dmmf: DMMF.Document): TimescaleSchema {
     }
     const isCagg = findAnnotation(annotations, "continuousAggregate") !== undefined;
     for (const field of model.fields) {
-      const fieldAnns = parseAnnotations(field.documentation);
-      if (fieldAnns.length === 0) continue;
       const fctx = `"${model.name}.${field.name}"`;
+      const fieldAnns = parseAnnotationsOn(field.documentation, fctx);
+      if (fieldAnns.length === 0) continue;
       if (!isCagg) {
         throw new Error(
           `@timescale.${fieldAnns[0]!.name} on ${fctx}: field-level annotations are only valid on a @timescale.continuousAggregate view.`,
@@ -466,7 +479,7 @@ function buildCagg(
   const aggregates: AggregateSpec[] = [];
 
   for (const field of view.fields) {
-    const fieldAnns = parseAnnotations(field.documentation);
+    const fieldAnns = parseAnnotationsOn(field.documentation, `"${view.name}.${field.name}"`);
     const fctx = `@timescale field on "${view.name}.${field.name}"`;
 
     if (findAnnotation(fieldAnns, "bucket")) {

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -1011,3 +1011,41 @@ model SensorReading {
     expect(hypertables).toHaveLength(1);
   });
 });
+
+describe("extractTimescaleSchema — parse errors carry model/field context", () => {
+  // The annotation parser is deliberately DMMF-free, so its errors ("Malformed annotation
+  // argument ...") name only the offending text. In a large schema that means grepping —
+  // the DMMF layer must say which model/field the bad annotation sits on.
+
+  it("names the model for a malformed model-level annotation", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column "time")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  @@id([deviceId, time])
+}`),
+    ).rejects.toThrow(/on model "SensorReading".*Malformed annotation argument/s);
+  });
+
+  it("names the view field for a malformed field-level annotation", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket  DateTime /// @timescale.bucket
+  avgTemp Float    /// @timescale.aggregate(fn "avg", column: "temperature")
+  @@unique([bucket])
+}`),
+    ).rejects.toThrow(/on "SensorHourly\.avgTemp".*Malformed annotation argument/s);
+  });
+});


### PR DESCRIPTION
Closes #70

## Problem

The annotation parser is deliberately DMMF-free (per the file-split design), so its syntax errors — `Malformed annotation argument: ...`, `Unbalanced () ...`, `Unterminated string ...` — name only the offending text. In a schema with dozens of models, the user has to grep for which `///` line broke.

## Fix

All three `parseAnnotations` call sites in the DMMF layer now go through `parseAnnotationsOn`, which prefixes parser errors with the location:

```
Invalid @timescale annotation on model "SensorReading": Malformed annotation argument: ...
Invalid @timescale annotation on "SensorHourly.avgTemp": Malformed annotation argument: ...
```

The parser itself stays DMMF-free; only the layer that knows the model/field adds context (same philosophy as the existing `@timescale.x on model "Y"` validation errors).

## Tests (TDD — written first, red → green)

Two new unit cases: a malformed model-level annotation names the model; a malformed field-level annotation names `View.field`. 270/270 unit tests green, typecheck clean.

Closes the last P1 item from the code review (follows #61, #62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation parsing error messages to include where the problem occurred, such as the model, field, or view field name.
  * Malformed `@timescale` annotations now surface clearer, context-rich feedback instead of generic parsing errors.

* **Tests**
  * Added coverage for parsing failures to verify that error messages include the correct model and field context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
