### PR TITLE
fix(client): accept the relation null shorthand in timeBucket where

### DIFF
--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -543,6 +543,7 @@ export function buildTimeBucketQuery(
         ...(r.columns ? { columns: r.columns } : {}),
         ...(r.fk ? { fk: r.fk } : {}),
         ...(r.targetModel ? { targetModel: r.targetModel } : {}),
+        ...(r.required ? { required: true } : {}),
       });
     }
     relMaps.set(m, fieldMap);

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -87,7 +87,15 @@ export function whereToSql(where: Record<string, unknown> | undefined, ctx: Wher
  * truth and `isNot`/`none` including the no-related-record case (verified against Prisma).
  */
 function relationClause(field: string, value: unknown, rel: RuntimeRelation, ctx: WhereCtx): string {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+  // Prisma-legal shorthand: `relation: null` on an optional to-one means `relation: { is: null }`
+  // (verified against findMany). List relations have no null shorthand — Prisma's types reject it.
+  if (value === null) {
+    if (rel.list) {
+      throw new Error(`timeBucket: relation filter on "${field}" cannot be null (use some / none / every on a list relation).`);
+    }
+    value = { is: null };
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`timeBucket: relation filter on "${field}" must be an object (some/none/every/is/isNot).`);
   }
   const filter = value as Record<string, unknown>;

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -43,6 +43,8 @@ export interface RuntimeRelation {
   columns?: Record<string, string>;
   /** Outer FK column(s) (DB names) for `is`/`isNot: null` (optional to-one only). */
   fk?: readonly string[];
+  /** true => required to-one: a `null` filter is rejected (Prisma's types reject it too). */
+  required?: boolean;
   /** Related model's Prisma name, used to resolve its own relations for deeper nesting. */
   targetModel?: string;
 }
@@ -87,11 +89,16 @@ export function whereToSql(where: Record<string, unknown> | undefined, ctx: Wher
  * truth and `isNot`/`none` including the no-related-record case (verified against Prisma).
  */
 function relationClause(field: string, value: unknown, rel: RuntimeRelation, ctx: WhereCtx): string {
-  // Prisma-legal shorthand: `relation: null` on an optional to-one means `relation: { is: null }`
-  // (verified against findMany). List relations have no null shorthand — Prisma's types reject it.
+  // Prisma-legal shorthand: `relation: null` on an OPTIONAL to-one means `relation: { is: null }`
+  // (verified against findMany). List relations and required to-one relations have no null
+  // shorthand — Prisma's types reject both, so the runtime rejects them loudly too instead of
+  // silently matching nothing.
   if (value === null) {
     if (rel.list) {
       throw new Error(`timeBucket: relation filter on "${field}" cannot be null (use some / none / every on a list relation).`);
+    }
+    if (rel.required) {
+      throw new Error(`timeBucket: relation filter on "${field}" cannot be null (the relation is required).`);
     }
     value = { is: null };
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,6 +61,8 @@ export interface RelationConfig {
   columns?: Record<string, string>;
   /** For an optional to-one relation: the hypertable's FK column(s) (DB names), for `is`/`isNot: null`. */
   fk?: readonly string[];
+  /** `true` for a required to-one relation — `null` filters are rejected (Prisma's types do too). */
+  required?: boolean;
 }
 
 /** Hypertable conversion config (SPEC §1.1 / §2.2). All names are DB names (post-@@map). */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -304,6 +304,8 @@ function buildRelations(model: DMMF.Model, byName: Map<string, DMMF.Model>): Rel
       on,
       ...(Object.keys(columns).length > 0 ? { columns } : {}),
       ...(fk ? { fk } : {}),
+      // Required to-one: a `null` filter is a Prisma type error, so the runtime rejects it too.
+      ...(!f.isList && f.isRequired ? { required: true } : {}),
     });
   }
   return relations;

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -772,7 +772,9 @@ model Tag {
     // so timeBucket where can resolve relation filters nested through them.
     expect(result.relationsByModel).toEqual({
       Device: [{ field: "readings", targetModel: "Reading", table: "Reading", list: true, on: [{ related: "deviceId", outer: "id" }] }],
-      Tag: [{ field: "reading", targetModel: "Reading", table: "Reading", list: false, on: [{ related: "id", outer: "readingId" }, { related: "time", outer: "readingTime" }], fk: ["readingId", "readingTime"] }],
+      // Tag.reading has no `?`: a required to-one carries `required: true` so the runtime
+      // rejects a `null` filter on it (Prisma's types reject it too).
+      Tag: [{ field: "reading", targetModel: "Reading", table: "Reading", list: false, on: [{ related: "id", outer: "readingId" }, { related: "time", outer: "readingTime" }], fk: ["readingId", "readingTime"], required: true }],
     });
   });
 

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -233,6 +233,16 @@ describe("whereToSql relation filters (EXISTS)", () => {
     expect(whereToSql({ device: { isNot: null } }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NOT NULL`);
   });
 
+  it("to-one null shorthand equals { is: null } (Prisma-legal, verified against findMany)", () => {
+    expect(whereToSql({ device: null }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NULL`);
+  });
+
+  it("null on a list relation still throws (Prisma's types reject it too)", () => {
+    expect(() => whereToSql({ tags: null }, relHarness().ctx)).toThrow(
+      /relation filter on "tags" cannot be null \(use some \/ none \/ every/,
+    );
+  });
+
   it("to-many some / none / every (every negates the inner)", () => {
     const a = relHarness();
     expect(whereToSql({ tags: { some: { label: "x" } } }, a.ctx)).toBe(

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -233,13 +233,38 @@ describe("whereToSql relation filters (EXISTS)", () => {
     expect(whereToSql({ device: { isNot: null } }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NOT NULL`);
   });
 
-  it("to-one null shorthand equals { is: null } (Prisma-legal, verified against findMany)", () => {
-    expect(whereToSql({ device: null }, relHarness().ctx)).toBe(`"public"."Reading"."deviceId" IS NULL`);
+  it("to-one null shorthand produces the same SQL as { is: null } (Prisma-legal, verified against findMany)", () => {
+    const shorthand = whereToSql({ device: null }, relHarness().ctx);
+    const explicit = whereToSql({ device: { is: null } }, relHarness().ctx);
+    expect(shorthand).toBe(explicit);
+    expect(shorthand).toBe(`"public"."Reading"."deviceId" IS NULL`);
   });
 
   it("null on a list relation still throws (Prisma's types reject it too)", () => {
     expect(() => whereToSql({ tags: null }, relHarness().ctx)).toThrow(
       /relation filter on "tags" cannot be null \(use some \/ none \/ every/,
+    );
+  });
+
+  it("null on a REQUIRED to-one relation throws instead of silently matching nothing", () => {
+    const params: unknown[] = [];
+    const owner: RuntimeRelation = {
+      table: `"public"."Device"`,
+      list: false,
+      required: true,
+      on: [{ related: "id", outer: "deviceId" }],
+      fk: ["deviceId"],
+    };
+    const ctx: WhereCtx = {
+      col: (f) => `"${f}"`,
+      push: (v) => {
+        params.push(v);
+        return `$${params.length}`;
+      },
+      rel: { outerTable: `"public"."Reading"`, get: (f) => (f === "device" ? owner : undefined) },
+    };
+    expect(() => whereToSql({ device: null }, ctx)).toThrow(
+      /relation filter on "device" cannot be null \(the relation is required\)/,
     );
   });
 


### PR DESCRIPTION
Second fix PR of the v1 campaign (#106).

## What

`where: { device: null }` is Prisma-legal shorthand for `{ device: { is: null } }` on an optional to-one relation: it type-checks against the generated WhereInput and findMany returns the null-FK rows (the review verified this end-to-end on Prisma 7.10). timeBucket's relationClause instead threw 'relation filter on "device" must be an object (some/none/every/is/isNot)'.

Null now routes through the existing is-null machinery (FK IS NULL when the FK is local, NOT EXISTS otherwise), so the shorthand produces byte-identical SQL to the explicit form. A list relation keeps rejecting null, matching Prisma's own types, with a message that names some/none/every.

## Validation

Two new unit tests (shorthand equals { is: null }; list relation still throws); full unit suite and typecheck pass locally.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - To-one relation filters now support `null` as shorthand for matching records without a related entry.

- **Bug Fixes**
  - Improved validation for `null` filters on list relations, with clearer guidance to use `some`, `none`, or `every`.
  - Preserved existing validation behavior for other invalid relation-filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->