### PR TITLE
fix(generator): treat enums as columns, validate chunkSkipping types, reject unannotated cagg fields

### DIFF
--- a/src/core/continuousAggregate.ts
+++ b/src/core/continuousAggregate.ts
@@ -1,9 +1,11 @@
 // Continuous aggregate SQL builder (SPEC §2.3 / CLAUDE.md constraints 3, 4).
-import type { CaggConfig, MigrationSql } from "./types.js";
+import type { AggregateSpec, CaggConfig, MigrationSql } from "./types.js";
 import { assertInterval } from "./interval.js";
 import { assertSafeIdent, qualifiedIdent, quoteIdent, quoteLiteral, relationLiteral } from "./sql.js";
 
-const AGG_FNS = new Set(["avg", "sum", "min", "max", "count"]);
+/** The supported continuous-aggregate functions. Shared with the generator's annotation
+ * validation (src/generator/dmmf.ts) so the two lists cannot drift. */
+export const AGG_FNS: ReadonlySet<AggregateSpec["fn"]> = new Set(["avg", "sum", "min", "max", "count"] as const);
 
 /**
  * Build the continuous aggregate create + optional refresh policy SQL.

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -538,6 +538,13 @@ function buildCagg(
       if (!srcField) {
         throw new Error(`${fctx}: aggregate column "${column}" does not exist on source "${source}".`);
       }
+      // Postgres defines min/max (label order) and count for enums, but not avg/sum — those
+      // would pass generation and fail the CREATE MATERIALIZED VIEW at migrate.
+      if (srcField.kind === "enum" && (fn === "avg" || fn === "sum")) {
+        throw new Error(
+          `${fctx}: aggregate fn "${fn}" is not defined for enum column "${column}" (Postgres supports min, max, and count on enum types).`,
+        );
+      }
       aggregates.push({ name: dbCol(field), fn, column: dbCol(srcField) });
     }
   }

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -16,6 +16,7 @@ import type {
 import type { Interval } from "../core/interval.js";
 import { assertInterval } from "../core/interval.js";
 import { parseOrderByTerm } from "../core/compression.js";
+import { AGG_FNS } from "../core/continuousAggregate.js";
 import {
   findAnnotation,
   optionalBoolean,
@@ -39,7 +40,12 @@ export interface TimescaleSchema {
 // (`by_range(col, INTERVAL …)`, `time_bucket($1, col)`), so accepting Int/BigInt here would pass
 // generation and then fail at `migrate`. Reject them up front with a clear message instead.
 const TIME_TYPES = new Set(["DateTime"]);
-const AGG_FNS = new Set<AggregateSpec["fn"]>(["avg", "sum", "min", "max", "count"]);
+
+// Prisma field types whose Postgres columns TimescaleDB's enable_chunk_skipping accepts. The
+// server supports "integer-like, timestamp-like" range calculation only (its own HINT wording);
+// Float (double precision), Decimal (numeric), String, Boolean, and enums all fail at migrate —
+// verified empirically against timescale/timescaledb 2.27.2. Reject at generation instead.
+const CHUNK_SKIPPING_TYPES = new Set(["Int", "BigInt", "DateTime"]);
 
 // The complete annotation surface. Anything outside these sets is a typo the user needs to hear
 // about NOW: an unknown name or argument key silently no-ops otherwise (no hypertable conversion,
@@ -224,7 +230,7 @@ function buildHypertable(
 
   const field = findScalarField(model, column);
   if (!field) {
-    throw new Error(`${ctx}: column "${column}" is not a scalar field on the model.`);
+    throw new Error(`${ctx}: column "${column}" is not a scalar or enum field on the model.`);
   }
   if (!TIME_TYPES.has(field.type)) {
     throw new Error(
@@ -350,7 +356,7 @@ function buildCompression(
   if (segmentByRaw !== undefined) {
     const segmentBy = splitList(segmentByRaw).map((name) => {
       const field = findScalarField(model, name);
-      if (!field) throw new Error(`${ctx}: segmentBy column "${name}" is not a scalar field on the model.`);
+      if (!field) throw new Error(`${ctx}: segmentBy column "${name}" is not a scalar or enum field on the model.`);
       return dbCol(field);
     });
     if (segmentBy.length > 0) config.segmentBy = segmentBy;
@@ -361,7 +367,7 @@ function buildCompression(
     const orderBy = splitList(orderByRaw).map((term) => {
       const parsed = parseOrderByTerm(term);
       const field = findScalarField(model, parsed.column);
-      if (!field) throw new Error(`${ctx}: orderBy column "${parsed.column}" is not a scalar field on the model.`);
+      if (!field) throw new Error(`${ctx}: orderBy column "${parsed.column}" is not a scalar or enum field on the model.`);
       return { ...parsed, column: dbCol(field) };
     });
     if (orderBy.length > 0) config.orderBy = orderBy;
@@ -393,7 +399,7 @@ function buildSpacePartition(
   }
   const field = findScalarField(model, partitionColumn);
   if (!field) {
-    throw new Error(`${ctx}: partitionColumn "${partitionColumn}" is not a scalar field on the model.`);
+    throw new Error(`${ctx}: partitionColumn "${partitionColumn}" is not a scalar or enum field on the model.`);
   }
   assertInEveryUniqueKey(model, partitionColumn, `partitionColumn "${partitionColumn}"`, ctx);
   const partitions = Number(partitionsRaw);
@@ -425,7 +431,12 @@ function buildChunkSkipping(
   const columns = splitList(raw).map((name) => {
     const field = findScalarField(model, name);
     if (!field) {
-      throw new Error(`${ctx}: chunkSkipping column "${name}" is not a scalar field on the model.`);
+      throw new Error(`${ctx}: chunkSkipping column "${name}" is not a scalar or enum field on the model.`);
+    }
+    if (field.kind !== "scalar" || !CHUNK_SKIPPING_TYPES.has(field.type)) {
+      throw new Error(
+        `${ctx}: chunkSkipping column "${name}" has type ${field.type}; chunk skipping supports integer-like and timestamp-like columns only (Int, BigInt, DateTime) — enable_chunk_skipping fails at migrate on anything else.`,
+      );
     }
     const db = dbCol(field);
     if (db === timeColumnDb) {
@@ -487,9 +498,20 @@ function buildCagg(
   const aggregates: AggregateSpec[] = [];
 
   for (const field of view.fields) {
+    // Relation fields are virtual — they never appear in the generated SELECT list.
+    if (field.kind === "object") continue;
     // Parsed (and syntax-validated, with location context) by the caller's field loop.
     const fieldAnns = fieldAnnotations.get(field.name) ?? [];
     const fctx = `@timescale field on "${view.name}.${field.name}"`;
+
+    // Every data field must be the bucket, a groupBy, or an aggregate: an unannotated field
+    // would be silently omitted from the CREATE MATERIALIZED VIEW while Prisma still selects
+    // it, so the first findMany() on the view dies with "column does not exist".
+    if (fieldAnns.length === 0) {
+      throw new Error(
+        `${ctx}: view field "${field.name}" has no @timescale annotation; every view field must carry @timescale.bucket, @timescale.groupBy, or @timescale.aggregate (otherwise it is omitted from the generated view and queries fail at runtime).`,
+      );
+    }
 
     if (findAnnotation(fieldAnns, "bucket")) {
       if (sawBucket) {
@@ -589,9 +611,11 @@ function assertInEveryUniqueKey(model: DMMF.Model, fieldName: string, what: stri
   }
 }
 
-/** Find a scalar (non-relation) field by name on a model. */
+/** Find a data (scalar or enum, non-relation) field by name on a model. Enum fields have DMMF
+ * kind "enum", not "scalar" — treating them as non-data dropped their @map renames and rejected
+ * legitimate enum segmentBy/groupBy/aggregate configurations. */
 function findScalarField(model: DMMF.Model, name: string): DMMF.Field | undefined {
-  return model.fields.find((f) => f.name === name && f.kind === "scalar");
+  return model.fields.find((f) => f.name === name && (f.kind === "scalar" || f.kind === "enum"));
 }
 
 /** DB table name: the @@map value, or the model name. */
@@ -604,11 +628,13 @@ function dbCol(field: DMMF.Field): string {
   return field.dbName ?? field.name;
 }
 
-/** Map of Prisma field name -> DB column name, for fields that were renamed via @map. */
+/** Map of Prisma field name -> DB column name, for fields that were renamed via @map. Enum
+ * fields (DMMF kind "enum") are columns too — omitting them made the runtime emit the Prisma
+ * name instead of the @map name in timeBucket SQL. */
 function columnMap(model: DMMF.Model): Record<string, string> {
   const map: Record<string, string> = {};
   for (const f of model.fields) {
-    if (f.kind === "scalar" && f.dbName) map[f.name] = f.dbName;
+    if ((f.kind === "scalar" || f.kind === "enum") && f.dbName) map[f.name] = f.dbName;
   }
   return map;
 }

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -108,7 +108,7 @@ model M {
 
   it("column is not a field", async () => {
     await expect(extract(htModel(`@timescale.hypertable(column: "nope")`))).rejects.toThrow(
-      /column "nope" is not a scalar field/,
+      /column "nope" is not a scalar or enum field/,
     );
   });
 
@@ -531,7 +531,7 @@ model SensorReading {
   @@id([deviceId, time])
 }
 `),
-    ).rejects.toThrow(/segmentBy column "nope" is not a scalar field/);
+    ).rejects.toThrow(/segmentBy column "nope" is not a scalar or enum field/);
   });
 
   it("rejects an unknown orderBy column", async () => {
@@ -545,7 +545,7 @@ model SensorReading {
   @@id([deviceId, time])
 }
 `),
-    ).rejects.toThrow(/orderBy column "nope" is not a scalar field/);
+    ).rejects.toThrow(/orderBy column "nope" is not a scalar or enum field/);
   });
 
   it("rejects a malformed orderBy direction token", async () => {
@@ -613,7 +613,7 @@ model SensorReading {
   @@id([deviceId, time])
 }
 `),
-    ).rejects.toThrow(/partitionColumn "nope" is not a scalar field/);
+    ).rejects.toThrow(/partitionColumn "nope" is not a scalar or enum field/);
   });
 
   it("rejects a non-positive partition count", async () => {
@@ -693,7 +693,7 @@ model SensorReading {
   @@id([deviceId, time])
 }
 `),
-    ).rejects.toThrow(/chunkSkipping column "nope" is not a scalar field/);
+    ).rejects.toThrow(/chunkSkipping column "nope" is not a scalar or enum field/);
   });
 
   it("rejects the time / partitioning column (it already prunes chunks)", async () => {
@@ -1047,5 +1047,133 @@ view SensorHourly {
   @@unique([bucket])
 }`),
     ).rejects.toThrow(/on "SensorHourly\.avgTemp".*Malformed annotation argument/s);
+  });
+});
+
+describe("extractTimescaleSchema — enum fields are data columns", () => {
+  const ENUM = `
+enum Status {
+  OK
+  ERR
+}
+`;
+
+  it("includes enum @map renames in the hypertable columns map", async () => {
+    const result = await extract(`${ENUM}
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time   DateTime
+  id     Int
+  status Status @map("status_col")
+  @@id([id, time])
+}
+`);
+    expect(result.hypertables[0]?.columns).toEqual({ status: "status_col" });
+  });
+
+  it("accepts an enum compression segmentBy column and resolves its @map name", async () => {
+    const result = await extract(`${ENUM}
+/// @timescale.hypertable(column: "time")
+/// @timescale.compression(after: "7 days", segmentBy: "status")
+model SensorReading {
+  time   DateTime
+  id     Int
+  status Status @map("status_col")
+  @@id([id, time])
+}
+`);
+    expect(result.hypertables[0]?.compression?.segmentBy).toEqual(["status_col"]);
+  });
+
+  it("accepts an enum groupBy column on a continuous aggregate", async () => {
+    const result = await extract(`${ENUM}
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  status      Status
+  temperature Float
+  @@id([status, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket  DateTime /// @timescale.bucket
+  status  Status   /// @timescale.groupBy
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([status, bucket])
+}
+`);
+    expect(result.continuousAggregates[0]?.groupBy).toEqual([{ source: "status", output: "status" }]);
+  });
+});
+
+describe("extractTimescaleSchema — chunkSkipping column types", () => {
+  it("rejects a Float chunkSkipping column (unsupported for range calculation)", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "temperature")
+model SensorReading {
+  time        DateTime
+  deviceId    Int
+  temperature Float
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "temperature" has type Float; chunk skipping supports integer-like and timestamp-like columns only/);
+  });
+
+  it("rejects an enum chunkSkipping column", async () => {
+    await expect(
+      extract(`
+enum Status {
+  OK
+  ERR
+}
+
+/// @timescale.hypertable(column: "time", chunkSkipping: "status")
+model SensorReading {
+  time     DateTime
+  deviceId Int
+  status   Status
+  @@id([deviceId, time])
+}
+`),
+    ).rejects.toThrow(/chunkSkipping column "status" has type Status; chunk skipping supports integer-like and timestamp-like columns only/);
+  });
+
+  it("accepts a DateTime chunkSkipping column that is not the time dimension", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time", chunkSkipping: "ingestedAt")
+model SensorReading {
+  time       DateTime
+  deviceId   Int
+  ingestedAt DateTime
+  @@id([deviceId, time])
+}
+`);
+    expect(result.hypertables[0]?.chunkSkipping).toEqual(["ingestedAt"]);
+  });
+});
+
+describe("extractTimescaleSchema — every cagg view field must be annotated", () => {
+  it("rejects an unannotated view field instead of silently omitting it", async () => {
+    await expect(
+      extract(`
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time        DateTime
+  temperature Float
+  @@id([time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket    DateTime /// @timescale.bucket
+  avgTemp   Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  forgotten Float
+  @@unique([bucket])
+}
+`),
+    ).rejects.toThrow(/view field "forgotten" has no @timescale annotation/);
   });
 });

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -1085,6 +1085,28 @@ model SensorReading {
     expect(result.hypertables[0]?.compression?.segmentBy).toEqual(["status_col"]);
   });
 
+  it("rejects avg/sum on an enum aggregate column but accepts min/max/count", async () => {
+    const schema = (fn: string) => `${ENUM}
+/// @timescale.hypertable(column: "time")
+model SensorReading {
+  time   DateTime
+  status Status
+  @@id([status, time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view SensorHourly {
+  bucket DateTime /// @timescale.bucket
+  agg    Status   /// @timescale.aggregate(fn: "${fn}", column: "status")
+  @@unique([bucket])
+}
+`;
+    await expect(extract(schema("avg"))).rejects.toThrow(/aggregate fn "avg" is not defined for enum column "status"/);
+    await expect(extract(schema("sum"))).rejects.toThrow(/aggregate fn "sum" is not defined for enum column "status"/);
+    const result = await extract(schema("max"));
+    expect(result.continuousAggregates[0]?.aggregates).toEqual([{ name: "agg", fn: "max", column: "status" }]);
+  });
+
   it("accepts an enum groupBy column on a continuous aggregate", async () => {
     const result = await extract(`${ENUM}
 /// @timescale.hypertable(column: "time")


### PR DESCRIPTION
First fix PR of the v1 correctness campaign (#106). Three generator findings, all in src/generator/dmmf.ts:

## Enum fields are data columns

DMMF gives enum-typed fields kind "enum", not "scalar", so findScalarField and columnMap skipped them. Consequences before this fix: an enum @map rename was missing from the runtime column map, so timeBucket emitted the Prisma name instead of the DB column (42703 at runtime, or silently the wrong column); and valid enum configurations for segmentBy, groupBy, aggregate, and partitionColumn were rejected at generation with 'not a scalar field'. Both helpers now accept scalar and enum kinds, and the error wording says 'scalar or enum field'.

## chunkSkipping column types are validated at generation

enable_chunk_skipping supports integer-like and timestamp-like columns only. Probed against timescale/timescaledb 2.27.2: int, bigint, smallint, date, and timestamp succeed; double precision, numeric, text, boolean, uuid, and enums fail with 'Integer-like, timestamp-like data types supported currently'. Before this fix an unsupported type passed generation and took down the entire objects migration at deploy. Generation now rejects anything but Int, BigInt, and DateTime with a clear message.

## Unannotated cagg view fields fail generation

A view field with no @timescale annotation was silently left out of the emitted CREATE MATERIALIZED VIEW while Prisma still selects every declared view column, so the first findMany() on the view failed with 42703. Every data field must now carry bucket, groupBy, or aggregate; relation fields remain exempt since they never appear in the SELECT list.

## Cleanup folded in

AGG_FNS was defined twice (dmmf.ts and core/continuousAggregate.ts); the core set is now exported and imported by the generator.

## Validation

Seven new unit tests cover the three fixes; the full suite (277 unit, type-level, build) passes locally. The chunk-skipping type matrix comes from a live container probe, quoted in the code comment.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enum fields are now supported in hypertable mappings, compression `segmentBy` settings, and continuous-aggregate `groupBy` definitions.
  - Continuous-aggregate views now support validated, shared aggregate-function definitions.

- **Bug Fixes**
  - Improved validation ensures continuous-aggregate data fields include the required Timescale annotations.
  - Chunk-skipping fields are restricted to supported types: `Int`, `BigInt`, and `DateTime`.
  - Validation messages now clearly identify supported scalar and enum field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->