### PR TITLE
docs: document SBOM verification and the dependency-audit gate

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,26 @@ The expected identity in the attestation is this repository:
 the release-please workflow. Treat any version whose provenance names a
 different repository or builder as compromised, and report it.
 
+Each GitHub release also carries a CycloneDX software bill of materials
+(`prisma-extension-timescaledb-<version>.cdx.json`) as an asset, listing the
+exact runtime dependency tree the release shipped with, along with a keyless
+Sigstore signature bundle over it (`.sigstore.json`). Verify the SBOM with:
+
+```bash
+cosign verify-blob \
+  --bundle prisma-extension-timescaledb-<version>.cdx.json.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/Krister-Johansson/prisma-extension-timescaledb/\.github/workflows/sbom\.yml@refs/tags/prisma-extension-timescaledb-v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  prisma-extension-timescaledb-<version>.cdx.json
+```
+
+The certificate identity must be this repository's sbom.yml workflow running
+on a release tag; treat anything else as compromised, and report it. One
+exception: releases 0.5.0 through 0.8.0 predate the signing workflow and had
+their signatures backfilled by a manual run of it, so their identity ends in
+`sbom.yml@refs/heads/main` instead of the tag. From the next release onward,
+expect the tag form.
+
 ## Reporting a vulnerability
 
 Do not open a public issue for security problems.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,17 +43,27 @@ Sigstore signature bundle over it (`.sigstore.json`). Verify the SBOM with:
 ```bash
 cosign verify-blob \
   --bundle prisma-extension-timescaledb-<version>.cdx.json.sigstore.json \
-  --certificate-identity-regexp '^https://github.com/Krister-Johansson/prisma-extension-timescaledb/\.github/workflows/sbom\.yml@refs/tags/prisma-extension-timescaledb-v' \
+  --certificate-identity "https://github.com/Krister-Johansson/prisma-extension-timescaledb/.github/workflows/sbom.yml@refs/tags/prisma-extension-timescaledb-v<version>" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   prisma-extension-timescaledb-<version>.cdx.json
 ```
 
 The certificate identity must be this repository's sbom.yml workflow running
-on a release tag; treat anything else as compromised, and report it. One
-exception: releases 0.5.0 through 0.8.0 predate the signing workflow and had
-their signatures backfilled by a manual run of it, so their identity ends in
-`sbom.yml@refs/heads/main` instead of the tag. From the next release onward,
-expect the tag form.
+on the release tag of the exact version you are verifying; treat anything
+else as compromised, and report it. One exception: releases 0.5.0 through
+0.8.0 predate the signing workflow and had their signatures backfilled by a
+manual run of it, so their identity is the workflow on `refs/heads/main`
+instead of the tag. Verify those four releases with:
+
+```bash
+cosign verify-blob \
+  --bundle prisma-extension-timescaledb-<version>.cdx.json.sigstore.json \
+  --certificate-identity "https://github.com/Krister-Johansson/prisma-extension-timescaledb/.github/workflows/sbom.yml@refs/heads/main" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  prisma-extension-timescaledb-<version>.cdx.json
+```
+
+From 0.9.0 onward, expect the tag form only.
 
 ## Reporting a vulnerability
 

--- a/docs/security-policies.md
+++ b/docs/security-policies.md
@@ -10,6 +10,11 @@ Dependabot opens weekly grouped update pull requests for npm dependencies and
 GitHub Actions. Socket and the OpenSSF Scorecard provide outside views of the
 same surface; Socket scans pull requests that change the dependency manifests
 (`package.json`, `package-lock.json`), which is the only surface it ingests.
+On top of that, every pull request runs a `dependency audit` check (`npm
+audit` against the production tree, with the advisory registry pinned to
+registry.npmjs.org) that fails on high or critical advisories, and the check
+is required by the branch ruleset, so a change cannot merge while it
+introduces a known-vulnerable production dependency.
 
 Remediation thresholds, counted from when an advisory becomes known:
 


### PR DESCRIPTION
## What

The follow-up both security documents deliberately deferred until the workflows existed. sbom.yml and sca.yml merged in #93, `dependency audit` and `CodeQL` are now required checks in the ruleset, and SBOM signatures are backfilled for releases 0.5.0 through 0.8.0.

- SECURITY.md "Verifying a release": the `cosign verify-blob` command against the release's Sigstore bundle, expecting the sbom.yml tag identity, with the documented exception that the four backfilled releases carry the `refs/heads/main` identity from the manual dispatch.
- docs/security-policies.md: the SCA section now records the required audit gate (production tree, registry pinned, fails on high or critical).

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release verification guidance to cover CycloneDX SBOM assets and Sigstore bundle verification.
  * Documented required identity checks and signature exceptions for versions 0.5.0–0.8.0.
  * Added a required `npm audit` check for pull requests to detect high or critical production dependency vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->