### PR TITLE
chore: bump brace-expansion to clear npm audit DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3086,9 +3086,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

A three-line lockfile change from `npm audit fix`: brace-expansion 2.1.1 to 2.1.4, clearing three high-severity DoS advisories (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895). Dev tree only; the published package has one runtime dependency and is unaffected.

Run with Node 24 / npm 11.16, matching CI's toolchain, so the lockfile keeps its platform-specific optionals (the known npm-version skew trap). Build and all 270 unit tests pass locally.

## Not fixed here

The one remaining finding, esbuild (low, arbitrary file read via the dev server on Windows), sits inside tsup's pinned range; `npm audit fix` cannot move it. It clears when tsup bumps its esbuild dependency, which dependabot's weekly group will pick up.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)