### PR TITLE
ci: vendor the shared-configs workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
-# Build/test matrix comes from the shared reusable workflow in
-# Krister-Johansson/shared-configs (dependabot keeps the pinned version fresh);
-# the integration and coverage-comment jobs are repo-specific and live here.
+# CI for this repository: build, typecheck, and the test suite with coverage
+# thresholds on Node 20 and 22, the type-level and published-types checks, the
+# issue-link check, the real-TimescaleDB integration suite, and the PR
+# coverage comment.
+#
+# Owned here since #90 (previously a thin caller into the shared-configs
+# reusable CI, now deprecated). The job names deliberately match the branch
+# ruleset's required status-check contexts ("ci / build + test (node NN)",
+# "ci / linked issue", "integration (real TimescaleDB)"), so the ruleset
+# needs no change.
 name: CI
 
 on:
@@ -13,13 +20,43 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    uses: Krister-Johansson/shared-configs/.github/workflows/ci.yml@b0186b7fb41009fc90457c1367869317c30fbfaf # v1.3.0
-    with:
-      post-test-scripts: "test:types attw"
-      upload-coverage-artifact: true
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  build-test:
+    name: ci / build + test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+      - run: npm run coverage
+      - run: npm run test:types
+      - run: npm run attw
+      - name: Upload coverage artifact
+        # First matrix entry only — one artifact is enough for the comment job.
+        if: strategy.job-index == 0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage
+          path: coverage/
+          if-no-files-found: error
+      - name: Upload coverage to Codecov
+        if: strategy.job-index == 0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Best-effort: never fail CI on an upload hiccup.
+          fail_ci_if_error: false
 
   integration:
     name: integration (real TimescaleDB)
@@ -39,9 +76,33 @@ jobs:
       # ubuntu-latest runners ship Docker, so Testcontainers can run the reset-safety proof.
       - run: npm run test:integration
 
+  # Every PR must track a GitHub issue (issue-first workflow). Machine PRs
+  # (dependabot, release-please) are exempt. The exemption keys on the PR
+  # AUTHOR, not github.actor: a maintainer updating a dependabot branch must
+  # not un-skip this required check (hit during the #75 triage). Skipped jobs
+  # count as passing for the ruleset, so this is safe to require.
+  require-issue-link:
+    name: ci / linked issue
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that the PR closes an issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?):? +([a-z0-9._-]+/[a-z0-9._-]+)?#[0-9]+'; then
+            echo "PR references an issue."
+          else
+            echo "::error::Every PR must track a GitHub issue. Add 'Closes #<issue-number>' to the PR description."
+            exit 1
+          fi
+
   coverage-comment:
     name: coverage comment
-    needs: ci
+    needs: build-test
     # PRs only — there's no PR to comment on for pushes to main. Kept as its own job
     # so the pull-requests:write token never covers a job that runs project code
     # (the build-test matrix stays contents:read). It consumes the coverage artifact only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,16 +77,20 @@ jobs:
       - run: npm run test:integration
 
   # Every PR must track a GitHub issue (issue-first workflow). Machine PRs
-  # (dependabot, release-please) are exempt. The exemption keys on the PR
-  # AUTHOR, not github.actor: a maintainer updating a dependabot branch must
-  # not un-skip this required check (hit during the #75 triage). Skipped jobs
-  # count as passing for the ruleset, so this is safe to require.
+  # (dependabot, release-please) are exempt. The exemptions key on facts an
+  # outside author cannot fake: the PR author for dependabot (not
+  # github.actor — a maintainer updating a dependabot branch must not
+  # un-skip this required check, hit during the #75 triage), and a
+  # same-repo release-please branch for release PRs (creating one needs
+  # write access; a title is author-controlled). Skipped jobs count as
+  # passing for the ruleset, so this is safe to require.
   require-issue-link:
     name: ci / linked issue
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      !startsWith(github.event.pull_request.title, 'chore(main): release')
+      !(github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
       - name: Check that the PR closes an issue

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
-# Thin caller for the shared CodeQL workflow. The triggers must live here
-# (cron cannot be defined in a reusable workflow).
-# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
-# the pinned version fresh.
+# CodeQL static analysis.
+#
+# Owned here since #90 (previously a thin caller into the shared-configs
+# reusable CodeQL workflow, now deprecated).
 name: CodeQL
 
 on:
@@ -12,13 +12,27 @@ on:
   schedule:
     - cron: "31 7 * * 2"
 
+# Least-privilege default; the analyze job adds only the write scope it needs.
 permissions:
   contents: read
 
 jobs:
-  codeql:
-    uses: Krister-Johansson/shared-configs/.github/workflows/codeql.yml@b0186b7fb41009fc90457c1367869317c30fbfaf # v1.3.0
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # upload results to code scanning
       actions: read
-      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: javascript-typescript
+      # No build step: CodeQL analyzes JS/TS sources directly.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@
 # Trusted Publisher):
 #   Provider: GitHub Actions · Organization: Krister-Johansson
 #   Repository: prisma-extension-timescaledb · Workflow filename: release-please.yml
+#   Allowed actions: npm publish (mandatory for configurations created on or
+#   after 2026-05-20)
 name: release-please
 
 on:
@@ -34,6 +36,7 @@ jobs:
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR
+      issues: write # release-please labels PRs; labeling uses the issues API
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -75,6 +78,9 @@ jobs:
               process.exit(1);
             }
           " "$V"
-      - run: npm ci
+      # --ignore-scripts: dependency lifecycle scripts must not run in the job
+      # holding the OIDC signing identity. The full prepublishOnly gate (build,
+      # unit and type tests, attw) passes without them — verified in #91.
+      - run: npm ci --ignore-scripts
       # prepublishOnly (build + unit + type tests + attw) runs as the pre-publish gate.
       - run: npm publish --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,32 +1,80 @@
-# Thin caller for the shared release-please + npm publish workflow.
-# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
-# the pinned version fresh.
+# Release automation: release-please (manifest mode) maintains the release PR
+# from Conventional Commits; merging it creates the tag and GitHub release, and
+# the publish job ships to npm through Trusted Publishing (OIDC, provenance
+# automatic, no token).
 #
-# publish-strategy 'oidc' needs a one-time Trusted Publisher on npmjs.com
-# (Package → Settings → Trusted Publisher):
+# Owned here since #90 (previously a thin caller into shared-configs, now
+# deprecated). The release-please step uses the RELEASE_PLEASE_TOKEN secret (a
+# fine-grained PAT: contents + pull-requests, read/write, this repo only) with
+# a GITHUB_TOKEN fallback. With the PAT, the events release-please creates are
+# real user events, so CI runs on release PRs (no close/reopen needed) and
+# release-published workflows (sbom.yml) fire.
+#
+# npm Trusted Publisher setup (one-time, on npmjs.com — Package → Settings →
+# Trusted Publisher):
 #   Provider: GitHub Actions · Organization: Krister-Johansson
-#   Repository: <this repo> · Workflow filename: release-please.yml
+#   Repository: prisma-extension-timescaledb · Workflow filename: release-please.yml
 name: release-please
 
 on:
   push:
     branches: [main]
   # Manual re-publish of the current version on main — e.g. when an auto-publish
-  # failed AFTER the GitHub release was created. Safe: npm publish fails harmlessly
-  # if the version is already on the registry.
+  # failed AFTER the GitHub release was created. Safe: npm publish fails
+  # harmlessly if the version is already on the registry.
   workflow_dispatch:
 
+# Least-privilege at the top level; each job elevates only what it needs.
 permissions:
   contents: read
 
 jobs:
-  release:
-    uses: Krister-Johansson/shared-configs/.github/workflows/release-please.yml@b0186b7fb41009fc90457c1367869317c30fbfaf # v1.3.0
+  release-please:
+    runs-on: ubuntu-latest
     permissions:
       contents: write # release commits, tags, and the GitHub release
       pull-requests: write # maintain the release PR
-      id-token: write # npm Trusted Publishing / provenance
-    with:
-      publish-strategy: oidc # or "npm-token" (then add the NPM_TOKEN secret)
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Manifest mode: release-please-config.json + .release-please-manifest.json.
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false # never cache in release builds
+      # Trusted Publishing requires npm >= 11.5.1. Recent Node 24.x bundles a
+      # satisfying npm, so no self-install is needed (and none would be
+      # hash-pinnable); assert the floor instead of assuming it.
+      - name: Assert npm >= 11.5.1 (Trusted Publishing floor)
+        run: |
+          V="$(npm --version)"
+          node -e "
+            const need = [11, 5, 1];
+            const got = process.argv[1].split('.').map(Number);
+            const cmp = got[0] - need[0] || got[1] - need[1] || got[2] - need[2];
+            if (cmp < 0) {
+              console.error('npm ' + process.argv[1] + ' is below the Trusted Publishing floor 11.5.1');
+              process.exit(1);
+            }
+          " "$V"
+      - run: npm ci
+      # prepublishOnly (build + unit + type tests + attw) runs as the pre-publish gate.
+      - run: npm publish --access public

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,11 @@
-# Thin caller for the shared OpenSSF Scorecard workflow. The triggers must live
-# here (cron cannot be defined in a reusable workflow).
-# The actual jobs live in Krister-Johansson/shared-configs; dependabot keeps
-# the pinned version fresh.
+# OpenSSF Scorecard analysis: publishes the score behind the README badge and
+# uploads findings to code scanning.
+#
+# Owned here since #90 (previously a thin caller into shared-configs, now
+# deprecated).
+# publish_results notes: the Scorecard API rejects runs from workflows with
+# top-level env vars, defaults, or workflow-level write permissions — keep this
+# file free of those.
 name: Scorecard supply-chain security
 
 on:
@@ -9,24 +13,51 @@ on:
   branch_protection_rule:
   # Weekly, so the published score and README badge stay current.
   schedule:
-    - cron: "27 7 * * 1"
+    - cron: '27 7 * * 1'
   push:
     branches: [main]
   # Allow re-scanning on demand (Actions tab → Run workflow).
   workflow_dispatch:
 
-# Least-privilege by default; the reusable workflow's job elevates what it needs.
-# Do NOT add top-level env/defaults/write permissions — the Scorecard publish API
-# rejects workflows that have them.
+# Least-privilege by default; the analysis job elevates only what it needs.
 permissions:
   contents: read
 
 jobs:
-  scorecard:
-    uses: Krister-Johansson/shared-configs/.github/workflows/scorecard.yml@b0186b7fb41009fc90457c1367869317c30fbfaf # v1.3.0
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
     permissions:
-      contents: read # job permissions replace read-all; the scan needs repo reads
+      contents: read # the scan needs repo reads
       security-events: write # SARIF upload to code scanning
       id-token: write # publish results to the OpenSSF API (badge)
-    secrets:
-      SCORECARD_TOKEN: ${{ secrets.SCORECARD_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # A PAT with Administration:read lets Scorecard read branch-protection
+          # rules (the default GITHUB_TOKEN cannot). Falls back to GITHUB_TOKEN.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
+          # Publish to the OpenSSF API so the README badge resolves.
+          publish_results: true
+
+      # Retain the SARIF for manual inspection / debugging.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Surface findings under Security → Code scanning.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## What

Replaces the four thin callers into `Krister-Johansson/shared-configs` (being deprecated) with self-contained workflows owned by this repo, based on gqlPrune's vendored versions and the pinned shared-configs sources. Everything stays SHA-pinned.

## Check-name compatibility

The required status-check contexts are preserved byte for byte, so the `main-protection` ruleset needs no change: the build-test matrix jobs are named `ci / build + test (node 20|22)`, the issue check `ci / linked issue`, and the integration job `integration (real TimescaleDB)` is unchanged. The `coverage comment` job now needs `build-test` instead of the old caller job.

## Deliberate behavior changes

- The linked-issue exemption keys on the PR author (`github.event.pull_request.user.login`) instead of `github.actor`. During the #75 triage, a maintainer branch update turned the actor into a human and un-skipped the required check on a dependabot PR, wedging it. The author-based check cannot be un-skipped that way.
- release-please runs with `RELEASE_PLEASE_TOKEN` (fine-grained PAT, contents + pull-requests on this repo) falling back to `GITHUB_TOKEN`. With the PAT in place, CI runs on release PRs and release-published workflows (the upcoming sbom.yml) fire. The secret does not exist yet; until it is added the fallback keeps today's behavior.
- The publish job asserts the npm >= 11.5.1 Trusted Publishing floor instead of self-installing npm (Scorecard flags `npm install -g npm@latest`), and relies on `prepublishOnly` (build + unit + type tests + attw) as the pre-publish gate.

## Maintainer follow-ups after merge

1. Mint the fine-grained PAT (contents + pull-requests, read/write, this repo only) and store it as the `RELEASE_PLEASE_TOKEN` repo secret.
2. The npm Trusted Publisher entry (already working for 0.8.0) keeps working unchanged: same repository and workflow filename.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build, type-checking, testing, coverage, and published-type validation across supported Node.js versions.
  * Strengthened security scanning and code-quality analysis with controlled permissions.
  * Updated release automation with safer publishing checks and trusted npm publishing.
  * Added required pull request issue-link validation, with exceptions for automated release updates.
  * Preserved coverage reporting and security analysis artifacts for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->