### PR TITLE
fix(generator): close the review gaps in the versioned-migrations design

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -23,4 +23,18 @@ jobs:
       - name: Audit production dependencies (fail on high or critical)
         # --registry pins the advisory source: a PR-supplied .npmrc must not be
         # able to point the audit at a registry that returns no advisories.
-        run: npm audit --registry=https://registry.npmjs.org/ --omit=dev --audit-level=high
+        # Three attempts with backoff: npm's advisory endpoint intermittently
+        # times out ("audit endpoint returned an error"), and a transient
+        # network failure must not read as a vulnerability finding. A REAL
+        # finding fails all three attempts identically.
+        run: |
+          for attempt in 1 2 3; do
+            if npm audit --registry=https://registry.npmjs.org/ --omit=dev --audit-level=high; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "npm audit attempt $attempt failed; retrying in $((attempt * 30))s"
+              sleep $((attempt * 30))
+            fi
+          done
+          exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,11 @@ test/
    desired state with idempotent, existence-guarded DO blocks (a block skips
    when a later Prisma migration dropped its table) and removes objects that
    disappeared from the schema, so a full replay of all versions converges on
-   the current state. The previous state is persisted in
+   the current state. A continuous aggregate whose definition changed is
+   dropped and recreated (together with any caggs built on top of it, children
+   first): its materialized data is discarded and refills on the next refresh.
+   A changed refresh, retention, or compression policy is removed and re-added,
+   since TimescaleDB never updates an existing policy in place. The previous state is persisted in
    `migrations/.prisma-extension-timescaledb.json`; an unchanged schema emits
    nothing. Within a version, hypertable conversions come before continuous
    aggregates, which need their source to already be a hypertable.

--- a/src/core/hypertable.ts
+++ b/src/core/hypertable.ts
@@ -53,9 +53,13 @@ export function createHypertableSql(config: HypertableConfig): MigrationSql {
   // Guarded form: skip when the table no longer exists (a later Prisma migration dropped it),
   // so an old migration snapshot replays cleanly on `migrate reset` — verified empirically
   // (PERFORM create_hypertable inside DO works; the guard skips on a missing relation).
+  // set_partitioning_interval re-asserts the chunk interval every apply: create_hypertable's
+  // if_not_exists never updates a LIVE hypertable's interval, so without it a changed
+  // chunkInterval would silently keep the old chunk size (a no-op when already equal).
   const guardedUp = `DO $$ BEGIN
   ${existenceGuard(rel)}
   PERFORM ${indentBody(convert)};${dimension ? `\n  PERFORM ${dimension};` : ""}
+  PERFORM set_partitioning_interval(${rel}, INTERVAL ${quoteLiteral(chunkInterval)});
 END $$;`;
 
   const down = `-- No separate un-hypertable step: dropping "${table}" (Prisma's own down) removes the hypertable.`;

--- a/src/generator/emit-migrations.ts
+++ b/src/generator/emit-migrations.ts
@@ -106,15 +106,24 @@ function orderCaggs(caggs: readonly CaggConfig[]): CaggConfig[] {
   return sorted;
 }
 
-/** Canonicalize a state for comparison: stable object-key and array order, no undefineds. */
+/**
+ * Canonicalize a state for comparison: stable object-key and array order, no undefineds, and
+ * ONLY the fields that reach emitted SQL. `relations`, `columns`, and `model` drive the runtime
+ * registry, not migrations — a rename/@map-only change must not spawn a new (empty) migration.
+ */
 function canonicalState(schema: TimescaleSchema): ObjectsState {
   const hypertables = [...schema.hypertables]
     .sort((a, b) => byCodePoint(qualify(a.schema, a.table), qualify(b.schema, b.table)))
-    // Strip relations: they drive the runtime registry, not migrations — a relation-only
-    // change must not spawn a new migration.
-    .map(({ relations: _relations, ...rest }) => rest);
-  const continuousAggregates = orderCaggs(schema.continuousAggregates);
+    .map(({ relations: _relations, columns: _columns, model: _model, ...rest }) => rest);
+  const continuousAggregates = orderCaggs(schema.continuousAggregates).map(({ model: _model, ...rest }) => rest);
   return { hypertables, continuousAggregates };
+}
+
+/** A cagg's definition WITHOUT its refresh policy — what decides drop-and-recreate. The policy
+ * is managed separately (it can be removed/re-added without touching the materialized data). */
+function caggDefinition(c: CaggConfig): string {
+  const { refresh: _refresh, model: _model, ...definition } = c;
+  return stableStringify(definition);
 }
 
 /** Deep-stable JSON: object keys sorted, so equality is structural. */
@@ -183,13 +192,53 @@ function renderCreates(state: ObjectsState): string[] {
 function renderRemovals(previous: ObjectsState, current: ObjectsState): string[] {
   const parts: string[] = [];
 
-  const currentCaggs = new Set(current.continuousAggregates.map((c) => qualify(c.schema, c.name)));
-  // Reverse topological order so a dropped hierarchical child goes before its dropped parent.
-  for (const c of [...orderCaggs(previous.continuousAggregates)].reverse()) {
-    if (currentCaggs.has(qualify(c.schema, c.name))) continue;
+  const currentCaggByKey = new Map(current.continuousAggregates.map((c) => [qualify(c.schema, c.name), c]));
+  const prevCaggByKey = new Map(previous.continuousAggregates.map((c) => [qualify(c.schema, c.name), c]));
+
+  // Caggs to DROP: removed ones, CHANGED ones (CREATE ... IF NOT EXISTS would silently keep the
+  // old definition), and — transitively — every cagg whose source chain reaches a dropped one
+  // (a matview cannot outlive its source). Dropped-but-still-declared caggs are recreated by
+  // renderCreates in the same migration; their materialized data refills via policy/refresh.
+  const dropSet = new Set<string>();
+  for (const [key, prev] of prevCaggByKey) {
+    const cur = currentCaggByKey.get(key);
+    if (!cur) dropSet.add(key); // removed
+    else if (caggDefinition(prev) !== caggDefinition(cur)) dropSet.add(key); // changed
+  }
+  // Transitive dependents, over the union graph (a child may exist in either state).
+  const unionCaggs = new Map(prevCaggByKey);
+  for (const [key, c] of currentCaggByKey) if (!unionCaggs.has(key)) unionCaggs.set(key, c);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const [key, c] of unionCaggs) {
+      if (dropSet.has(key)) continue;
+      if (dropSet.has(qualify(c.sourceSchema, c.source))) {
+        dropSet.add(key);
+        grew = true;
+      }
+    }
+  }
+  // Reverse topological order so a dependent child is dropped before its parent.
+  for (const c of [...orderCaggs([...unionCaggs.values()])].reverse()) {
+    const key = qualify(c.schema, c.name);
+    if (!dropSet.has(key)) continue;
+    const reason = !currentCaggByKey.has(key) ? "Removed" : "Changed (drop + recreate; materialized data refills on refresh)";
     // Constraint 4: DROP MATERIALIZED VIEW, never DROP VIEW.
+    parts.push(`-- ${reason} continuous aggregate: ${key}\nDROP MATERIALIZED VIEW IF EXISTS ${qualifiedIdent(c.name, c.schema)};`);
+  }
+
+  // Surviving, unchanged caggs whose REFRESH POLICY changed or disappeared: the guarded create
+  // re-adds with if_not_exists, which keeps old parameters — remove the old policy first.
+  // (remove_continuous_aggregate_policy's idempotent flag is confusingly named if_not_exists.)
+  for (const [key, prev] of prevCaggByKey) {
+    if (dropSet.has(key)) continue;
+    const cur = currentCaggByKey.get(key);
+    if (!cur || !prev.refresh) continue;
+    if (cur.refresh && stableStringify(prev.refresh) === stableStringify(cur.refresh)) continue;
+    const rel = relationLiteral(cur.name, cur.schema);
     parts.push(
-      `-- Removed continuous aggregate: ${qualify(c.schema, c.name)}\nDROP MATERIALIZED VIEW IF EXISTS ${qualifiedIdent(c.name, c.schema)};`,
+      `-- ${cur.refresh ? "Changed" : "Removed"} refresh policy: ${key}\nDO $$ BEGIN\n  ${existenceGuard(rel)}\n  PERFORM remove_continuous_aggregate_policy(${rel}, if_not_exists => TRUE);\nEND $$;`,
     );
   }
 
@@ -207,16 +256,19 @@ function renderRemovals(previous: ObjectsState, current: ObjectsState): string[]
       );
       continue;
     }
-    if (prev.retention && !cur.retention) {
+    // A policy REMOVED or CHANGED both need the old one removed first: TimescaleDB never
+    // updates an existing policy whose parameters differ (if_not_exists keeps the old one with
+    // a NOTICE), so the guarded re-add in renderCreates only works on a clean slate.
+    if (prev.retention && (!cur.retention || stableStringify(prev.retention) !== stableStringify(cur.retention))) {
       parts.push(
-        `-- Removed retention policy: ${key}\nDO $$ BEGIN\n  ${guard}\n  PERFORM remove_retention_policy(${rel}, if_exists => TRUE);\nEND $$;`,
+        `-- ${cur.retention ? "Changed" : "Removed"} retention policy: ${key}\nDO $$ BEGIN\n  ${guard}\n  PERFORM remove_retention_policy(${rel}, if_exists => TRUE);\nEND $$;`,
       );
     }
-    if (prev.compression && !cur.compression) {
+    if (prev.compression && (!cur.compression || stableStringify(prev.compression) !== stableStringify(cur.compression))) {
       // remove_columnstore_policy is a PROCEDURE (CALL); leaves the columnstore enabled —
       // disabling fails once any chunk is compressed (same rationale as the builder's down).
       parts.push(
-        `-- Removed compression policy: ${key}\nDO $$ BEGIN\n  ${guard}\n  CALL remove_columnstore_policy(${rel}, if_exists => TRUE);\nEND $$;`,
+        `-- ${cur.compression ? "Changed" : "Removed"} compression policy: ${key}\nDO $$ BEGIN\n  ${guard}\n  CALL remove_columnstore_policy(${rel}, if_exists => TRUE);\nEND $$;`,
       );
     }
     const curSkip = new Set(cur.chunkSkipping ?? []);
@@ -240,6 +292,43 @@ export function objectsMigrationName(sequence: number): string {
 }
 
 /**
+ * Parse and validate a state-file's raw JSON. Returns undefined (never throws) for anything
+ * that is not a fully-shaped v1 state — a hand-edited file with a missing array would
+ * otherwise surface later as a TypeError deep inside the removal diff.
+ */
+export function parseGeneratorState(raw: string | undefined): GeneratorState | undefined {
+  if (raw === undefined) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as Partial<GeneratorState>;
+    if (
+      parsed.version === 1 &&
+      Number.isInteger(parsed.sequence) &&
+      (parsed.sequence as number) >= 1 &&
+      parsed.state !== null &&
+      typeof parsed.state === "object" &&
+      Array.isArray(parsed.state?.hypertables) &&
+      Array.isArray(parsed.state?.continuousAggregates)
+    ) {
+      return parsed as GeneratorState;
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+/** The highest existing `..._v000N` sequence among migration folder names (0 when none). */
+export function maxObjectsSequence(folderNames: readonly string[]): number {
+  const pattern = new RegExp(`^${OBJECTS_MIGRATION_PREFIX}_v(\\d{4,})$`);
+  let max = 0;
+  for (const name of folderNames) {
+    const m = pattern.exec(name);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max;
+}
+
+/**
  * Build the migration files to ADD for a parsed schema, given the previously persisted state.
  *
  * - First run (no previous state) with timescale objects: the extension migration plus
@@ -250,15 +339,28 @@ export function objectsMigrationName(sequence: number): string {
  * - Changed state: one new `..._v<n+1>` migration with guarded creates for the full new state
  *   plus explicit removals for objects that disappeared.
  * - No timescale objects and no previous state: nothing to emit.
+ *
+ * `maxExistingSequence` is the highest `..._v000N` folder already on disk (0 when none): the
+ * next sequence never collides with it, so a lost or corrupt state file can never overwrite an
+ * applied versioned migration — recovery emits the FULL state as the next version instead.
  */
-export function emitMigrations(schema: TimescaleSchema, previous?: GeneratorState): EmitResult {
+export function emitMigrations(
+  schema: TimescaleSchema,
+  previous?: GeneratorState,
+  maxExistingSequence = 0,
+): EmitResult {
   const state = canonicalState(schema);
   const empty = state.hypertables.length === 0 && state.continuousAggregates.length === 0;
 
-  if (!previous && empty) return { files: {} };
+  const noHistory = !previous && maxExistingSequence === 0;
+  if (noHistory && empty) return { files: {} };
   if (previous && stableStringify(previous.state) === stableStringify(state)) return { files: {} };
+  // State file lost but versioned migrations exist, and the schema is empty: without the
+  // previous state there is nothing to diff removals against; emit nothing rather than a
+  // migration of pure guesses. (The normal empty case with intact state emits removals.)
+  if (!previous && empty) return { files: {} };
 
-  const sequence = (previous?.sequence ?? 0) + 1;
+  const sequence = Math.max(previous?.sequence ?? 0, maxExistingSequence) + 1;
   const files: FileMap = {};
 
   // The extension migration is fixed-name and content-stable; (re-)emitting it is a

--- a/src/generator/emit-migrations.ts
+++ b/src/generator/emit-migrations.ts
@@ -110,13 +110,19 @@ function orderCaggs(caggs: readonly CaggConfig[]): CaggConfig[] {
  * Canonicalize a state for comparison: stable object-key and array order, no undefineds, and
  * ONLY the fields that reach emitted SQL. `relations`, `columns`, and `model` drive the runtime
  * registry, not migrations — a rename/@map-only change must not spawn a new (empty) migration.
+ * Also applied to a PERSISTED previous state before diffing: a pre-versioning state file may
+ * still carry the registry-only fields, which must not read as a change after an upgrade.
  */
-function canonicalState(schema: TimescaleSchema): ObjectsState {
-  const hypertables = [...schema.hypertables]
+function canonicalObjects(state: ObjectsState): ObjectsState {
+  const hypertables = [...state.hypertables]
     .sort((a, b) => byCodePoint(qualify(a.schema, a.table), qualify(b.schema, b.table)))
     .map(({ relations: _relations, columns: _columns, model: _model, ...rest }) => rest);
-  const continuousAggregates = orderCaggs(schema.continuousAggregates).map(({ model: _model, ...rest }) => rest);
+  const continuousAggregates = orderCaggs(state.continuousAggregates).map(({ model: _model, ...rest }) => rest);
   return { hypertables, continuousAggregates };
+}
+
+function canonicalState(schema: TimescaleSchema): ObjectsState {
+  return canonicalObjects({ hypertables: schema.hypertables, continuousAggregates: schema.continuousAggregates });
 }
 
 /** A cagg's definition WITHOUT its refresh policy — what decides drop-and-recreate. The policy
@@ -307,7 +313,20 @@ export function parseGeneratorState(raw: string | undefined): GeneratorState | u
       parsed.state !== null &&
       typeof parsed.state === "object" &&
       Array.isArray(parsed.state?.hypertables) &&
-      Array.isArray(parsed.state?.continuousAggregates)
+      Array.isArray(parsed.state?.continuousAggregates) &&
+      // Entry-level shape: the removal diff reads these fields directly, so a null or
+      // truncated entry must fall back to full re-assert, not throw mid-diff.
+      parsed.state.hypertables.every(
+        (h) => h !== null && typeof h === "object" && typeof h.table === "string" && typeof h.column === "string",
+      ) &&
+      parsed.state.continuousAggregates.every(
+        (c) =>
+          c !== null &&
+          typeof c === "object" &&
+          typeof c.name === "string" &&
+          typeof c.source === "string" &&
+          Array.isArray(c.aggregates),
+      )
     ) {
       return parsed as GeneratorState;
     }
@@ -352,9 +371,13 @@ export function emitMigrations(
   const state = canonicalState(schema);
   const empty = state.hypertables.length === 0 && state.continuousAggregates.length === 0;
 
+  // Canonicalize the persisted state too: a pre-versioning state file may carry the
+  // registry-only fields the canonical form strips, and that must not read as a change.
+  const prevState = previous ? canonicalObjects(previous.state) : undefined;
+
   const noHistory = !previous && maxExistingSequence === 0;
   if (noHistory && empty) return { files: {} };
-  if (previous && stableStringify(previous.state) === stableStringify(state)) return { files: {} };
+  if (prevState && stableStringify(prevState) === stableStringify(state)) return { files: {} };
   // State file lost but versioned migrations exist, and the schema is empty: without the
   // previous state there is nothing to diff removals against; emit nothing rather than a
   // migration of pure guesses. (The normal empty case with intact state emits removals.)
@@ -372,7 +395,7 @@ ${createExtensionSql().up}
 `;
 
   const creates = renderCreates(state);
-  const removals = previous ? renderRemovals(previous.state, state) : [];
+  const removals = prevState ? renderRemovals(prevState, state) : [];
   const sections = [...removals, ...creates];
 
   files[`${objectsMigrationName(sequence)}/migration.sql`] = `${GENERATED_BANNER}

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -5,7 +5,7 @@
 //
 // This file is intentionally NOT imported by the runtime entry (src/index.ts): the client
 // extension must work without the generator (CLAUDE.md resilience requirement).
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 // Default import (not named): @prisma/generator-helper is CommonJS, and Node's ESM loader
 // rejects named imports from it at runtime. Default import resolves to module.exports under
@@ -14,7 +14,14 @@ import generatorHelper from "@prisma/generator-helper";
 import { extractTimescaleSchema } from "./dmmf.js";
 
 const { generatorHandler } = generatorHelper;
-import { emitMigrations, STATE_FILE, type FileMap, type GeneratorState } from "./emit-migrations.js";
+import {
+  emitMigrations,
+  maxObjectsSequence,
+  parseGeneratorState,
+  STATE_FILE,
+  type FileMap,
+  type GeneratorState,
+} from "./emit-migrations.js";
 import { emitTypes } from "./emit-types.js";
 
 const DEFAULT_OUTPUT = "node_modules/.prisma-extension-timescaledb";
@@ -53,9 +60,14 @@ generatorHandler({
         : join(schemaDir, "migrations");
 
     // Previous emitted state, so a changed schema appends the NEXT versioned objects migration
-    // and an unchanged one is a byte-stable no-op. A missing/corrupt file means "no history":
-    // the emitted v1 (or v-next) re-asserts the full state idempotently either way.
-    const { files, nextState } = emitMigrations(schema, readState(join(migrationsDir, STATE_FILE)));
+    // and an unchanged one is a byte-stable no-op. On a missing/corrupt state file, the highest
+    // existing ..._v000N folder pins the next sequence, so recovery re-asserts the full state
+    // as a NEW migration and never overwrites an applied one.
+    const { files, nextState } = emitMigrations(
+      schema,
+      readState(join(migrationsDir, STATE_FILE)),
+      maxObjectsSequence(listDir(migrationsDir)),
+    );
     writeFileMap(migrationsDir, files);
     if (nextState) {
       mkdirSync(migrationsDir, { recursive: true });
@@ -65,22 +77,29 @@ generatorHandler({
   },
 });
 
-/** Read and minimally validate the generator state file; undefined when absent or unusable. */
+/** Read the generator state file; undefined (with a warning) when absent or unusable. The
+ * shape validation lives in parseGeneratorState so it is unit-testable without a filesystem. */
 function readState(path: string): GeneratorState | undefined {
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
   } catch {
-    return undefined;
+    return undefined; // no file — first run, or pre-v1 project
   }
+  const state = parseGeneratorState(raw);
+  if (state === undefined) {
+    console.warn(
+      `prisma-extension-timescaledb: ignoring unreadable state file at ${path}; re-asserting the full state as a new migration.`,
+    );
+  }
+  return state;
+}
+
+/** Directory entries of `dir`, or empty when it does not exist yet. */
+function listDir(dir: string): string[] {
   try {
-    const parsed = JSON.parse(raw) as Partial<GeneratorState>;
-    if (parsed.version === 1 && Number.isInteger(parsed.sequence) && parsed.state) {
-      return parsed as GeneratorState;
-    }
+    return readdirSync(dir);
   } catch {
-    // fall through
+    return [];
   }
-  console.warn(`prisma-extension-timescaledb: ignoring unreadable state file at ${path}; re-asserting full state.`);
-  return undefined;
 }

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -95,11 +95,14 @@ function readState(path: string): GeneratorState | undefined {
   return state;
 }
 
-/** Directory entries of `dir`, or empty when it does not exist yet. */
+/** Directory entries of `dir`, or empty when it does not exist yet. Any error other than
+ * ENOENT rethrows: an unreadable migrations dir (EACCES) must abort, not read as "no history"
+ * and let a later write truncate an existing versioned migration. */
 function listDir(dir: string): string[] {
   try {
     return readdirSync(dir);
-  } catch {
-    return [];
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw e;
   }
 }

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -507,8 +507,10 @@ view Daily {
     expect(dropDaily).toBeGreaterThanOrEqual(0);
     expect(dropHourly).toBeGreaterThanOrEqual(0);
     expect(dropDaily).toBeLessThan(dropHourly); // child before parent
-    // Both are recreated after the drops (creates section re-asserts the full state).
+    // Both are recreated after the drops (creates section re-asserts the full state),
+    // the dependent included — dropping Daily without recreating it would lose the view.
     expect(v2.indexOf(`CREATE MATERIALIZED VIEW IF NOT EXISTS "Hourly"`)).toBeGreaterThan(dropHourly);
+    expect(v2.indexOf(`CREATE MATERIALIZED VIEW IF NOT EXISTS "Daily"`)).toBeGreaterThan(dropHourly);
     expect(v2).toContain("2 hours");
   });
 
@@ -604,5 +606,33 @@ model SensorReading {
         ".prisma-extension-timescaledb.json",
       ]),
     ).toBe(12);
+  });
+});
+
+describe("emitMigrations — second-round review behaviors", () => {
+  it("rejects state files with malformed ENTRIES, not just malformed containers", () => {
+    const base = { version: 1, sequence: 1 };
+    expect(
+      parseGeneratorState(JSON.stringify({ ...base, state: { hypertables: [null], continuousAggregates: [] } })),
+    ).toBeUndefined();
+    expect(
+      parseGeneratorState(JSON.stringify({ ...base, state: { hypertables: [{ table: "T" }], continuousAggregates: [] } })),
+    ).toBeUndefined(); // hypertable entry missing column
+    expect(
+      parseGeneratorState(
+        JSON.stringify({ ...base, state: { hypertables: [], continuousAggregates: [{ name: "V", source: "T" }] } }),
+      ),
+    ).toBeUndefined(); // cagg entry missing aggregates
+  });
+
+  it("a legacy state file carrying registry-only fields does not read as a change", async () => {
+    const schema = await loadSchema();
+    const { nextState } = emitMigrations(schema);
+    // Simulate a state persisted before canonicalState stripped model/columns.
+    const legacy: GeneratorState = JSON.parse(JSON.stringify(nextState)) as GeneratorState;
+    (legacy.state.hypertables[0] as { model?: string; columns?: Record<string, string> }).model = "SensorReading";
+    (legacy.state.hypertables[0] as { model?: string; columns?: Record<string, string> }).columns = { deviceId: "device_id" };
+    (legacy.state.continuousAggregates[0] as { model?: string }).model = "SensorHourly";
+    expect(emitMigrations(schema, legacy).files).toEqual({});
   });
 });

--- a/test/unit/emit.test.ts
+++ b/test/unit/emit.test.ts
@@ -8,6 +8,8 @@ import { extractTimescaleSchema, type TimescaleSchema } from "../../src/generato
 import {
   emitMigrations,
   objectsMigrationName,
+  maxObjectsSequence,
+  parseGeneratorState,
   EXTENSION_MIGRATION,
   OBJECTS_MIGRATION_PREFIX,
   type GeneratorState,
@@ -140,6 +142,7 @@ describe("emitMigrations (append-only versioned objects migrations)", () => {
           if_not_exists => TRUE,
           migrate_data  => TRUE
         );
+        PERFORM set_partitioning_interval('"SensorReading"', INTERVAL '1 day');
       END $$;
 
       -- Continuous aggregate: SensorHourly
@@ -438,5 +441,168 @@ model Device {
     expect(source).toContain(`"relationsByModel"`);
     expect(source).toContain(`"targetModel": "Reading"`); // Device.readings -> Reading, for nesting
     expect(typeCheck(source)).toEqual([]);
+  });
+});
+
+describe("emitMigrations — review follow-up behaviors", () => {
+  const V2 = `${objectsMigrationName(2)}/migration.sql`;
+
+  it("registry-only changes (model rename, @map columns) do not spawn a migration", async () => {
+    const schema = await loadSchema();
+    const first = emitMigrations(schema);
+    const renamed: typeof schema = {
+      ...schema,
+      hypertables: schema.hypertables.map((h) => ({ ...h, model: "RenamedModel", columns: { deviceId: "device_id" } })),
+      continuousAggregates: schema.continuousAggregates.map((c) => ({ ...c, model: "RenamedView" })),
+    };
+    expect(emitMigrations(renamed, first.nextState).files).toEqual({});
+  });
+
+  it("a CHANGED cagg is dropped and recreated; its dependents are dropped first", async () => {
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views"]
+}
+datasource db {
+  provider = "postgresql"
+}
+
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+model SensorReading {
+  time        DateTime
+  temperature Float
+  @@id([time])
+}
+
+/// @timescale.continuousAggregate(source: "SensorReading", bucket: "1 hour", timeColumn: "time")
+view Hourly {
+  bucket  DateTime /// @timescale.bucket
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "temperature")
+  @@unique([bucket])
+}
+
+/// @timescale.continuousAggregate(source: "Hourly", bucket: "1 day", timeColumn: "bucket")
+view Daily {
+  bucket  DateTime /// @timescale.bucket
+  avgTemp Float    /// @timescale.aggregate(fn: "avg", column: "avgTemp")
+  @@unique([bucket])
+}
+`,
+    });
+    const schema = extractTimescaleSchema(dmmf);
+    const first = emitMigrations(schema);
+    // Change the PARENT cagg's bucket: it and its dependent Daily must be dropped, child first.
+    const changed: typeof schema = {
+      ...schema,
+      continuousAggregates: schema.continuousAggregates.map((c) =>
+        c.name === "Hourly" ? { ...c, bucket: "2 hours" as (typeof c)["bucket"] } : c,
+      ),
+    };
+    const v2 = emitMigrations(changed, first.nextState).files[V2]!;
+    const dropDaily = v2.indexOf(`DROP MATERIALIZED VIEW IF EXISTS "Daily";`);
+    const dropHourly = v2.indexOf(`DROP MATERIALIZED VIEW IF EXISTS "Hourly";`);
+    expect(dropDaily).toBeGreaterThanOrEqual(0);
+    expect(dropHourly).toBeGreaterThanOrEqual(0);
+    expect(dropDaily).toBeLessThan(dropHourly); // child before parent
+    // Both are recreated after the drops (creates section re-asserts the full state).
+    expect(v2.indexOf(`CREATE MATERIALIZED VIEW IF NOT EXISTS "Hourly"`)).toBeGreaterThan(dropHourly);
+    expect(v2).toContain("2 hours");
+  });
+
+  it("a changed or removed refresh policy on an UNCHANGED cagg removes the old policy without dropping the view", async () => {
+    const schema = await loadSchema(); // SensorHourly has a refresh policy
+    const first = emitMigrations(schema);
+    const withoutRefresh: typeof schema = {
+      ...schema,
+      continuousAggregates: schema.continuousAggregates.map(({ refresh: _refresh, ...rest }) => rest),
+    };
+    const v2 = emitMigrations(withoutRefresh, first.nextState).files[V2]!;
+    expect(v2).toContain(`PERFORM remove_continuous_aggregate_policy('"SensorHourly"', if_not_exists => TRUE);`);
+    expect(v2).not.toContain(`DROP MATERIALIZED VIEW IF EXISTS "SensorHourly"`);
+  });
+
+  it("a changed retention policy is removed before the new one is re-added", async () => {
+    const dmmf = await getDMMF({
+      datamodel: `
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma"
+  previewFeatures = ["views"]
+}
+datasource db {
+  provider = "postgresql"
+}
+
+/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
+/// @timescale.retention(dropAfter: "30 days")
+model SensorReading {
+  time DateTime
+  @@id([time])
+}
+`,
+    });
+    const schema = extractTimescaleSchema(dmmf);
+    const first = emitMigrations(schema);
+    const changed: typeof schema = {
+      ...schema,
+      hypertables: schema.hypertables.map((h) => ({
+        ...h,
+        retention: { dropAfter: "60 days" as NonNullable<(typeof h)["retention"]>["dropAfter"] },
+      })),
+    };
+    const v2 = emitMigrations(changed, first.nextState).files[V2]!;
+    const remove = v2.indexOf(`remove_retention_policy('"SensorReading"', if_exists => TRUE)`);
+    const add = v2.indexOf(`add_retention_policy('"SensorReading"', drop_after => INTERVAL '60 days'`);
+    expect(remove).toBeGreaterThanOrEqual(0);
+    expect(add).toBeGreaterThan(remove);
+  });
+
+  it("the guarded hypertable block re-asserts the chunk interval (converges after a change)", async () => {
+    const schema = await loadSchema();
+    const v1 = emitMigrations(schema).files[`${objectsMigrationName(1)}/migration.sql`]!;
+    expect(v1).toContain(`PERFORM set_partitioning_interval('"SensorReading"', INTERVAL '1 day');`);
+  });
+
+  it("a lost state file never reuses an existing version number (recovery appends)", async () => {
+    const schema = await loadSchema();
+    // No previous state, but v0001..v0003 already exist on disk.
+    const { files, nextState } = emitMigrations(schema, undefined, 3);
+    expect(Object.keys(files)).toContain(`${objectsMigrationName(4)}/migration.sql`);
+    expect(nextState?.sequence).toBe(4);
+    // Recovery has no previous state to diff against: full re-assert, no removals.
+    expect(files[`${objectsMigrationName(4)}/migration.sql`]).not.toContain("DROP MATERIALIZED VIEW");
+  });
+
+  it("parseGeneratorState rejects malformed shapes instead of passing them through", async () => {
+    const schema = await loadSchema();
+    const good = emitMigrations(schema).nextState!;
+    expect(parseGeneratorState(JSON.stringify(good))).toEqual(good);
+    expect(parseGeneratorState(undefined)).toBeUndefined();
+    expect(parseGeneratorState("not json")).toBeUndefined();
+    expect(parseGeneratorState(JSON.stringify({ version: 1, sequence: 1 }))).toBeUndefined(); // no state
+    expect(
+      parseGeneratorState(JSON.stringify({ version: 1, sequence: 1, state: { hypertables: [] } })), // no caggs array
+    ).toBeUndefined();
+    expect(
+      parseGeneratorState(JSON.stringify({ version: 2, sequence: 1, state: { hypertables: [], continuousAggregates: [] } })),
+    ).toBeUndefined(); // unknown version
+    expect(parseGeneratorState(JSON.stringify({ version: 1, sequence: 0, state: { hypertables: [], continuousAggregates: [] } }))).toBeUndefined();
+  });
+
+  it("maxObjectsSequence reads the highest versioned folder and ignores everything else", () => {
+    expect(maxObjectsSequence([])).toBe(0);
+    expect(
+      maxObjectsSequence([
+        "20260101000000_init",
+        "00000000000000_timescaledb_extension",
+        "99999999999999_timescaledb_objects", // pre-v1 legacy: not versioned
+        "99999999999999_timescaledb_objects_v0001",
+        "99999999999999_timescaledb_objects_v0012",
+        ".prisma-extension-timescaledb.json",
+      ]),
+    ).toBe(12);
   });
 });


### PR DESCRIPTION
Addresses all five CodeRabbit findings on #122, which auto-merged 44 seconds before the review posted (a check rerun raced the review; the branch ruleset now requires the CodeRabbit check, so a PR can no longer merge before its review completes and its threads resolve).

## The fixes

- **State excludes registry-only fields.** canonicalState kept model and columns, so adding @map or renaming a model spawned a new migration whose SQL was identical. Both are stripped now, with a test proving a rename-only change emits nothing.
- **Changed caggs are dropped and recreated.** CREATE ... IF NOT EXISTS silently keeps an old definition, and dropping a changed parent fails while dependents exist. A definition change (refresh excluded) now drops the cagg plus every dependent, children first in reverse topological order over the union graph, and the same migration's creates rebuild them; materialized data refills on refresh. Verified drop ordering empirically, and docs/architecture.md states the data-refill consequence.
- **Policy changes remove-then-re-add.** TimescaleDB never updates an existing policy in place, so a changed or removed refresh, retention, or compression policy now removes the old one first (remove_continuous_aggregate_policy's idempotent no-policy case probed on 2.27.2). The guarded hypertable block also re-asserts the chunk interval through set_partitioning_interval, since create_hypertable never updates a live hypertable — probed: a re-run with a changed interval converges.
- **Sequence recovery never overwrites.** The generator scans existing ..._v000N folders and takes max+1, so a lost or corrupt state file appends a full-re-assert migration instead of restarting at v0001 over an applied file.
- **State-file validation.** parseGeneratorState (now pure and unit-tested) validates the full shape including both arrays; a malformed file falls back to the documented full re-assert instead of a TypeError.

## Also

The dependency-audit workflow retries npm audit three times with backoff: npm's advisory endpoint timed out twice today (that transient failure is what let #122's auto-merge race the review), and a network blip must not read as a vulnerability. A real finding still fails all three attempts.

## Validation

307 unit tests (8 new emit tests covering each fix), typecheck, build; evolution, reset-safety, and set-chunk-interval Testcontainers suites pass against real TimescaleDB; three new container probes quoted in comments.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration recovery to prevent overwriting existing migrations and to continue safely when saved state is missing or invalid.
  - Changed continuous aggregates are recreated in dependency order, with dependent data refreshed afterward.
  - Updated refresh, retention, and compression policies are correctly reapplied.
  - Hypertable partition intervals are now consistently preserved during guarded updates.

- **Reliability**
  - Production dependency audits retry up to three times before failing, while persistent vulnerabilities still fail the audit.

- **Documentation**
  - Documented aggregate and policy update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->