### PR TITLE
ci: add SBOM signing and dependency-audit workflows

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,78 @@
+# Attaches a CycloneDX SBOM to every GitHub release, signed with keyless
+# cosign, so each published version ships with a machine-readable inventory
+# of its runtime dependency tree and a verifiable signature over it
+# (see docs/security-policies.md and the Verifying a release section of
+# SECURITY.md).
+#
+# Two jobs on purpose: generating the SBOM runs npm ci, and dependency
+# lifecycle scripts must never share a job with the OIDC signing identity or
+# a writable token. The generate job is read-only; the sign job holds the
+# elevated permissions but installs no dependencies.
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  # Backfill: run the same pipeline against an existing release, e.g. one
+  # published before signing existed. A dispatch runs from the default branch,
+  # so the signing identity is sbom.yml@refs/heads/main rather than the
+  # release tag; SECURITY.md notes this for backfilled releases.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to regenerate, sign, and attach the SBOM for (e.g. prisma-extension-timescaledb-v0.8.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    name: generate SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - run: npm ci
+      - name: Generate CycloneDX SBOM for the production tree
+        run: npm sbom --sbom-format cyclonedx --omit dev > "prisma-extension-timescaledb-${TAG#prisma-extension-timescaledb-v}.cdx.json"
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: prisma-extension-timescaledb-*.cdx.json
+          if-no-files-found: error
+
+  sign-attach:
+    name: sign + attach
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # upload the assets to the release
+      id-token: write # keyless cosign signing via OIDC
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign the SBOM (keyless, Sigstore bundle)
+        run: |
+          for f in prisma-extension-timescaledb-*.cdx.json; do
+            cosign sign-blob --yes --bundle "$f.sigstore.json" "$f"
+          done
+      - name: Attach SBOM and signature bundle to the release
+        run: gh release upload "$TAG" prisma-extension-timescaledb-*.cdx.json prisma-extension-timescaledb-*.cdx.json.sigstore.json --clobber
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+          # No checkout in this job, so gh needs the repo context explicitly.
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -41,7 +41,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci
+      # --ignore-scripts: the generated SBOM feeds the signing job, so
+      # dependency lifecycle scripts must not be able to tamper with it.
+      # npm sbom reads the lockfile and installed metadata only.
+      - run: npm ci --ignore-scripts
       - name: Generate CycloneDX SBOM for the production tree
         run: npm sbom --sbom-format cyclonedx --omit dev > "prisma-extension-timescaledb-${TAG#prisma-extension-timescaledb-v}.cdx.json"
         env:

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,24 @@
+# Blocks pull requests that introduce known-vulnerable dependencies:
+# fails on high or critical advisories against the production tree
+# (thresholds and process in docs/security-policies.md).
+name: SCA
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Audit production dependencies (fail on high or critical)
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -21,4 +21,6 @@ jobs:
         with:
           node-version: 24
       - name: Audit production dependencies (fail on high or critical)
-        run: npm audit --omit=dev --audit-level=high
+        # --registry pins the advisory source: a PR-supplied .npmrc must not be
+        # able to point the audit at a registry that returns no advisories.
+        run: npm audit --registry=https://registry.npmjs.org/ --omit=dev --audit-level=high


### PR DESCRIPTION
## What

Adds the two remaining pipeline workflows from the hardening plan, copied from gqlPrune and adapted to this repo's release tag format (`prisma-extension-timescaledb-vX.Y.Z`):

- **sbom.yml**: on every published release, generates a CycloneDX SBOM of the production tree and attaches it with a keyless cosign Sigstore signature bundle. Split into two jobs so `npm ci` lifecycle scripts never run in the job holding the OIDC signing identity and the writable token. The `workflow_dispatch` tag input backfills the existing releases (0.5.0 through 0.8.0); dispatch runs sign as `sbom.yml@refs/heads/main` rather than the tag, which SECURITY.md will note.
- **sca.yml**: a `dependency audit` check on every PR, `npm audit --omit=dev --audit-level=high`. Verified locally: the production tree is clean today, so the check starts green.

## Follow-ups after merge

1. Add `dependency audit` and `CodeQL` to the required checks in the main-protection ruleset (after both have reported on a PR).
2. Extend SECURITY.md's "Verifying a release" with the cosign verification command and docs/security-policies.md with the audit-gate paragraph, now that both exist.
3. Backfill SBOMs for the four existing releases via the dispatch input.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated software bill of materials (SBOM) generation for releases.
  * SBOMs are signed and attached to releases for authenticity verification.
  * Added pull request checks for high- and critical-severity production dependency vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->