### PR TITLE
fix(client)!: bind $timescale to the calling client so transactions apply

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,7 +11,7 @@ import {
   type TimeBucketMethod,
   type TimeBucketRuntimeArgs,
 } from "./timeBucket.js";
-import { makeManage, type RawClient } from "./manage.js";
+import { makeManage, type RawClient, type TimescaleManage } from "./manage.js";
 
 /** Manual configuration accepted by `timescaledb()` (also satisfied by the generated registry). */
 export interface TimescaleConfig {
@@ -116,6 +116,12 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
     return (ctx.$parent as UnsafeRawClient).$queryRawUnsafe(sql, ...params);
   } as unknown as TimeBucketMethod;
 
+  // One namespace per executing client, keyed weakly so transaction clients can be collected.
+  const manageCache = new WeakMap<
+    object,
+    TimescaleManage<NamesOrString<HypertableModelNames<C>>, NamesOrString<CaggModelNames<C>>>
+  >();
+
   return Prisma.defineExtension((client) =>
     client.$extends({
       name: "prisma-extension-timescaledb",
@@ -123,11 +129,28 @@ export function timescaledb<const C extends TimescaleConfig = TimescaleConfig>(c
         $allModels: { timeBucket },
       },
       client: {
-        $timescale: makeManage<NamesOrString<HypertableModelNames<C>>, NamesOrString<CaggModelNames<C>>>(
-          client as unknown as RawClient,
-          caggViewByModel,
-          { hypertableByModel },
-        ),
+        /**
+         * The management namespace, bound to the client it is called on. A METHOD, not a
+         * property: Prisma serves client-extension values unbound, so a prebuilt namespace
+         * object would close over the base client forever — inside `$transaction(async (tx) =>
+         * ...)` its SQL would escape the transaction onto a separate pooled connection, and it
+         * would bypass extensions chained after this one. Called as `tx.$timescale()`, plain
+         * JS method binding hands us the transaction client, so the SQL joins the transaction
+         * and flows through the full extension chain.
+         */
+        $timescale(this: unknown) {
+          const ctx = Prisma.getExtensionContext(this) as object;
+          let manage = manageCache.get(ctx);
+          if (!manage) {
+            manage = makeManage<NamesOrString<HypertableModelNames<C>>, NamesOrString<CaggModelNames<C>>>(
+              ctx as unknown as RawClient,
+              caggViewByModel,
+              { hypertableByModel },
+            );
+            manageCache.set(ctx, manage);
+          }
+          return manage;
+        },
       },
     }),
   );

--- a/src/core/compression.ts
+++ b/src/core/compression.ts
@@ -23,7 +23,7 @@ export interface CompressionPolicyConfig extends CompressionConfig {
  * Parse a columnstore `orderby` term such as `"time DESC NULLS LAST"` into its parts. The column
  * is left as written (a Prisma field name from an annotation / runtime arg; the caller maps it to
  * the DB name). Throws on malformed direction / NULLS tokens. Shared by the generator (annotation
- * parsing) and the runtime ($timescale.addCompressionPolicy).
+ * parsing) and the runtime ($timescale().addCompressionPolicy).
  */
 export function parseOrderByTerm(term: string): CompressionOrderBy {
   const tokens = term.trim().split(/\s+/);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -130,7 +130,7 @@ export interface RefreshPolicy {
 /** Continuous aggregate config (SPEC §1.2 / §2.3). */
 export interface CaggConfig {
   /**
-   * Prisma view model name, used by `$timescale.refreshContinuousAggregate(...)` to resolve
+   * Prisma view model name, used by `$timescale().refreshContinuousAggregate(...)` to resolve
    * the caller's name to the DB view. Omitted when it equals `name` (no @@map).
    */
   model?: string;

--- a/test/integration/bucket-column.test.ts
+++ b/test/integration/bucket-column.test.ts
@@ -113,7 +113,7 @@ describe.skipIf(!DOCKER_OK)("physical `bucket` column (real TimescaleDB)", () =>
   });
 
   it("the cagg over the colliding source refreshes and reads back", async () => {
-    await prisma.$timescale.refreshContinuousAggregate("ReadingHourly");
+    await prisma.$timescale().refreshContinuousAggregate("ReadingHourly");
     const rows = await prisma.readingHourly.findMany();
     expect(rows).toHaveLength(1);
     expect(rows[0].avgValue).toBe(20);

--- a/test/integration/cagg-policy.test.ts
+++ b/test/integration/cagg-policy.test.ts
@@ -1,5 +1,5 @@
 // Continuous-aggregate refresh-policy management at runtime, on real TimescaleDB:
-// $timescale.removeContinuousAggregatePolicy / addContinuousAggregatePolicy. The default harness
+// $timescale().removeContinuousAggregatePolicy / addContinuousAggregatePolicy. The default harness
 // schema already has a refresh policy from the annotation; verified against timescaledb_information.jobs.
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
@@ -56,14 +56,14 @@ describe.skipIf(!DOCKER_OK)("continuous-aggregate refresh policy (runtime)", () 
     // The generator already added a refresh policy from the annotation.
     expect(await refreshJobs(h)).toBe(1);
 
-    await prisma.$timescale.removeContinuousAggregatePolicy("SensorHourly");
+    await prisma.$timescale().removeContinuousAggregatePolicy("SensorHourly");
     expect(await refreshJobs(h)).toBe(0);
 
-    await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", policy);
+    await prisma.$timescale().addContinuousAggregatePolicy("SensorHourly", policy);
     expect(await refreshJobs(h)).toBe(1);
 
     // Idempotent: re-adding the identical policy is a no-op, not an error.
-    await prisma.$timescale.addContinuousAggregatePolicy("SensorHourly", policy);
+    await prisma.$timescale().addContinuousAggregatePolicy("SensorHourly", policy);
     expect(await refreshJobs(h)).toBe(1);
   });
 });

--- a/test/integration/chunk-helpers.test.ts
+++ b/test/integration/chunk-helpers.test.ts
@@ -65,22 +65,22 @@ describe.skipIf(!DOCKER_OK)("$timescale chunk + size helpers (real TimescaleDB)"
   });
 
   it("reports total / detailed size and an approximate row count as bigints", async () => {
-    const size = await prisma.$timescale.hypertableSize("SensorReading");
+    const size = await prisma.$timescale().hypertableSize("SensorReading");
     expect(typeof size).toBe("bigint");
     expect(size).toBeGreaterThan(0n);
 
-    const detailed = await prisma.$timescale.hypertableDetailedSize("SensorReading");
+    const detailed = await prisma.$timescale().hypertableDetailedSize("SensorReading");
     expect(typeof detailed.totalBytes).toBe("bigint");
     expect(detailed.totalBytes).toBeGreaterThan(0n);
     expect(detailed.totalBytes).toBe(detailed.tableBytes + detailed.indexBytes + detailed.toastBytes);
 
-    const rows = await prisma.$timescale.approximateRowCount("SensorReading");
+    const rows = await prisma.$timescale().approximateRowCount("SensorReading");
     expect(typeof rows).toBe("bigint");
     expect(rows).toBe(3n);
   });
 
   it("dropChunks drops old chunks on demand and returns their names", async () => {
-    const dropped = await prisma.$timescale.dropChunks("SensorReading", { olderThan: "15 days" });
+    const dropped = await prisma.$timescale().dropChunks("SensorReading", { olderThan: "15 days" });
     expect(dropped).toHaveLength(1); // only the ~20-days-ago chunk is entirely older than 15 days
     expect(dropped.every((c: string) => c.includes("_hyper_"))).toBe(true);
 
@@ -89,8 +89,8 @@ describe.skipIf(!DOCKER_OK)("$timescale chunk + size helpers (real TimescaleDB)"
   });
 
   it("compressionStats reads catalog stats once columnstore is enabled", async () => {
-    await prisma.$timescale.addCompressionPolicy("SensorReading", { after: "7 days" });
-    const stats = await prisma.$timescale.compressionStats("SensorReading");
+    await prisma.$timescale().addCompressionPolicy("SensorReading", { after: "7 days" });
+    const stats = await prisma.$timescale().compressionStats("SensorReading");
     expect(typeof stats.totalChunks).toBe("bigint");
     expect(stats.compressedChunks).toBe(0n); // policy hasn't run yet — nothing compressed
   });

--- a/test/integration/chunk-ops.test.ts
+++ b/test/integration/chunk-ops.test.ts
@@ -1,4 +1,4 @@
-// On-demand chunk operations at runtime, on real TimescaleDB: $timescale.showChunks /
+// On-demand chunk operations at runtime, on real TimescaleDB: $timescale().showChunks /
 // compressChunk / decompressChunk. The hypertable enables the columnstore (@timescale.compression)
 // so compress_chunk works; we insert two days' worth of data to get two chunks.
 //
@@ -72,28 +72,28 @@ describe.skipIf(!DOCKER_OK)("on-demand chunk operations (runtime)", () => {
   });
 
   it("lists chunks and applies interval bounds", async () => {
-    const chunks: string[] = await prisma.$timescale.showChunks("SensorReading");
+    const chunks: string[] = await prisma.$timescale().showChunks("SensorReading");
     expect(chunks).toHaveLength(2);
     expect(chunks.every((c) => c.includes("_hyper_"))).toBe(true);
 
     // The data is from early 2026; nothing is older than ~27 years before now, so the bound filters all out.
-    expect(await prisma.$timescale.showChunks("SensorReading", { olderThan: "10000 days" })).toHaveLength(0);
+    expect(await prisma.$timescale().showChunks("SensorReading", { olderThan: "10000 days" })).toHaveLength(0);
   });
 
   it("compresses and decompresses a single chunk, idempotently", async () => {
-    const [chunk] = await prisma.$timescale.showChunks("SensorReading");
+    const [chunk] = await prisma.$timescale().showChunks("SensorReading");
     expect(await compressedChunks(h)).not.toContain(chunk);
 
-    await prisma.$timescale.compressChunk(chunk);
+    await prisma.$timescale().compressChunk(chunk);
     expect(await compressedChunks(h)).toContain(chunk);
     // Idempotent: re-compressing an already-compressed chunk is a no-op, not an error.
-    await prisma.$timescale.compressChunk(chunk);
+    await prisma.$timescale().compressChunk(chunk);
     expect(await compressedChunks(h)).toContain(chunk);
 
-    await prisma.$timescale.decompressChunk(chunk);
+    await prisma.$timescale().decompressChunk(chunk);
     expect(await compressedChunks(h)).not.toContain(chunk);
     // Idempotent the other way too.
-    await prisma.$timescale.decompressChunk(chunk);
+    await prisma.$timescale().decompressChunk(chunk);
     expect(await compressedChunks(h)).not.toContain(chunk);
   });
 });

--- a/test/integration/chunk-skipping.test.ts
+++ b/test/integration/chunk-skipping.test.ts
@@ -2,7 +2,7 @@
 //   1. Generated + reset-safe: the `chunkSkipping` annotation emits a DO block that turns the
 //      `timescaledb.enable_chunk_skipping` GUC on and calls enable_chunk_skipping(...), surviving
 //      `migrate reset` (idempotent replay).
-//   2. Runtime: $timescale.disableChunkSkipping / enableChunkSkipping toggle the column, idempotently.
+//   2. Runtime: $timescale().disableChunkSkipping / enableChunkSkipping toggle the column, idempotently.
 // Verified against the internal catalog `_timescaledb_catalog.chunk_column_stats` (there is no public
 // timescaledb_information view for chunk skipping). The GUC requirement and the "compressed chunks
 // only" caveat are exercised implicitly: the enable call only succeeds because we set the GUC.
@@ -91,16 +91,16 @@ describe.skipIf(!DOCKER_OK)("chunk skipping (generated + runtime)", () => {
     // The generator already enabled eventId from the annotation.
     expect(await skippingColumns(h)).toBe(1);
 
-    await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
+    await prisma.$timescale().disableChunkSkipping("SensorReading", "eventId");
     expect(await skippingColumns(h)).toBe(0);
     // Idempotent: re-disabling a not-enabled column is a no-op, not an error.
-    await prisma.$timescale.disableChunkSkipping("SensorReading", "eventId");
+    await prisma.$timescale().disableChunkSkipping("SensorReading", "eventId");
     expect(await skippingColumns(h)).toBe(0);
 
-    await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
+    await prisma.$timescale().enableChunkSkipping("SensorReading", "eventId");
     expect(await skippingColumns(h)).toBe(1);
     // Idempotent: re-enabling is a no-op.
-    await prisma.$timescale.enableChunkSkipping("SensorReading", "eventId");
+    await prisma.$timescale().enableChunkSkipping("SensorReading", "eventId");
     expect(await skippingColumns(h)).toBe(1);
   });
 

--- a/test/integration/compression.test.ts
+++ b/test/integration/compression.test.ts
@@ -77,7 +77,7 @@ describe.skipIf(!DOCKER_OK)("compression policies (generated + runtime)", () => 
     expect(await compressionJobs(h)).toBe(1);
   });
 
-  it("$timescale.addCompressionPolicy / removeCompressionPolicy operate at runtime", async () => {
+  it("$timescale().addCompressionPolicy / removeCompressionPolicy operate at runtime", async () => {
     const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
     const { PrismaPg } = await import("@prisma/adapter-pg");
     const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
@@ -85,10 +85,10 @@ describe.skipIf(!DOCKER_OK)("compression policies (generated + runtime)", () => 
     const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
     const prisma = base.$extends(timescaledb(registry));
     try {
-      await prisma.$timescale.removeCompressionPolicy("SensorReading");
+      await prisma.$timescale().removeCompressionPolicy("SensorReading");
       expect(await compressionJobs(h)).toBe(0);
 
-      await prisma.$timescale.addCompressionPolicy("SensorReading", {
+      await prisma.$timescale().addCompressionPolicy("SensorReading", {
         after: "7 days",
         segmentBy: "deviceId",
         orderBy: "time DESC",
@@ -96,7 +96,7 @@ describe.skipIf(!DOCKER_OK)("compression policies (generated + runtime)", () => 
       expect(await compressionJobs(h)).toBe(1);
 
       // Idempotent: re-adding the identical policy is a no-op, not an error.
-      await prisma.$timescale.addCompressionPolicy("SensorReading", {
+      await prisma.$timescale().addCompressionPolicy("SensorReading", {
         after: "7 days",
         segmentBy: "deviceId",
         orderBy: "time DESC",

--- a/test/integration/jobs.test.ts
+++ b/test/integration/jobs.test.ts
@@ -1,4 +1,4 @@
-// Background-job control + introspection at runtime, on real TimescaleDB: $timescale.listJobs /
+// Background-job control + introspection at runtime, on real TimescaleDB: $timescale().listJobs /
 // jobStats / jobErrors / alterJob / runJob / deleteJob. The schema declares a retention policy
 // (job -> SensorReading) and a cagg refresh policy (job -> SensorHourly), so we can exercise both
 // the model filter (hypertable vs cagg) and the full job lifecycle.
@@ -73,7 +73,7 @@ describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
   });
 
   const jobByProc = async (model: string, proc: string): Promise<TimescaleJob | undefined> =>
-    (await prisma.$timescale.listJobs(model)).find((j: TimescaleJob) => j.procName === proc);
+    (await prisma.$timescale().listJobs(model)).find((j: TimescaleJob) => j.procName === proc);
 
   it("lists jobs and filters by model (hypertable vs continuous aggregate)", async () => {
     const retention = await jobByProc("SensorReading", "policy_retention");
@@ -85,17 +85,17 @@ describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
     expect(refresh.hypertableName).toBe("SensorHourly");
 
     // The model filter excludes the other relation's jobs and the built-in (relation-less) jobs.
-    const onlyRetention = await prisma.$timescale.listJobs("SensorReading");
+    const onlyRetention = await prisma.$timescale().listJobs("SensorReading");
     expect(onlyRetention.every((j: { hypertableName: string }) => j.hypertableName === "SensorReading")).toBe(true);
   });
 
   it("alterJob pauses, resumes, and reschedules a policy", async () => {
     const before = await jobByProc("SensorReading", "policy_retention");
 
-    await prisma.$timescale.alterJob(before.jobId, { scheduled: false });
+    await prisma.$timescale().alterJob(before.jobId, { scheduled: false });
     expect((await jobByProc("SensorReading", "policy_retention")).scheduled).toBe(false);
 
-    await prisma.$timescale.alterJob(before.jobId, { scheduled: true, scheduleInterval: "2 days" });
+    await prisma.$timescale().alterJob(before.jobId, { scheduled: true, scheduleInterval: "2 days" });
     const after = await jobByProc("SensorReading", "policy_retention");
     expect(after.scheduled).toBe(true);
     expect(after.scheduleInterval).toBe("2 days");
@@ -104,18 +104,18 @@ describe.skipIf(!DOCKER_OK)("job control + introspection (runtime)", () => {
   it("runJob runs a job synchronously and jobStats returns bigint counts", async () => {
     const retention = await jobByProc("SensorReading", "policy_retention");
     // Retention on recent/empty data is a safe no-op; it must not throw.
-    await prisma.$timescale.runJob(retention.jobId);
+    await prisma.$timescale().runJob(retention.jobId);
 
-    const [stats] = await prisma.$timescale.jobStats("SensorReading");
+    const [stats] = await prisma.$timescale().jobStats("SensorReading");
     expect(stats.jobId).toBe(retention.jobId);
     expect(typeof stats.totalRuns).toBe("bigint");
     // jobErrors is queryable (no failures expected) and returns an array.
-    expect(Array.isArray(await prisma.$timescale.jobErrors("SensorReading"))).toBe(true);
+    expect(Array.isArray(await prisma.$timescale().jobErrors("SensorReading"))).toBe(true);
   });
 
   it("deleteJob removes a job", async () => {
     const retention = await jobByProc("SensorReading", "policy_retention");
-    await prisma.$timescale.deleteJob(retention.jobId);
+    await prisma.$timescale().deleteJob(retention.jobId);
     expect(await jobByProc("SensorReading", "policy_retention")).toBeUndefined();
   });
 });

--- a/test/integration/mapped.test.ts
+++ b/test/integration/mapped.test.ts
@@ -134,7 +134,7 @@ describe.skipIf(!DOCKER_OK)("@@map / @map (generated migrations + runtime)", () 
       ]);
 
       // Model name "SensorHourly" resolves to the DB view "sensor_hourly".
-      await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+      await prisma.$timescale().refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });
       expect(
         hourly.map((r: { deviceId: number; avgTemp: number }) => ({ d: r.deviceId, avg: Number(r.avgTemp) })),

--- a/test/integration/multi-schema.test.ts
+++ b/test/integration/multi-schema.test.ts
@@ -136,7 +136,7 @@ describe.skipIf(!DOCKER_OK)("@@schema / multiSchema (generated migrations + runt
         { h: "2026-06-15T10:00:00.000Z", d: 2, avg: 15 },
       ]);
 
-      await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+      await prisma.$timescale().refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });
       expect(
         hourly.map((r: { deviceId: number; avgTemp: number }) => ({ d: r.deviceId, avg: Number(r.avgTemp) })),

--- a/test/integration/reset-safety.test.ts
+++ b/test/integration/reset-safety.test.ts
@@ -157,7 +157,7 @@ describe.skipIf(!DOCKER_OK)("reset-safety (generated migrations)", () => {
       expect(exact.sumNum).toBe(6);
 
       // Refresh the continuous aggregate, then read it as a normal typed Prisma view.
-      await prisma.$timescale.refreshContinuousAggregate("SensorHourly");
+      await prisma.$timescale().refreshContinuousAggregate("SensorHourly");
       const hourly = await prisma.sensorHourly.findMany({ orderBy: [{ deviceId: "asc" }, { bucket: "asc" }] });
       expect(
         hourly.map((r: { bucket: Date; deviceId: number; avgTemp: number }) => ({

--- a/test/integration/retention.test.ts
+++ b/test/integration/retention.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(!DOCKER_OK)("retention policies (generated + runtime)", () => {
     expect(await retentionJobs(h)).toBe(1);
   });
 
-  it("$timescale.addRetentionPolicy / removeRetentionPolicy operate at runtime", async () => {
+  it("$timescale().addRetentionPolicy / removeRetentionPolicy operate at runtime", async () => {
     const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
     const { PrismaPg } = await import("@prisma/adapter-pg");
     const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
@@ -71,14 +71,47 @@ describe.skipIf(!DOCKER_OK)("retention policies (generated + runtime)", () => {
     const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
     const prisma = base.$extends(timescaledb(registry));
     try {
-      await prisma.$timescale.removeRetentionPolicy("SensorReading");
+      await prisma.$timescale().removeRetentionPolicy("SensorReading");
       expect(await retentionJobs(h)).toBe(0);
 
-      await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      await prisma.$timescale().addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
       expect(await retentionJobs(h)).toBe(1);
 
       // Idempotent: re-adding the identical policy is a no-op, not an error.
-      await prisma.$timescale.addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      await prisma.$timescale().addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      expect(await retentionJobs(h)).toBe(1);
+    } finally {
+      await base.$disconnect();
+    }
+  });
+
+  it("$timescale() joins an interactive transaction: a rollback undoes the policy", async () => {
+    // $timescale used to close over the pre-extension client, so its SQL ran on a separate
+    // pooled connection and committed despite the surrounding rollback. As a method it binds
+    // to the client it is called on — the transaction client inside $transaction.
+    const { PrismaClient } = await import(pathToFileURL(join(h.projectDir, "client", "client.ts")).href);
+    const { PrismaPg } = await import("@prisma/adapter-pg");
+    const { registry } = await import(pathToFileURL(join(h.projectDir, "timescale", "index.ts")).href);
+
+    const base = new PrismaClient({ adapter: new PrismaPg({ connectionString: h.databaseUrl }) });
+    const prisma = base.$extends(timescaledb(registry));
+    try {
+      await prisma.$timescale().removeRetentionPolicy("SensorReading");
+      expect(await retentionJobs(h)).toBe(0);
+
+      await expect(
+        prisma.$transaction(async (tx: typeof prisma) => {
+          await tx.$timescale().addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+          throw new Error("abort");
+        }),
+      ).rejects.toThrow("abort");
+      // The add above must have been part of the transaction, so the rollback removed it.
+      expect(await retentionJobs(h)).toBe(0);
+
+      // And a committed transaction keeps it.
+      await prisma.$transaction(async (tx: typeof prisma) => {
+        await tx.$timescale().addRetentionPolicy("SensorReading", { dropAfter: "7 days" });
+      });
       expect(await retentionJobs(h)).toBe(1);
     } finally {
       await base.$disconnect();

--- a/test/integration/set-chunk-interval.test.ts
+++ b/test/integration/set-chunk-interval.test.ts
@@ -1,5 +1,5 @@
 // Changing a live hypertable's chunk interval at runtime on real TimescaleDB:
-// $timescale.setChunkInterval -> set_partitioning_interval. The default harness hypertable is
+// $timescale().setChunkInterval -> set_partitioning_interval. The default harness hypertable is
 // created with chunkInterval "1 day"; we resize it and confirm via timescaledb_information.dimensions.
 // Runtime-only feature (no migration emitted), so no migrate-reset assertion is needed.
 import { execFileSync } from "node:child_process";
@@ -61,11 +61,11 @@ describe.skipIf(!DOCKER_OK)("set chunk interval (runtime)", () => {
     // Created at "1 day" by the annotation.
     expect(await chunkIntervalSeconds(h)).toBe(DAY);
 
-    await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
+    await prisma.$timescale().setChunkInterval("SensorReading", "6 hours");
     expect(await chunkIntervalSeconds(h)).toBe(SIX_HOURS);
 
     // Re-applying the same value is a no-op, not an error.
-    await prisma.$timescale.setChunkInterval("SensorReading", "6 hours");
+    await prisma.$timescale().setChunkInterval("SensorReading", "6 hours");
     expect(await chunkIntervalSeconds(h)).toBe(SIX_HOURS);
   });
 });


### PR DESCRIPTION
Sixth fix PR of the v1 campaign (#106), and the first breaking one.

## The defect

$timescale was a namespace object built once over the client captured by the defineExtension callback. Prisma serves client-extension values unbound: reading the installed 7.10 runtime, the merged client components are plain values ({...extension.client} in the extension chain, getPropertyValue returning them as-is) and the interactive-transaction client re-attaches the same stored object. Consequences, both verified:

- Inside prisma.$transaction(async (tx) => { await tx.$timescale.dropChunks(...); throw ... }), the SQL ran on a separate pooled connection and committed despite the rollback.
- $timescale SQL bypassed any extension chained after this one (logging, tracing).

## The fix

$timescale becomes a client-extension METHOD. A function invoked as tx.$timescale() receives tx as this through ordinary JS method binding, and Prisma.getExtensionContext(this) is the identity function, so the namespace binds to exactly the client it is called on: transaction clients join the transaction, and the SQL flows through the full extension chain. Namespaces are cached per client in a WeakMap so transaction clients can be collected.

## Breaking change

prisma.$timescale.foo(...) becomes prisma.$timescale().foo(...). Mechanical migration; the model-name type safety is unchanged. The wiki's Management page will need the same one-character update after release.

## Validation

New Testcontainers regression test: a retention policy added inside a rolled-back transaction does not exist afterward, and one added in a committed transaction does. Full unit (278), type-level, build, and the complete integration suite pass locally.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Timescale management API to use the `$timescale()` method for compression, retention, continuous aggregate, job, chunk, and interval operations.
  * Management operations now preserve the active transaction and client context, including when chained through extensions.

* **Documentation**
  * Updated API guidance and examples to reflect the `$timescale()` method syntax.

* **Tests**
  * Updated integration coverage for the new API and transaction behavior, including idempotent operations and rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->