### PR TITLE
fix(generator): stop parsing parenthesized doc prose as annotation arguments

### DIFF
--- a/src/generator/annotations.ts
+++ b/src/generator/annotations.ts
@@ -6,6 +6,8 @@
 //   @timescale.<name>                       -> { name, args: {} }
 //   @timescale.<name>(<key>: <value>, ...)  -> { name, args }
 //   value := "string" | { <key>: <value>, ... } | bare-token
+// The `(` must follow the name with no whitespace (like Prisma's own attributes), so
+// parenthesized prose elsewhere in the doc comment is never mistaken for an argument list.
 //
 // Examples:
 //   @timescale.hypertable(column: "time", chunkInterval: "1 day")
@@ -36,8 +38,11 @@ export function parseAnnotations(doc: string | null | undefined): ParsedAnnotati
     if (name === undefined) continue;
 
     let args: AnnotationArgs = {};
-    let i = NAME_RE.lastIndex;
-    while (i < doc.length && /\s/.test(doc[i] ?? "")) i++;
+    const i = NAME_RE.lastIndex;
+    // The argument list must open IMMEDIATELY after the name, like Prisma's own attributes
+    // (`@map("x")`). Skipping whitespace here used to swallow ordinary parenthesized doc prose —
+    // Prisma joins /// lines with \n, so `@timescale.bucket` followed by a line reading
+    // `(aligned to UTC hours)` failed generation with a malformed-argument error.
     if (doc[i] === "(") {
       const { body, end } = readBalanced(doc, i, "(", ")");
       args = parseArgs(body);

--- a/test/unit/annotations.test.ts
+++ b/test/unit/annotations.test.ts
@@ -43,6 +43,17 @@ describe("parseAnnotations", () => {
     expect(ann?.args).toEqual({ a: "1", nested: { b: "2", c: "3" }, d: "4" });
   });
 
+  it("does not treat parenthesized doc prose on the next line as arguments (Prisma joins /// lines with \\n)", () => {
+    expect(parseAnnotations("@timescale.bucket\n(aligned to UTC hours)")).toEqual([{ name: "bucket", args: {} }]);
+  });
+
+  it("does not treat same-line parenthesized prose after whitespace as arguments", () => {
+    expect(parseAnnotations("@timescale.bucket (aligned to UTC)")).toEqual([{ name: "bucket", args: {} }]);
+    // With no space the parens sit in argument position and stay an argument list, matching
+    // Prisma's own attribute syntax.
+    expect(() => parseAnnotations("@timescale.bucket(aligned to UTC)")).toThrow(/Malformed annotation argument/);
+  });
+
   it("rejects trailing characters after a string value", () => {
     expect(() => parseAnnotations(`@timescale.hypertable(column: "time"oops)`)).toThrow(/trailing characters after string/);
   });


### PR DESCRIPTION
Fourth fix PR of the v1 campaign (#106).

## What

After an annotation name the parser skipped ALL whitespace, newlines included, and consumed the next parenthesized text as the argument list. Prisma joins /// doc lines with \n, so this innocent comment broke prisma generate:

```prisma
/// @timescale.bucket
/// (aligned to UTC hours)
```

with 'Malformed annotation argument: "aligned to UTC hours"'; the same-line form '@timescale.bucket (note: ...)' failed with 'takes no arguments'.

The argument list must now open immediately after the name, exactly like Prisma's own attributes (@map("x")). Parenthesized prose anywhere else in the comment is plain documentation.

## Compatibility note

A schema written as '@timescale.hypertable (column: "time")' with a space, a form no documentation ever showed, previously parsed as arguments; it now reads as a bare annotation, and the DMMF layer rejects it loudly with 'missing or non-string argument "column"' rather than anything silent. Accepted as part of the v1 window.

## Validation

Three new parser tests (next-line prose, same-line prose, and the no-space form staying an argument list); full unit suite and typecheck pass.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved annotation parsing to require parentheses immediately after the annotation name.
  - Prevented parenthesized prose separated by spaces or line breaks from being incorrectly interpreted as annotation arguments.
  - Preserved support for directly attached arguments and clearer handling of malformed input.

- **Tests**
  - Added coverage for whitespace, line breaks, valid arguments, and malformed annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->