### PR TITLE
fix: export the timeBucket types from the package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,16 @@ export type {
   JobError,
   AlterJobOptions,
 } from "./client/index.js";
+// timeBucket types, so callers can type wrappers around model.timeBucket(...) — the client
+// barrel re-exported these but the package root (the only published entry) did not.
+export type {
+  TimeBucketArgs,
+  TimeBucketRow,
+  AggregateInput,
+  AggregateOp,
+  ScalarRow,
+  WhereInput,
+} from "./client/timeBucket.js";
 
 // Re-export the core types + SQL builders for convenience (also available at "./core").
 export type {

--- a/test/types/root-exports.test-d.ts
+++ b/test/types/root-exports.test-d.ts
@@ -1,0 +1,43 @@
+// Type-level test: the timeBucket types are reachable from the PACKAGE ROOT, the only
+// published entry point ("." in package.json exports). Consumers type wrappers around
+// model.timeBucket(...) with these; before this test they existed only in the client
+// barrel, which is not published, so no consumer could name them.
+import type {
+  TimeBucketArgs,
+  TimeBucketRow,
+  AggregateInput,
+  AggregateOp,
+  ScalarRow,
+  WhereInput,
+  TimescaleManage,
+  JobStats,
+} from "../../src/index.js";
+
+interface Row {
+  time: Date;
+  deviceId: number;
+  temperature: number;
+}
+
+// A consumer-style wrapper signature: args in, typed rows out.
+declare function myWrapper<const A extends TimeBucketArgs<Row, { deviceId?: number }>>(
+  args: A,
+): Promise<Array<TimeBucketRow<Row, A>>>;
+
+const agg: AggregateInput<Row> = { avgTemp: { avg: "temperature" } };
+const op: AggregateOp<Row> = { max: "temperature" };
+
+declare const rows: Awaited<ReturnType<typeof myWrapper<{ bucket: "1 hour"; range: { start: Date; end: Date }; aggregate: { avgTemp: { avg: "temperature" } } }>>>;
+const _n: number = rows[0]!.avgTemp;
+
+// The manage types stay importable alongside them.
+declare const manage: TimescaleManage;
+declare const stats: JobStats[];
+
+// Prisma-coupled helpers resolve too (structurally unknown here, but must be nameable).
+type _S = ScalarRow<unknown>;
+type _W = WhereInput<unknown>;
+
+// Silence unused-variable checks: naming the values is the whole test.
+export { agg, op, _n, manage, stats };
+export type { _S, _W };


### PR DESCRIPTION
Fifth fix PR of the v1 campaign (#106).

dist/index.d.ts declared TimeBucketArgs, TimeBucketRow, and AggregateInput but never exported them, and package.json publishes only '.' and './core', so a consumer typing a wrapper around model.timeBucket(...) had no way to name the types (the repo's own type tests do it through a src import consumers cannot write). The root barrel now re-exports them, plus AggregateOp, ScalarRow, and WhereInput, mirroring the already-exported manage types.

A new type-level test (test/types/root-exports.test-d.ts) imports everything through the root entry and types a consumer-style wrapper. Build, attw (all entrypoints green), and the full suite pass locally.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenient package-level access to time-bucket, aggregation, filtering, scalar-row, management, and job-statistics TypeScript types.

* **Tests**
  * Added type-level coverage to verify these types can be imported and used correctly from the package root.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->