### PR TITLE
fix(client): correct four $timescale defects and dedupe interval rendering

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -66,7 +66,14 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
   // Key by Prisma model name (ctx.$name); values hold the resolved DB table + schema + column map.
   const hypertableByModel = new Map<
     string,
-    { table: string; schema?: string; column: string; columns: Record<string, string> }
+    {
+      table: string;
+      schema?: string;
+      column: string;
+      columns: Record<string, string>;
+      segmentBy?: readonly string[];
+      partitionColumn?: string;
+    }
   >();
   // Prisma model name -> that model's relations, for relation filters in timeBucket where. The
   // generator's `relationsByModel` covers related (non-hypertable) models; each hypertable's own
@@ -84,6 +91,11 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
       ...(h.schema !== undefined ? { schema: h.schema } : {}),
       column: h.column,
       columns: { ...(h.columns ?? {}) },
+      // Compression / partitioning metadata (DB column names), so $timescale.enableChunkSkipping
+      // can enforce the same guards the generator does (skipping a segmentBy column returns
+      // wrong results; the partitioning dimensions already prune chunks).
+      ...(h.compression?.segmentBy ? { segmentBy: h.compression.segmentBy } : {}),
+      ...(h.spacePartition ? { partitionColumn: h.spacePartition.column } : {}),
     });
     if (h.relations && h.relations.length > 0 && !relationsByModel.has(name)) {
       relationsByModel.set(name, h.relations);

--- a/src/client/manage.ts
+++ b/src/client/manage.ts
@@ -16,6 +16,12 @@ export interface HypertableRef {
   schema?: string;
   /** Prisma field name -> DB column, to map `segmentBy`/`orderBy` in addCompressionPolicy (@map). */
   columns?: Record<string, string>;
+  /** Time-dimension DB column, so enableChunkSkipping can reject it (it already prunes chunks). */
+  column?: string;
+  /** Compression segmentBy DB columns — chunk skipping on one returns wrong results. */
+  segmentBy?: readonly string[];
+  /** Hash space-partition DB column, if any — it already prunes chunks. */
+  partitionColumn?: string;
 }
 
 /** Options for a data-retention policy. */
@@ -123,7 +129,9 @@ export interface TimescaleJob {
   nextStart: Date | null;
 }
 
-/** Per-job run statistics from `timescaledb_information.job_stats`. */
+/** Per-job run statistics from `timescaledb_information.job_stats` (joined to `jobs` so
+ * `hypertableName` is the user-facing relation — a cagg job reports its view name, not the
+ * internal materialization hypertable). */
 export interface JobStats {
   jobId: number;
   hypertableName: string | null;
@@ -335,6 +343,18 @@ function isConcurrentRefreshError(err: unknown): boolean {
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Render an optional named Interval argument as `key => INTERVAL '...'` after validation. A typed
+ * literal, not a bind param: the TimescaleDB functions take these through polymorphic "any" /
+ * interval parameters that a parameter placeholder leaves type-ambiguous. Shared by dropChunks,
+ * showChunks, and alterJob so the validate-then-render rule lives in one place.
+ */
+function intervalArg(key: string, value: Interval | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  assertInterval(value);
+  return `${key} => INTERVAL ${quoteLiteral(value)}`;
+}
+
 /** Normalize a `segmentBy` input (comma-separated string or array) to trimmed, non-empty field names. */
 function normalizeSegmentBy(input: string | readonly string[] | undefined): string[] | undefined {
   if (input == null) return undefined;
@@ -397,6 +417,26 @@ export function makeManage<HModels extends string = string, CModels extends stri
     const ref = resolveHypertable(model);
     const dbColumn = (ref.columns ?? {})[column] ?? column;
     assertSafeIdent(dbColumn, "chunk-skipping column");
+    // Mirror the generator's guards where the registry carries the metadata: the partitioning
+    // dimensions already prune chunks, and skipping on a compression segmentBy column returns
+    // wrong (empty) results once chunks compress — verified empirically. Disable stays unguarded.
+    if (fn === "enable_chunk_skipping") {
+      if (ref.column !== undefined && dbColumn === ref.column) {
+        throw new Error(
+          `enableChunkSkipping: column "${column}" is the time/partitioning column; that dimension already prunes chunks.`,
+        );
+      }
+      if (ref.partitionColumn !== undefined && dbColumn === ref.partitionColumn) {
+        throw new Error(
+          `enableChunkSkipping: column "${column}" is the hash space-partition column; that dimension already prunes chunks.`,
+        );
+      }
+      if (ref.segmentBy?.includes(dbColumn)) {
+        throw new Error(
+          `enableChunkSkipping: column "${column}" is a compression segmentBy column; skipping on a segmentBy column returns wrong (empty) results once chunks compress.`,
+        );
+      }
+    }
     const rel = relationLiteral(ref.table, ref.schema);
     return `DO $$ BEGIN SET LOCAL timescaledb.enable_chunk_skipping = on; PERFORM ${fn}(${rel}, ${quoteLiteral(dbColumn)}, if_not_exists => TRUE); END $$`;
   };
@@ -522,10 +562,13 @@ export function makeManage<HModels extends string = string, CModels extends stri
       const reloptions = columnstoreReloptions(segmentBy, orderBy);
       const rel = relationLiteral(ref.table, ref.schema);
       const alterTarget = qualifiedIdent(ref.table, ref.schema);
-      // Two statements: add_columnstore_policy errors unless the columnstore is enabled first.
-      await client.$executeRawUnsafe(`ALTER TABLE ${alterTarget} SET (${reloptions.join(", ")})`);
+      // One DO block, one connection, one transaction: the ALTER must run before the CALL
+      // (add_columnstore_policy errors unless the columnstore is enabled), and running them as
+      // two autocommitted statements left the columnstore reconfigured with no policy when the
+      // CALL failed. A failing CALL now rolls the ALTER back too — verified empirically against
+      // timescale/timescaledb 2.27.2.
       await client.$executeRawUnsafe(
-        `CALL add_columnstore_policy(${rel}, after => INTERVAL ${quoteLiteral(opts.after)}, if_not_exists => TRUE)`,
+        `DO $$ BEGIN ALTER TABLE ${alterTarget} SET (${reloptions.join(", ")}); CALL add_columnstore_policy(${rel}, after => INTERVAL ${quoteLiteral(opts.after)}, if_not_exists => TRUE); END $$`,
       );
     },
 
@@ -540,12 +583,7 @@ export function makeManage<HModels extends string = string, CModels extends stri
       const rel = relationLiteral(ref.table, ref.schema);
       // Each bound is a validated Interval interpolated as `INTERVAL '...'` — a typed literal, so
       // `older_than`'s polymorphic "any" parameter resolves (a bind param would be type-ambiguous).
-      const bound = (key: string, value: Interval | undefined): string | undefined => {
-        if (value === undefined) return undefined;
-        assertInterval(value);
-        return `${key} => INTERVAL ${quoteLiteral(value)}`;
-      };
-      const args = [bound("older_than", opts.olderThan), bound("newer_than", opts.newerThan)].filter(
+      const args = [intervalArg("older_than", opts.olderThan), intervalArg("newer_than", opts.newerThan)].filter(
         (a): a is string => a !== undefined,
       );
       if (args.length === 0) {
@@ -663,7 +701,12 @@ export function makeManage<HModels extends string = string, CModels extends stri
     },
 
     async jobStats(model) {
-      const { where, params } = jobFilter(model);
+      // job_stats reports a continuous aggregate's MATERIALIZATION hypertable
+      // (_timescaledb_internal._materialized_hypertable_N), not the user-facing view name —
+      // verified empirically on 2.27.2 — so filtering it directly matched zero rows for cagg
+      // models. Join to the jobs view (which reports the view name, like listJobs) for both
+      // the filter and the reported hypertable_name.
+      const { where, params } = jobFilter(model, "j.");
       const rows = await client.$queryRawUnsafe<
         {
           job_id: number;
@@ -680,14 +723,15 @@ export function makeManage<HModels extends string = string, CModels extends stri
         }[]
       >(
         [
-          "SELECT job_id, hypertable_name, last_run_started_at, last_successful_finish, last_run_status,",
-          "job_status, last_run_duration::text AS last_run_duration, next_start,",
-          "COALESCE(total_runs, 0)::bigint AS total_runs,",
-          "COALESCE(total_successes, 0)::bigint AS total_successes,",
-          "COALESCE(total_failures, 0)::bigint AS total_failures",
-          "FROM timescaledb_information.job_stats",
+          "SELECT s.job_id, j.hypertable_name, s.last_run_started_at, s.last_successful_finish, s.last_run_status,",
+          "s.job_status, s.last_run_duration::text AS last_run_duration, s.next_start,",
+          "COALESCE(s.total_runs, 0)::bigint AS total_runs,",
+          "COALESCE(s.total_successes, 0)::bigint AS total_successes,",
+          "COALESCE(s.total_failures, 0)::bigint AS total_failures",
+          "FROM timescaledb_information.job_stats s",
+          "LEFT JOIN timescaledb_information.jobs j ON j.job_id = s.job_id",
           where,
-          "ORDER BY job_id",
+          "ORDER BY s.job_id",
         ]
           .filter(Boolean)
           .join(" "),
@@ -710,19 +754,11 @@ export function makeManage<HModels extends string = string, CModels extends stri
 
     async jobErrors(model) {
       // job_errors has no hypertable_name column, so a model filter joins to the jobs view by job_id.
-      const rel = model === undefined ? undefined : resolveRelationName(model);
-      const params: unknown[] = [];
-      let from = "timescaledb_information.job_errors e";
-      let where = "";
-      if (rel) {
-        from += " JOIN timescaledb_information.jobs j ON j.job_id = e.job_id";
-        params.push(rel.name);
-        where = "WHERE j.hypertable_name = $1";
-        if (rel.schema !== undefined) {
-          params.push(rel.schema);
-          where += " AND j.hypertable_schema = $2";
-        }
-      }
+      const { where, params } = jobFilter(model, "j.");
+      const from =
+        model === undefined
+          ? "timescaledb_information.job_errors e"
+          : "timescaledb_information.job_errors e JOIN timescaledb_information.jobs j ON j.job_id = e.job_id";
       const rows = await client.$queryRawUnsafe<
         {
           job_id: number;
@@ -757,18 +793,20 @@ export function makeManage<HModels extends string = string, CModels extends stri
       const id = jobIdLiteral(jobId);
       const args: string[] = [];
       const params: unknown[] = [];
-      const interval = (key: string, value: Interval | undefined): void => {
-        if (value === undefined) return;
-        assertInterval(value);
-        args.push(`${key} => INTERVAL ${quoteLiteral(value)}`);
-      };
-      interval("schedule_interval", options.scheduleInterval);
-      interval("max_runtime", options.maxRuntime);
-      interval("retry_period", options.retryPeriod);
+      for (const [key, value] of [
+        ["schedule_interval", options.scheduleInterval],
+        ["max_runtime", options.maxRuntime],
+        ["retry_period", options.retryPeriod],
+      ] as const) {
+        const arg = intervalArg(key, value);
+        if (arg !== undefined) args.push(arg);
+      }
       if (options.maxRetries !== undefined) {
-        if (!Number.isInteger(options.maxRetries) || options.maxRetries < 0) {
+        // -1 is TimescaleDB's "unlimited retries" sentinel (JOB_RETRY_UNLIMITED) and the default
+        // for policy jobs — rejecting it made a finite value a one-way door.
+        if (!Number.isInteger(options.maxRetries) || options.maxRetries < -1) {
           throw new Error(
-            `alterJob: maxRetries must be a non-negative integer (got ${JSON.stringify(options.maxRetries)}).`,
+            `alterJob: maxRetries must be an integer >= -1 (got ${JSON.stringify(options.maxRetries)}; -1 means unlimited retries).`,
           );
         }
         args.push(`max_retries => ${options.maxRetries}`);
@@ -801,14 +839,8 @@ export function makeManage<HModels extends string = string, CModels extends stri
     async showChunks(model, options = {}) {
       const ref = resolveHypertable(model);
       const rel = relationLiteral(ref.table, ref.schema);
-      // Bounds are validated Intervals interpolated as typed `INTERVAL '...'` literals (the args are
-      // polymorphic "any" — a bind param would be type-ambiguous, same as dropChunks). Both optional.
-      const bound = (key: string, value: Interval | undefined): string | undefined => {
-        if (value === undefined) return undefined;
-        assertInterval(value);
-        return `${key} => INTERVAL ${quoteLiteral(value)}`;
-      };
-      const args = [rel, bound("older_than", options.olderThan), bound("newer_than", options.newerThan)].filter(
+      // Bounds are optional, validated Intervals rendered by the shared intervalArg helper.
+      const args = [rel, intervalArg("older_than", options.olderThan), intervalArg("newer_than", options.newerThan)].filter(
         (a): a is string => a !== undefined,
       );
       const rows = await client.$queryRawUnsafe<{ chunk: string }[]>(

--- a/test/unit/manage.test.ts
+++ b/test/unit/manage.test.ts
@@ -172,19 +172,18 @@ describe("makeManage retention policies", () => {
 });
 
 describe("makeManage compression policies", () => {
-  it("addCompressionPolicy enables the columnstore then adds the policy (two statements)", async () => {
+  it("addCompressionPolicy enables the columnstore and adds the policy in ONE atomic DO block", async () => {
+    // One statement, one transaction: two autocommitted statements left the columnstore
+    // reconfigured with no policy when the CALL failed (verified empirically on 2.27.2).
     const { client, calls } = fakeClient();
     await makeManage(client).addCompressionPolicy("SensorReading", {
       after: "7 days",
       segmentBy: "deviceId",
       orderBy: "time DESC",
     });
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(1);
     expect(calls[0]!.sql).toBe(
-      `ALTER TABLE "SensorReading" SET (timescaledb.enable_columnstore = true, timescaledb.segmentby = '"deviceId"', timescaledb.orderby = '"time" DESC')`,
-    );
-    expect(calls[1]!.sql).toBe(
-      `CALL add_columnstore_policy('"SensorReading"', after => INTERVAL '7 days', if_not_exists => TRUE)`,
+      `DO $$ BEGIN ALTER TABLE "SensorReading" SET (timescaledb.enable_columnstore = true, timescaledb.segmentby = '"deviceId"', timescaledb.orderby = '"time" DESC'); CALL add_columnstore_policy('"SensorReading"', after => INTERVAL '7 days', if_not_exists => TRUE); END $$`,
     );
   });
 
@@ -199,17 +198,14 @@ describe("makeManage compression policies", () => {
       orderBy: [{ column: "time", direction: "desc", nulls: "last" }],
     });
     expect(calls[0]!.sql).toBe(
-      `ALTER TABLE "metrics"."sensor_readings" SET (timescaledb.enable_columnstore = true, timescaledb.segmentby = '"device_id"', timescaledb.orderby = '"ts" DESC NULLS LAST')`,
-    );
-    expect(calls[1]!.sql).toBe(
-      `CALL add_columnstore_policy('"metrics"."sensor_readings"', after => INTERVAL '7 days', if_not_exists => TRUE)`,
+      `DO $$ BEGIN ALTER TABLE "metrics"."sensor_readings" SET (timescaledb.enable_columnstore = true, timescaledb.segmentby = '"device_id"', timescaledb.orderby = '"ts" DESC NULLS LAST'); CALL add_columnstore_policy('"metrics"."sensor_readings"', after => INTERVAL '7 days', if_not_exists => TRUE); END $$`,
     );
   });
 
   it("omits segmentby / orderby when not provided (enable columnstore only)", async () => {
     const { client, calls } = fakeClient();
     await makeManage(client).addCompressionPolicy("SensorReading", { after: "30 days" });
-    expect(calls[0]!.sql).toBe(`ALTER TABLE "SensorReading" SET (timescaledb.enable_columnstore = true)`);
+    expect(calls[0]!.sql).toContain(`ALTER TABLE "SensorReading" SET (timescaledb.enable_columnstore = true);`);
   });
 
   it("removeCompressionPolicy emits an idempotent CALL remove", async () => {
@@ -378,6 +374,36 @@ describe("makeManage chunk skipping", () => {
       /Invalid/,
     );
   });
+
+  it("enableChunkSkipping enforces the generator's guards when the registry carries the metadata", async () => {
+    const hypertableByModel = new Map([
+      [
+        "SensorReading",
+        {
+          table: "SensorReading",
+          column: "time",
+          columns: { deviceId: "device_id" },
+          segmentBy: ["device_id"],
+          partitionColumn: "region",
+        },
+      ],
+    ]);
+    const m = makeManage(fakeClient().client, new Map(), { hypertableByModel });
+    // The time dimension and the hash space-partition column already prune chunks.
+    await expect(m.enableChunkSkipping("SensorReading", "time")).rejects.toThrow(/time\/partitioning column/);
+    await expect(m.enableChunkSkipping("SensorReading", "region")).rejects.toThrow(/hash space-partition column/);
+    // Skipping a compression segmentBy column returns wrong results (checked on the @map DB name).
+    await expect(m.enableChunkSkipping("SensorReading", "deviceId")).rejects.toThrow(/segmentBy column/);
+  });
+
+  it("disableChunkSkipping stays unguarded so a bad enable can always be undone", async () => {
+    const hypertableByModel = new Map([
+      ["SensorReading", { table: "SensorReading", column: "time", segmentBy: ["deviceId"] }],
+    ]);
+    const { client, calls } = fakeClient();
+    await makeManage(client, new Map(), { hypertableByModel }).disableChunkSkipping("SensorReading", "deviceId");
+    expect(calls[0]!.sql).toContain("disable_chunk_skipping");
+  });
 });
 
 describe("makeManage chunk interval", () => {
@@ -466,11 +492,23 @@ describe("makeManage job introspection", () => {
       { job_id: 1001, total_runs: null, total_successes: null, total_failures: null },
     ]);
     const stats = await makeManage(client).jobStats();
-    expect(queries[0]!.sql).toContain("FROM timescaledb_information.job_stats");
-    expect(queries[0]!.sql).toContain("COALESCE(total_runs, 0)::bigint AS total_runs");
+    expect(queries[0]!.sql).toContain("FROM timescaledb_information.job_stats s");
+    expect(queries[0]!.sql).toContain("COALESCE(s.total_runs, 0)::bigint AS total_runs");
     expect(stats[0]!.totalRuns).toBe(5n);
     expect(stats[1]!.totalRuns).toBe(0n);
     expect(stats[1]!.totalFailures).toBe(0n);
+  });
+
+  it("jobStats joins to the jobs view: cagg models filter (and report) the VIEW name, not the materialization hypertable", async () => {
+    // job_stats reports _timescaledb_internal._materialized_hypertable_N for cagg jobs
+    // (verified empirically on 2.27.2), so a direct filter always matched zero rows.
+    const { client, queries } = fakeClient([]);
+    const viewByModel = new Map([["SensorHourly", { name: "sensor_hourly" }]]);
+    await makeManage(client, viewByModel).jobStats("SensorHourly");
+    expect(queries[0]!.sql).toContain("LEFT JOIN timescaledb_information.jobs j ON j.job_id = s.job_id");
+    expect(queries[0]!.sql).toContain("SELECT s.job_id, j.hypertable_name");
+    expect(queries[0]!.sql).toContain("WHERE j.hypertable_name = $1");
+    expect(queries[0]!.params).toEqual(["sensor_hourly"]);
   });
 
   it("jobErrors() reads job_errors directly; jobErrors(model) joins to jobs for the filter", async () => {
@@ -530,7 +568,14 @@ describe("makeManage job control", () => {
     await expect(m.alterJob(-1, { scheduled: false })).rejects.toThrow(/Invalid job id/);
     await expect(m.alterJob(1.5, { scheduled: false })).rejects.toThrow(/Invalid job id/);
     await expect(m.alterJob(1000, { scheduleInterval: "1 fortnight" as never })).rejects.toThrow(/Invalid interval/);
-    await expect(m.alterJob(1000, { maxRetries: -1 })).rejects.toThrow(/non-negative integer/);
+    await expect(m.alterJob(1000, { maxRetries: -2 })).rejects.toThrow(/integer >= -1/);
+    await expect(m.alterJob(1000, { maxRetries: 1.5 })).rejects.toThrow(/integer >= -1/);
+  });
+
+  it("alterJob accepts maxRetries: -1 (TimescaleDB's unlimited-retries sentinel and policy default)", async () => {
+    const { client, calls } = fakeClient();
+    await makeManage(client).alterJob(1000, { maxRetries: -1 });
+    expect(calls[0]!.sql).toBe("SELECT alter_job(1000, max_retries => -1, if_exists => TRUE)");
   });
 
   it("deleteJob and runJob emit the right SQL (run_job via CALL)", async () => {


### PR DESCRIPTION
Third fix PR of the v1 campaign (#106), all in the $timescale namespace.

## jobStats works for continuous aggregates

timescaledb_information.job_stats reports a cagg job under its internal materialization hypertable (_timescaledb_internal._materialized_hypertable_N), not the view name (verified empirically on 2.27.2), so `jobStats('SensorHourly')` always returned []. The query now joins the jobs view (which reports the user-facing name, like listJobs) for both the filter and the reported hypertableName. jobErrors reuses the same jobFilter prefix path instead of duplicating it.

## enableChunkSkipping enforces the generator's guards

Enabling chunk skipping on a compression segmentBy column succeeds and later returns wrong (empty) query results once chunks compress; the time and hash-partition columns already prune chunks. The generator rejects all three, but the runtime had only a JSDoc warning, and the extension registry discarded the metadata needed to check. The registry now carries segmentBy and partitionColumn, and enableChunkSkipping applies the same three guards. disableChunkSkipping stays unguarded so a bad enable can always be undone.

## addCompressionPolicy is atomic

The ALTER TABLE (enable columnstore + segmentby/orderby) and CALL add_columnstore_policy ran as two autocommitted statements, so a failing CALL left the columnstore reconfigured with no policy, and finding #3 in the campaign means callers cannot transaction-wrap it themselves. Both now run in one DO block. Probed against timescale/timescaledb 2.27.2: the block registers the policy, and a failing CALL rolls the ALTER back.

## alterJob accepts maxRetries: -1

-1 is TimescaleDB's unlimited-retries sentinel (JOB_RETRY_UNLIMITED) and the insert default for policy jobs; rejecting it made any finite value permanent. The floor is now -1, with -2 and non-integers still rejected.

## Cleanup folded in

The identical bound()/interval() closures in dropChunks, showChunks, and alterJob are hoisted into one intervalArg helper, and jobFilter's previously unused prefix parameter now has both its intended callers.

## Validation

Unit suite updated and extended (274 tests); jobs, compression, and chunk-skipping Testcontainers suites pass locally against real TimescaleDB.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring jobs with unlimited retries.
  - Improved job statistics and error reporting with clearer continuous aggregate names.

- **Bug Fixes**
  - Prevented chunk-skipping from being enabled on time, partitioning, or compression segment-by columns.
  - Made compression policy setup atomic, reducing the risk of partially applied configuration changes.
  - Improved handling of interval values across chunk and job operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->