### PR TITLE
ci(dependabot): ignore TypeScript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 breaks tsup and vitest, which consume the TypeScript 6
+      # compiler API (see issue #79). Remove once the toolchain supports TS 7.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
     groups:
       npm-development:
         dependency-type: development


### PR DESCRIPTION
## What

Adds an ignore rule to `.github/dependabot.yml` so dependabot stops proposing TypeScript major bumps in the npm-development group.

## Why

PR #78 fails all three test jobs with `TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`. The group carries a TypeScript 6.0.3 to 7.0.2 bump, and tsup and vitest consume the TypeScript 6 compiler API, so they crash under TS 7. The other ten updates in that group are fine but cannot land while the group includes the bump.

After this merges, a `@dependabot recreate` comment on #78 rebuilds the group without TypeScript. The rule comes out again once tsup and vitest support TypeScript 7.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)