### PR TITLE
feat(client): support implicit many-to-many relations in timeBucket filters

### DIFF
--- a/src/client/timeBucket.ts
+++ b/src/client/timeBucket.ts
@@ -544,6 +544,15 @@ export function buildTimeBucketQuery(
         ...(r.fk ? { fk: r.fk } : {}),
         ...(r.targetModel ? { targetModel: r.targetModel } : {}),
         ...(r.required ? { required: true } : {}),
+        ...(r.through
+          ? {
+              through: {
+                table: qualifiedIdent(r.through.table, r.through.schema),
+                outerColumn: r.through.outerColumn,
+                relatedColumn: r.through.relatedColumn,
+              },
+            }
+          : {}),
       });
     }
     relMaps.set(m, fieldMap);

--- a/src/client/where.ts
+++ b/src/client/where.ts
@@ -47,6 +47,10 @@ export interface RuntimeRelation {
   required?: boolean;
   /** Related model's Prisma name, used to resolve its own relations for deeper nesting. */
   targetModel?: string;
+  /** Implicit many-to-many: the hidden join table (already quoted/qualified) and which of its
+   * columns points at which side. With `through` set, `on` holds one pair: the related model's
+   * id column (`related`) and the outer model's id column (`outer`), both unquoted DB names. */
+  through?: { table: string; outerColumn: string; relatedColumn: string };
 }
 
 const SUPPORTED = "equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith";
@@ -130,8 +134,19 @@ function relationClause(field: string, value: unknown, rel: RuntimeRelation, ctx
       ? { rel: { outerTable: alias, get: nestedGet, depth: level, relationsOf: ctx.rel!.relationsOf } }
       : {}),
   };
-  const join = rel.on.map((p) => `${alias}.${quoteIdent(p.related)} = ${outer}.${quoteIdent(p.outer)}`).join(" AND ");
-  const from = `${rel.table} AS ${alias}`;
+  // Implicit m-n goes through the hidden join table: FROM _jt JOIN related ON related.id = _jt.<X>
+  // WHERE _jt.<Y> = outer.id. The join-table alias is depth-unique like the relation alias.
+  let join: string;
+  let from: string;
+  if (rel.through) {
+    const jt = quoteIdent(level === 1 ? "_jt" : `_jt${level}`);
+    const pair = rel.on[0]!;
+    from = `${rel.through.table} AS ${jt} JOIN ${rel.table} AS ${alias} ON ${alias}.${quoteIdent(pair.related)} = ${jt}.${quoteIdent(rel.through.relatedColumn)}`;
+    join = `${jt}.${quoteIdent(rel.through.outerColumn)} = ${outer}.${quoteIdent(pair.outer)}`;
+  } else {
+    join = rel.on.map((p) => `${alias}.${quoteIdent(p.related)} = ${outer}.${quoteIdent(p.outer)}`).join(" AND ");
+    from = `${rel.table} AS ${alias}`;
+  }
 
   // EXISTS (SELECT 1 FROM related AS _rel WHERE join AND (inner)); inner "" -> TRUE. `every` negates
   // the inner (NOT EXISTS where a related row fails it). `negate` wraps the whole thing in NOT.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -63,6 +63,22 @@ export interface RelationConfig {
   fk?: readonly string[];
   /** `true` for a required to-one relation — `null` filters are rejected (Prisma's types do too). */
   required?: boolean;
+  /**
+   * For an implicit many-to-many relation: Prisma's hidden join table (`_<relationName>`). Its
+   * `"A"` column references the alphabetically-first model's id, `"B"` the other — verified
+   * empirically against Prisma's own DDL. With `through` set, `on` holds ONE pair: the two
+   * models' id DB columns (`related` = the related model's id, `outer` = this model's id).
+   */
+  through?: {
+    /** Join table DB name (always `_<relationName>`). */
+    table: string;
+    /** Join table's `@@schema` (multiSchema) — the models' shared schema. */
+    schema?: string;
+    /** Join-table column (`"A"` or `"B"`) referencing THIS model's id. */
+    outerColumn: string;
+    /** Join-table column (`"A"` or `"B"`) referencing the related model's id. */
+    relatedColumn: string;
+  };
 }
 
 /** Hypertable conversion config (SPEC §1.1 / §2.2). All names are DB names (post-@@map). */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -292,7 +292,20 @@ function buildRelations(model: DMMF.Model, byName: Map<string, DMMF.Model>): Rel
       const owning = related.fields.find(
         (g) => g.kind === "object" && g.relationName === f.relationName && (g.relationFromFields?.length ?? 0) > 0,
       );
-      if (!owning?.relationFromFields || !owning.relationToFields) continue;
+      if (!owning?.relationFromFields || !owning.relationToFields) {
+        // NEITHER side owns a FK: an implicit many-to-many. Prisma keeps the pairs in a
+        // hidden join table named `_<relationName>` whose "A" column references the
+        // alphabetically-first model's id and "B" the other — verified empirically against
+        // Prisma's own DDL (including a custom @relation name and an @map'd id). Self-relations
+        // stay unsupported: both join columns reference the same model, so the filter
+        // direction is ambiguous.
+        const m2m =
+          f.isList && f.relationName && model.name !== related.name
+            ? implicitManyToMany(model, related, f)
+            : undefined;
+        if (m2m) relations.push(m2m);
+        continue;
+      }
       const toFields = owning.relationToFields;
       on = owning.relationFromFields.map((fromField, i) => ({
         related: resolveCol(related, fromField),
@@ -320,6 +333,35 @@ function buildRelations(model: DMMF.Model, byName: Map<string, DMMF.Model>): Rel
 /** Resolve a field name on a model to its DB column name (the @map value, or the field name). */
 function resolveCol(model: DMMF.Model, fieldName: string): string {
   return model.fields.find((f) => f.name === fieldName)?.dbName ?? fieldName;
+}
+
+/**
+ * Build the RelationConfig for one side of an implicit many-to-many relation. `on` carries one
+ * pair — the two models' single id DB columns — and `through` names the hidden join table and
+ * which of its "A"/"B" columns points at which side. Prisma requires a single-field id on both
+ * models for an implicit m-n, so a missing one means the DMMF is not what we expect; skip.
+ */
+function implicitManyToMany(model: DMMF.Model, related: DMMF.Model, f: DMMF.Field): RelationConfig | undefined {
+  const modelId = model.fields.find((g) => g.isId);
+  const relatedId = related.fields.find((g) => g.isId);
+  if (!modelId || !relatedId) return undefined;
+  const columns = columnMap(related);
+  const outerIsA = model.name < related.name;
+  return {
+    field: f.name,
+    targetModel: related.name,
+    table: dbTable(related),
+    ...(related.schema ? { schema: related.schema } : {}),
+    list: true,
+    on: [{ related: dbCol(relatedId), outer: dbCol(modelId) }],
+    ...(Object.keys(columns).length > 0 ? { columns } : {}),
+    through: {
+      table: `_${f.relationName}`,
+      ...(model.schema ? { schema: model.schema } : {}),
+      outerColumn: outerIsA ? "A" : "B",
+      relatedColumn: outerIsA ? "B" : "A",
+    },
+  };
 }
 
 /** Parse the optional `@timescale.retention(dropAfter)` annotation on a hypertable model. */

--- a/src/generator/dmmf.ts
+++ b/src/generator/dmmf.ts
@@ -347,6 +347,10 @@ function implicitManyToMany(model: DMMF.Model, related: DMMF.Model, f: DMMF.Fiel
   if (!modelId || !relatedId) return undefined;
   const columns = columnMap(related);
   const outerIsA = model.name < related.name;
+  // The join table lives in the alphabetically-FIRST model's schema — probed empirically
+  // (cross-schema implicit m-n validates, and db push placed _CategoryToDevice in Category's
+  // schema), matching Prisma's multiSchema docs.
+  const throughSchema = outerIsA ? model.schema : related.schema;
   return {
     field: f.name,
     targetModel: related.name,
@@ -357,7 +361,7 @@ function implicitManyToMany(model: DMMF.Model, related: DMMF.Model, f: DMMF.Fiel
     ...(Object.keys(columns).length > 0 ? { columns } : {}),
     through: {
       table: `_${f.relationName}`,
-      ...(model.schema ? { schema: model.schema } : {}),
+      ...(throughSchema ? { schema: throughSchema } : {}),
       outerColumn: outerIsA ? "A" : "B",
       relatedColumn: outerIsA ? "B" : "A",
     },

--- a/test/integration/relation-filters.test.ts
+++ b/test/integration/relation-filters.test.ts
@@ -34,9 +34,15 @@ model Reading {
   @@id([id, time])
 }
 model Device {
-  id       Int       @id
-  active   Boolean
-  readings Reading[]
+  id         Int        @id
+  active     Boolean
+  readings   Reading[]
+  categories Category[]
+}
+model Category {
+  id      Int      @id
+  name    String
+  devices Device[]
 }
 model Tag {
   id          Int      @id
@@ -52,7 +58,11 @@ const INIT_SQL = `CREATE TABLE "Device" ("id" INTEGER PRIMARY KEY, "active" BOOL
 CREATE TABLE "Reading" ("time" TIMESTAMP(3) NOT NULL, "id" INTEGER NOT NULL, "deviceId" INTEGER,
   CONSTRAINT "Reading_pkey" PRIMARY KEY ("id","time"));
 CREATE TABLE "Tag" ("id" INTEGER PRIMARY KEY, "label" TEXT NOT NULL, "readingId" INTEGER NOT NULL,
-  "readingTime" TIMESTAMP(3) NOT NULL);`;
+  "readingTime" TIMESTAMP(3) NOT NULL);
+CREATE TABLE "Category" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL);
+CREATE TABLE "_CategoryToDevice" ("A" INTEGER NOT NULL REFERENCES "Category"("id"), "B" INTEGER NOT NULL REFERENCES "Device"("id"));
+CREATE UNIQUE INDEX "_CategoryToDevice_AB_unique" ON "_CategoryToDevice"("A", "B");
+CREATE INDEX "_CategoryToDevice_B_index" ON "_CategoryToDevice"("B");`;
 
 const t = (m: number) => new Date(`2026-06-15T10:${String(m).padStart(2, "0")}:00Z`);
 
@@ -82,6 +92,9 @@ describe.skipIf(!DOCKER_OK)("timeBucket relation filters (real TimescaleDB)", ()
         { id: 4, time: t(35), deviceId: 1 },
       ],
     });
+    // D1 in [sensors, beta]; D2 in [sensors] — reached via the implicit m-n join table.
+    await prisma.category.create({ data: { id: 1, name: "sensors", devices: { connect: [{ id: 1 }, { id: 2 }] } } });
+    await prisma.category.create({ data: { id: 2, name: "beta", devices: { connect: [{ id: 1 }] } } });
     await prisma.tag.createMany({
       data: [
         { id: 1, label: "prod", readingId: 1, readingTime: t(5) },
@@ -134,6 +147,20 @@ describe.skipIf(!DOCKER_OK)("timeBucket relation filters (real TimescaleDB)", ()
   it("composes with scalar filters and AND/OR", async () => {
     expect(await count({ AND: [{ device: { is: { active: true } } }, { tags: { some: { label: "dev" } } }] })).toBe(2); // R1, R4
     expect(await count({ deviceId: { not: null }, tags: { none: { label: "dev" } } })).toBe(1); // R2 (has device, no dev tag)
+  });
+
+  it("filters through an implicit many-to-many, matching Prisma findMany exactly", async () => {
+    // Reading -> device (to-one) -> categories (implicit m-n via the hidden _CategoryToDevice
+    // join table). Counts are checked against Prisma's own findMany, never hand-computed.
+    const cases: object[] = [
+      { device: { is: { categories: { some: { name: "beta" } } } } }, // R1, R4 (device 1)
+      { device: { is: { categories: { none: { name: "beta" } } } } }, // R2 (device 2)
+      { device: { is: { categories: { every: { name: "sensors" } } } } }, // device 2 only
+      { device: { is: { categories: { some: { devices: { some: { active: false } } } } } } }, // m-n nested inside m-n
+    ];
+    for (const where of cases) {
+      expect(await count(where)).toBe(await expected(where));
+    }
   });
 
   it("nests relation filters THROUGH other relations, matching Prisma findMany exactly", async () => {

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -1284,3 +1284,56 @@ model Person {
     expect(result.relationsByModel["Person"] ?? []).toEqual([]);
   });
 });
+
+describe("extractTimescaleSchema — implicit m-n across schemas (multiSchema)", () => {
+  it("places the join table in the alphabetically-first model's schema", async () => {
+    // Probed empirically: db push on this exact shape created meta._CategoryToDevice
+    // (Category's schema), matching Prisma's multiSchema docs.
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views", "multiSchema"]
+}
+datasource db {
+  provider = "postgresql"
+  schemas = ["iot", "meta"]
+}
+
+/// @timescale.hypertable(column: "time")
+model Reading {
+  time DateTime
+  id   Int
+  @@id([id, time])
+  @@schema("iot")
+}
+model Device {
+  id         Int        @id
+  categories Category[]
+  @@schema("iot")
+}
+model Category {
+  id      Int      @id
+  devices Device[]
+  @@schema("meta")
+}
+`,
+    });
+    const result = extractTimescaleSchema(dmmf);
+    // From Device (name > Category): Device is the "B" side; the join table sits in meta.
+    expect(result.relationsByModel["Device"]?.[0]?.through).toEqual({
+      table: "_CategoryToDevice",
+      schema: "meta",
+      outerColumn: "B",
+      relatedColumn: "A",
+    });
+    // From Category (the "A" side): same table, same schema, columns flipped.
+    expect(result.relationsByModel["Category"]?.[0]?.through).toEqual({
+      table: "_CategoryToDevice",
+      schema: "meta",
+      outerColumn: "A",
+      relatedColumn: "B",
+    });
+  });
+});

--- a/test/unit/dmmf.test.ts
+++ b/test/unit/dmmf.test.ts
@@ -1201,3 +1201,86 @@ view SensorHourly {
     ).rejects.toThrow(/view field "forgotten" has no @timescale annotation/);
   });
 });
+
+describe("extractTimescaleSchema — implicit many-to-many relations", () => {
+  const SCHEMA = `
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model Reading {
+  time     DateTime
+  id       Int
+  deviceId Int?
+  device   Device? @relation(fields: [deviceId], references: [id])
+  @@id([id, time])
+}
+model Device {
+  id         Int        @id
+  categories Category[]
+  readings   Reading[]
+}
+model Category {
+  id      Int      @id @map("cat_id")
+  name    String
+  devices Device[]
+}
+`;
+
+  it("extracts both sides with the hidden join table (A = alphabetically-first model, @map ids resolved)", async () => {
+    // Verified empirically against Prisma's DDL: table _<relationName>, column "A" references
+    // the alphabetically-first model's id, "B" the other, ids via their @map DB columns.
+    const result = await extract(SCHEMA);
+    expect(result.relationsByModel["Device"]).toContainEqual({
+      field: "categories",
+      targetModel: "Category",
+      table: "Category",
+      list: true,
+      on: [{ related: "cat_id", outer: "id" }],
+      columns: { id: "cat_id" },
+      through: { table: "_CategoryToDevice", outerColumn: "B", relatedColumn: "A" },
+    });
+    expect(result.relationsByModel["Category"]).toContainEqual({
+      field: "devices",
+      targetModel: "Device",
+      table: "Device",
+      list: true,
+      on: [{ related: "id", outer: "cat_id" }],
+      through: { table: "_CategoryToDevice", outerColumn: "A", relatedColumn: "B" },
+    });
+  });
+
+  it("uses the custom @relation name for the join table", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time")
+model Reading {
+  time DateTime
+  id   Int
+  @@id([id, time])
+}
+model Device {
+  id   Int   @id
+  tags Tag[] @relation("labelled")
+}
+model Tag {
+  id      Int      @id
+  devices Device[] @relation("labelled")
+}
+`);
+    expect(result.relationsByModel["Device"]?.[0]?.through?.table).toBe("_labelled");
+  });
+
+  it("skips an implicit many-to-many self-relation (direction is ambiguous)", async () => {
+    const result = await extract(`
+/// @timescale.hypertable(column: "time")
+model Reading {
+  time DateTime
+  id   Int
+  @@id([id, time])
+}
+model Person {
+  id        Int      @id
+  friends   Person[] @relation("friends")
+  friendOf  Person[] @relation("friends")
+}
+`);
+    expect(result.relationsByModel["Person"] ?? []).toEqual([]);
+  });
+});

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -383,3 +383,42 @@ describe("whereToSql nested relation filters (multi-level EXISTS)", () => {
     );
   });
 });
+
+describe("whereToSql — implicit many-to-many (through join table)", () => {
+  function m2mHarness() {
+    const params: unknown[] = [];
+    const categories: RuntimeRelation = {
+      table: `"public"."Category"`,
+      list: true,
+      on: [{ related: "cat_id", outer: "id" }],
+      columns: { id: "cat_id" },
+      through: { table: `"_CategoryToDevice"`, outerColumn: "B", relatedColumn: "A" },
+    };
+    const ctx: WhereCtx = {
+      col: (f) => `"${f}"`,
+      push: (v) => {
+        params.push(v);
+        return `$${params.length}`;
+      },
+      rel: { outerTable: `"public"."Device"`, get: (f) => (f === "categories" ? categories : undefined) },
+    };
+    return { ctx, params };
+  }
+
+  it("some routes through the join table with both hops", () => {
+    const { ctx, params } = m2mHarness();
+    expect(whereToSql({ categories: { some: { name: "beta" } } }, ctx)).toBe(
+      `EXISTS (SELECT 1 FROM "_CategoryToDevice" AS "_jt" JOIN "public"."Category" AS "_rel" ON "_rel"."cat_id" = "_jt"."A" WHERE "_jt"."B" = "public"."Device"."id" AND ("_rel"."name" = $1))`,
+    );
+    expect(params).toEqual(["beta"]);
+  });
+
+  it("none / every wrap the same join (every negates the inner)", () => {
+    expect(whereToSql({ categories: { none: { name: "beta" } } }, m2mHarness().ctx)).toBe(
+      `NOT EXISTS (SELECT 1 FROM "_CategoryToDevice" AS "_jt" JOIN "public"."Category" AS "_rel" ON "_rel"."cat_id" = "_jt"."A" WHERE "_jt"."B" = "public"."Device"."id" AND ("_rel"."name" = $1))`,
+    );
+    expect(whereToSql({ categories: { every: { name: "beta" } } }, m2mHarness().ctx)).toBe(
+      `NOT EXISTS (SELECT 1 FROM "_CategoryToDevice" AS "_jt" JOIN "public"."Category" AS "_rel" ON "_rel"."cat_id" = "_jt"."A" WHERE "_jt"."B" = "public"."Device"."id" AND (NOT ("_rel"."name" = $1)))`,
+    );
+  });
+});


### PR DESCRIPTION
Seventh PR of the v1 campaign (#106) — the last contained finding, implemented as real support instead of a better error message.

## Before

buildRelations required an owning side with relationFromFields, so implicit many-to-many relations (both sides lists, no FK) were silently dropped from the registry. A Prisma-legal filter like where: { device: { is: { categories: { some: { name: 'x' } } } } } then fell through to the scalar path and threw 'relation filters are not supported' — misleading, since relation filters are supported and this one was silently discarded.

## Now

Probed Prisma's actual DDL on a real Postgres (db push, inspected information_schema and pg_constraint): the hidden join table is _<relationName> (custom @relation names included), its "A" column references the alphabetically-first model's id and "B" the other, and the FKs target each side's single @id through its @map column. The generator emits that as a through config on the relation, and the runtime builds a two-hop EXISTS: join table joined to the related table, correlated to the outer row, with depth-unique aliases so nesting works.

Implicit m-n SELF-relations stay unsupported and skipped: both join columns reference the same model, so the filter direction is ambiguous.

## Validation

- Unit: join-table SQL for some/none/every; extraction of both sides (A/B assignment, @map ids, custom relation names); self-relation skip. 292 unit tests total.
- Integration: the relation-filters suite gains an implicit m-n leg (Reading -> device -> categories), with every count checked against Prisma's own findMany on the same where — including an m-n nested inside another m-n. Passes against real TimescaleDB.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering across implicit many-to-many relationships.
  - Supports nested `some`, `none`, and `every` filters through relationship join tables.
  - Handles mapped identifiers, custom relation names, and related filtering scenarios.

- **Bug Fixes**
  - Many-to-many relations are now recognized and configured instead of being skipped.

- **Tests**
  - Added coverage for many-to-many relation discovery, SQL generation, parameter binding, and nested filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->