### PR TITLE
chore: let breaking changes bump the major version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
+      "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false
     }
   }


### PR DESCRIPTION
The release trigger for v1.0.0.

## Why the Release-As footer did not work

#124 carried a `Release-As: 1.0.0` footer in its single commit, but this repo is configured with `squash_merge_commit_message: BLANK`: the squash commit keeps only the PR title plus co-author trailers, so no footer of any kind survives a merge here. That approach cannot work in this repo.

## What this does instead

`bump-minor-pre-major: true` forces breaking changes into minor bumps while the version is below 1.0.0, which is why release-please proposed 0.9.0. Setting it to `false` (release-please's own default) lets the two breaking changes already on main bump 0.8.0 straight to 1.0.0:

- #118 `fix(client)!`: $timescale is now called as a method, so it joins interactive transactions.
- #122 `feat(generator)!`: append-only versioned objects migrations plus a state file.

It is also the correct setting for the package from here on: once past 1.0.0, breaking changes should bump the major version.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUTryPqg4mdUoxZkgUR9CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pre-major releases now follow patch-version increments instead of automatically increasing the minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->