### PR TITLE
docs: agents must not merge PRs or enable auto-merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ wrong version bump.
   `npm run build && npm run typecheck && npm run coverage && npm run test:types && npm run attw`
   (integration tests need Docker: `npm run test:integration`).
 - All changes land through PRs — `main` is protected; CI must be green.
+- **Agents never merge PRs and never enable auto-merge.** CodeRabbit's review
+  must complete (it is not a required status check, so auto-merge would not
+  wait for it), and the merge itself is a human decision. When everything is
+  green, report the PR as ready to merge.
 
 ## Release model (do not do these manually)
 


### PR DESCRIPTION
Closes #68

Adds the workflow rule to AGENTS.md after gqlPrune#81 was auto-merged before CodeRabbit completed its review: agents prepare PRs and report them ready; a human merges once CodeRabbit's review is complete (it is not a required status check, so auto-merge would not wait for it).

**Not arming auto-merge on this PR — merging is yours.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the review and merge workflow, including that AI-generated reviews must finish before a human approves merging after CI passes.
  * Added guidance preventing automatic merges by AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->