### PR TITLE
test(integration): fail loudly when Docker is missing, and harden the harness startup path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
       - run: npm ci
       - run: npm run build
       # ubuntu-latest runners ship Docker, so Testcontainers can run the reset-safety proof.
+      # REQUIRE_DOCKER makes an unreachable daemon fail the job instead of skipping the suite:
+      # a skip here would mean the reset-safety proof quietly did not run, and the job still
+      # went green. (GitHub sets CI=true, which the harness also honours; this is explicit.)
       - run: npm run test:integration
+        env:
+          REQUIRE_DOCKER: "1"
 
   # Every PR must track a GitHub issue (issue-first workflow). Machine PRs
   # (dependabot, release-please) are exempt. The exemptions key on facts an

--- a/test/integration/aggregates.test.ts
+++ b/test/integration/aggregates.test.ts
@@ -1,25 +1,13 @@
 // Standard aggregates in timeBucket, end-to-end on real TimescaleDB: stddev / variance (+ pop),
 // count(distinct), and histogram. Verifies both the computed values and the JS return shapes
 // (numbers for the stats, a real number[] for histogram) through @prisma/adapter-pg.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED aggregates.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's standard aggregates are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/bucket-column.test.ts
+++ b/test/integration/bucket-column.test.ts
@@ -3,27 +3,13 @@
 // the "bucket" alias used to fail every timeBucket() on such a model with "column ... must appear
 // in the GROUP BY clause" — and the same alias capture broke the cagg CREATE at migrate deploy.
 // Proves both builders group by the expression instead.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED bucket-column.test.ts: Docker is not available. bucket-column collision is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("bucket-column collision is NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {

--- a/test/integration/cagg-depth.test.ts
+++ b/test/integration/cagg-depth.test.ts
@@ -4,22 +4,10 @@
 // The reset-safety run is the real proof: `migrate reset` replays the managed migration from
 // scratch, so the inner cagg must be emitted before the outer or the replay would fail. Verified
 // against timescaledb_information.continuous_aggregates, including migrate reset (twice).
-import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED cagg-depth.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Hierarchical continuous aggregates are NOT verified.");
 
 // SensorReading matches the harness's default CREATE TABLE (time / deviceId / temperature).
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")

--- a/test/integration/cagg-policy.test.ts
+++ b/test/integration/cagg-policy.test.ts
@@ -1,25 +1,13 @@
 // Continuous-aggregate refresh-policy management at runtime, on real TimescaleDB:
 // $timescale().removeContinuousAggregatePolicy / addContinuousAggregatePolicy. The default harness
 // schema already has a refresh policy from the annotation; verified against timescaledb_information.jobs.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED cagg-policy.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Continuous-aggregate refresh policies are NOT verified.");
 
 async function refreshJobs(h: Harness): Promise<number> {
   const [row] = await h.query<{ n: number }>(

--- a/test/integration/candlestick.test.ts
+++ b/test/integration/candlestick.test.ts
@@ -1,25 +1,13 @@
 // Toolkit candlestick_agg in timeBucket, end-to-end on real TimescaleDB (the `-ha` image carries
 // timescaledb_toolkit). One op returns an OHLC + vwap JS object per bucket (jsonb_build_object over
 // candlestick_agg(time, price, volume)). Three trades make the values predictable.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED candlestick.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's candlestick / OHLC hyperfunctions are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Trade {

--- a/test/integration/chunk-helpers.test.ts
+++ b/test/integration/chunk-helpers.test.ts
@@ -1,25 +1,13 @@
 // $timescale chunk + size helpers, end-to-end on real TimescaleDB: drop_chunks (on-demand
 // retention) plus the size / row-count / compression-stats introspection. Sizes come back as
 // exact JS bigints. Verified against a 3-chunk hypertable (one chunk per day).
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED chunk-helpers.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("The $timescale chunk and size helpers are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/chunk-ops.test.ts
+++ b/test/integration/chunk-ops.test.ts
@@ -4,25 +4,13 @@
 //
 // Runtime-only feature (these $timescale methods emit no migration SQL), so — like the other runtime
 // $timescale tests — it uses migrate deploy without a migrate-reset assertion.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED chunk-ops.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("On-demand chunk operations are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 /// @timescale.compression(after: "7 days", segmentBy: "deviceId")

--- a/test/integration/chunk-skipping.test.ts
+++ b/test/integration/chunk-skipping.test.ts
@@ -6,25 +6,13 @@
 // Verified against the internal catalog `_timescaledb_catalog.chunk_column_stats` (there is no public
 // timescaledb_information view for chunk skipping). The GUC requirement and the "compressed chunks
 // only" caveat are exercised implicitly: the enable call only succeeds because we set the GUC.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED chunk-skipping.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Chunk skipping is NOT verified.");
 
 // eventId is a secondary (non-partitioning, non-segmentBy) column — the correct target for chunk
 // skipping. segmentBy is deviceId, so the generator guard does not trip.

--- a/test/integration/compression.test.ts
+++ b/test/integration/compression.test.ts
@@ -2,27 +2,13 @@
 // reset-safe `enable_columnstore` + `add_columnstore_policy` from @timescale.compression, and the
 // $timescale runtime helpers add/remove a policy. Verified against timescaledb_information.jobs and
 // hypertable_columnstore_settings. Requires TimescaleDB >= 2.18 (the columnstore API).
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED compression.test.ts: Docker is not available. Compression policies are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Compression policies are NOT verified.");
 
 // Hypertable with a columnstore-compression policy (matches the harness default CREATE TABLE).
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")

--- a/test/integration/counter-timeweight.test.ts
+++ b/test/integration/counter-timeweight.test.ts
@@ -1,25 +1,13 @@
 // Toolkit counter_agg (rate / delta) and time-weighted average in timeBucket, end-to-end on real
 // TimescaleDB (the `-ha` image carries timescaledb_toolkit). A counter that RESETS mid-bucket proves
 // reset-awareness: a naive last-first delta would be ~50, but reset-aware delta is 350.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED counter-timeweight.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's counter_agg and time_weight hyperfunctions are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/down-migrations.test.ts
+++ b/test/integration/down-migrations.test.ts
@@ -4,26 +4,12 @@
 // executed against a real database (it's only asserted as a string snapshot in unit tests).
 // This proves it end to end: `DROP VIEW` is rejected, the generated `DROP MATERIALIZED VIEW`
 // drops the cagg cleanly, and re-running it is an idempotent no-op (constraint 3).
-import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { createContinuousAggregateSql } from "../../src/core/index.js";
 import type { CaggConfig } from "../../src/core/types.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED: Docker is not available. Down-migration (constraint 4) is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Down-migration (constraint 4) is NOT verified.");
 
 // Mirrors the harness DEFAULT_MODELS `SensorHourly` cagg. Only `name`/`schema` drive the
 // `down` SQL, but the builder validates the whole config, so it must be well-formed.

--- a/test/integration/evolution-values.test.ts
+++ b/test/integration/evolution-values.test.ts
@@ -12,26 +12,12 @@
 // So a changed value only lands because the generator emits an explicit removal ahead of the
 // idempotent re-add. That diff is unit-tested as SQL strings; this runs it against a real
 // TimescaleDB and reads the values back out of the catalog.
-import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED evolution-values.test.ts: Docker is not available. Changed annotation values are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Changed annotation values are NOT verified.");
 
 const TABLE = `model SensorReading {
   time        DateTime

--- a/test/integration/evolution.test.ts
+++ b/test/integration/evolution.test.ts
@@ -6,20 +6,9 @@ import { execFileSync } from "node:child_process";
 import { readdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED evolution.test.ts: Docker is not available. Schema evolution is NOT verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Schema evolution is NOT verified.");
 
 const MODELS_V1 = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/extension-setup.test.ts
+++ b/test/integration/extension-setup.test.ts
@@ -9,25 +9,13 @@
 // These cases need a database with no `timescaledb` in it, which the harness cannot give: the
 // image installs the extension into `template1`, so every database cloned from it already has
 // one in `public`. Each test creates its own from `template0` instead.
-import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import pg from "pg";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
-import { IMAGE } from "./harness.js";
+import { IMAGE, dockerAvailable } from "./harness.js";
 import { createExtensionSql } from "../../src/core/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED extension-setup.test.ts: Docker is not available. Extension setup is NOT verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Extension setup is NOT verified.");
 
 const EXTENSION_SQL = createExtensionSql().up;
 

--- a/test/integration/first-last.test.ts
+++ b/test/integration/first-last.test.ts
@@ -1,25 +1,13 @@
 // first() / last() aggregates in timeBucket, end-to-end on real TimescaleDB: the value of one
 // column at the earliest / latest time in each bucket (ordered by the model's time column by
 // default). Verified for a numeric and a text column against known per-bucket extremes.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED first-last.test.ts: Docker is not available. first/last are NOT verified.\n");
-}
+const DOCKER_OK = dockerAvailable("first/last are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/gapfill.test.ts
+++ b/test/integration/gapfill.test.ts
@@ -2,25 +2,13 @@
 // bucket across the range (via time_bucket_gapfill, bounds inferred from the range WHERE), and the
 // per-aggregate fill modes carry forward (locf) / interpolate empty buckets. Values verified
 // against a known gap (bucket 01:00 has no data between 00:00 and 02:00).
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED gapfill.test.ts: Docker is not available. Gap-filling is NOT verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Gap-filling is NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -133,20 +133,31 @@ export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> 
   const databaseUrl = `${baseUrl}/app?schema=${urlSchema}`;
   const shadowUrl = `${baseUrl}/shadow?schema=${urlSchema}`;
 
-  // Belt and braces on top of the wait strategy: prove a real client session works.
-  await withContainerLogs(container, "waiting for Postgres to accept connections", () =>
-    waitForReady(`${baseUrl}/app`),
-  );
-  // Shadow DB on the same server (TimescaleDB-capable), required by migrate reset/dev. Retried
-  // like everything else that touches the network here: an unretried statement between container
-  // start and the first test is exactly the shape of failure that shows up as a beforeAll throw
-  // once in a few hundred container starts, with no output left behind to explain it.
-  await withContainerLogs(container, "creating the shadow database", () =>
-    retry(() => runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow")),
-  );
+  // Everything from here on can throw, and until we return a Harness the caller has no stop() to
+  // reach. Without this the container outlives the failed startup, and a run that trips the same
+  // failure in several files leaves that many containers behind.
+  const projectDir = await onFailureStopContainer(container, async () => {
+    // Belt and braces on top of the wait strategy: prove a real client session works.
+    await withContainerLogs(container, "waiting for Postgres to accept connections", () =>
+      waitForReady(`${baseUrl}/app`),
+    );
+    // Shadow DB on the same server (TimescaleDB-capable), required by migrate reset/dev. Retried
+    // like everything else that touches the network here: an unretried statement between container
+    // start and the first test is exactly the shape of failure that shows up as a beforeAll throw
+    // once in a few hundred container starts, with no output left behind to explain it.
+    await withContainerLogs(container, "creating the shadow database", () =>
+      retry(() => runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow")),
+    );
 
-  const projectDir = mkdtempSync(join(REPO_ROOT, ".tmp-int-"));
-  scaffoldProject(projectDir, opts);
+    const dir = mkdtempSync(join(REPO_ROOT, ".tmp-int-"));
+    try {
+      scaffoldProject(dir, opts);
+    } catch (err) {
+      rmSync(dir, { recursive: true, force: true });
+      throw err;
+    }
+    return dir;
+  });
 
   const env = {
     ...process.env,
@@ -342,6 +353,24 @@ async function withContainerLogs<T>(
       // fall through to the placeholder
     }
     throw new Error(`[harness] failed while ${step}: ${(e as Error).message}\n--- container logs (tail) ---\n${tail}`);
+  }
+}
+
+/**
+ * Run the startup steps that happen after `container.start()` but before a `Harness` exists. On
+ * failure the container is stopped, since the caller never gets a `stop()` to call, and the
+ * original error is rethrown: a failure to stop must not replace the reason startup failed.
+ */
+async function onFailureStopContainer<T>(container: StartedTestContainer, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    try {
+      await container.stop();
+    } catch {
+      // The startup failure is the useful one; a failed stop would only mask it.
+    }
+    throw e;
   }
 }
 

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -22,6 +22,11 @@ export const IMAGE = "timescale/timescaledb-ha:pg17.10-ts2.27.2";
 // granted it for this build (their message: "yes"). Required so reset runs unattended.
 const PRISMA_CONSENT = "yes";
 
+/** Retries for the Docker probe, so one hiccup cannot silently cost a file's coverage. */
+const DOCKER_PROBE_ATTEMPTS = 3;
+/** Where Docker is expected, an unavailable daemon is a failure, not a skip. */
+const DOCKER_REQUIRED = process.env["REQUIRE_DOCKER"] === "1" || process.env["CI"] === "true";
+
 export interface Harness {
   container: StartedTestContainer;
   projectDir: string;
@@ -42,6 +47,43 @@ export interface Harness {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime-generated client, no static types exist
 export type TestPrismaClient = any;
+
+/**
+ * Whether Docker is usable, for the `describe.skipIf` every integration file guards itself with.
+ *
+ * `docker info` is retried, because a single hiccup from a busy daemon used to turn a whole
+ * file's tests into a silent skip while the run still reported green. That is coverage
+ * disappearing without anyone being told, which is the opposite of what these tests are for.
+ *
+ * Where Docker is supposed to exist, an unavailable daemon THROWS instead of skipping. CI runners
+ * ship Docker, so a skip there never means "no Docker available", it means something broke and
+ * the suite quietly proved nothing. Set `REQUIRE_DOCKER=1` to demand the same locally.
+ *
+ * @param whatIsNotVerified what the reader loses by this file being skipped, named concretely.
+ */
+export function dockerAvailable(whatIsNotVerified: string): boolean {
+  for (let attempt = 1; attempt <= DOCKER_PROBE_ATTEMPTS; attempt++) {
+    try {
+      execFileSync("docker", ["info"], { stdio: "ignore" });
+      return true;
+    } catch {
+      // Synchronous: the value is read at collection time, before any hook can await.
+      if (attempt < DOCKER_PROBE_ATTEMPTS) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+    }
+  }
+
+  if (DOCKER_REQUIRED) {
+    throw new Error(
+      `[integration] Docker is required here (CI, or REQUIRE_DOCKER=1) but \`docker info\` failed ` +
+        `${DOCKER_PROBE_ATTEMPTS} times. Failing instead of skipping: ${whatIsNotVerified}`,
+    );
+  }
+  // Written straight to stderr, not console.warn: vitest buffers console output per test and
+  // drops it for a file whose tests are all skipped, which is precisely this case. The whole
+  // point is that a skip announces what it cost.
+  process.stderr.write(`\n[integration] SKIPPED: Docker is not available. ${whatIsNotVerified}\n`);
+  return false;
+}
 
 /** Ensure the package (incl. the generator binary) is built. */
 export function ensureBuilt(): void {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import pg from "pg";
-import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { GenericContainer, Wait, type StartedTestContainer } from "testcontainers";
 
 export const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const PRISMA_BIN = join(REPO_ROOT, "node_modules", ".bin", "prisma");
@@ -113,9 +113,17 @@ export interface HarnessOptions {
 export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> {
   ensureBuilt();
 
+  // The image declares no HEALTHCHECK (`docker inspect` reports null), so testcontainers would
+  // fall back to waiting on the mapped port alone. A bound port only means something is
+  // listening, not that Postgres will accept a connection. The entrypoint starts a throwaway
+  // server to run the init scripts and then restarts, so the ready line appears exactly twice;
+  // waiting for the second one is what actually says the real server is up.
   const container = await new GenericContainer(IMAGE)
     .withEnvironment({ POSTGRES_USER: "postgres", POSTGRES_PASSWORD: "postgres", POSTGRES_DB: "app" })
     .withExposedPorts(5432)
+    .withWaitStrategy(
+      Wait.forAll([Wait.forListeningPorts(), Wait.forLogMessage(/database system is ready to accept connections/, 2)]),
+    )
     .start();
 
   const host = container.getHost();
@@ -125,10 +133,17 @@ export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> 
   const databaseUrl = `${baseUrl}/app?schema=${urlSchema}`;
   const shadowUrl = `${baseUrl}/shadow?schema=${urlSchema}`;
 
-  // Wait until Postgres actually accepts connections (the image restarts once during init).
-  await waitForReady(`${baseUrl}/app`);
-  // Shadow DB on the same server (TimescaleDB-capable), required by migrate reset/dev.
-  await runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow");
+  // Belt and braces on top of the wait strategy: prove a real client session works.
+  await withContainerLogs(container, "waiting for Postgres to accept connections", () =>
+    waitForReady(`${baseUrl}/app`),
+  );
+  // Shadow DB on the same server (TimescaleDB-capable), required by migrate reset/dev. Retried
+  // like everything else that touches the network here: an unretried statement between container
+  // start and the first test is exactly the shape of failure that shows up as a beforeAll throw
+  // once in a few hundred container starts, with no output left behind to explain it.
+  await withContainerLogs(container, "creating the shadow database", () =>
+    retry(() => runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow")),
+  );
 
   const projectDir = mkdtempSync(join(REPO_ROOT, ".tmp-int-"));
   scaffoldProject(projectDir, opts);
@@ -271,6 +286,63 @@ async function waitForReady(connectionString: string, attempts = 30): Promise<vo
     }
   }
   throw new Error("TimescaleDB did not become ready in time");
+}
+
+/**
+ * Retry a step that touches the container, with a short backoff.
+ *
+ * A step that runs exactly once between container start and the first test has no second chance:
+ * if it throws, `startHarness` throws, the `beforeAll` throws, and vitest marks the file failed
+ * and skips its tests (verified against @vitest/runner: a failing beforeAll calls `failTask` then
+ * `markTasksAsSkipped`). That is a whole file of coverage lost to one transient.
+ */
+async function retry<T>(fn: () => Promise<T>, attempts = 5): Promise<T> {
+  let last: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      last = e;
+      // "already exists" means a previous attempt actually succeeded and the failure was in
+      // the acknowledgement; nothing is gained by trying again.
+      if (e instanceof Error && /already exists/i.test(e.message)) return undefined as T;
+      if (attempt < attempts) await new Promise((r) => setTimeout(r, 250 * attempt));
+    }
+  }
+  throw last;
+}
+
+/**
+ * Run a startup step, and on failure attach the container's log tail to the error.
+ *
+ * The reason the one observed failure of this harness could not be diagnosed is that nothing
+ * survived it. Postgres writes the reason it refused a connection to its own log, so put that in
+ * front of whoever reads the failure instead of leaving them to reconstruct it.
+ */
+async function withContainerLogs<T>(
+  container: StartedTestContainer,
+  step: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    let tail = "(container logs unavailable)";
+    try {
+      const stream = await container.logs();
+      const chunks: string[] = [];
+      await new Promise<void>((resolve) => {
+        stream.on("data", (c: Buffer | string) => chunks.push(String(c)));
+        stream.on("end", () => resolve());
+        stream.on("error", () => resolve());
+        setTimeout(resolve, 5000).unref?.();
+      });
+      tail = chunks.join("").split("\n").slice(-40).join("\n");
+    } catch {
+      // fall through to the placeholder
+    }
+    throw new Error(`[harness] failed while ${step}: ${(e as Error).message}\n--- container logs (tail) ---\n${tail}`);
+  }
 }
 
 async function runOnce(connectionString: string, sql: string): Promise<void> {

--- a/test/integration/jobs.test.ts
+++ b/test/integration/jobs.test.ts
@@ -7,26 +7,14 @@
 // runtime $timescale tests (cagg-policy, chunk-helpers, set-chunk-interval) — it uses migrate deploy
 // without a migrate-reset assertion. Reset-safety of the underlying retention/cagg refresh policies
 // is covered by retention.test.ts / reset-safety.test.ts.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 import type { TimescaleJob } from "../../src/client/manage.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED jobs.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Job control and introspection are NOT verified.");
 
 // Default harness columns (time / deviceId / temperature) + a retention policy on the hypertable and
 // a refresh policy on the cagg.

--- a/test/integration/mapped.test.ts
+++ b/test/integration/mapped.test.ts
@@ -1,27 +1,13 @@
 // End-to-end proof that @@map / @map work: a fully renamed schema (table "sensor_readings",
 // columns "ts"/"device_id", view "sensor_hourly", "avg_temp"). Proves the generator emits
 // DB-mapped SQL and the runtime resolves Prisma names -> DB names against real TimescaleDB.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED: Docker is not available. The @@map/@map reset-safety + runtime checks are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("The @@map/@map reset-safety + runtime checks are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/migrate-dev-drift.test.ts
+++ b/test/integration/migrate-dev-drift.test.ts
@@ -12,26 +12,12 @@
 //
 // The builder passes `create_default_indexes => FALSE`, which leaves the Prisma schema as the
 // only thing that creates indexes on the table, so there is nothing for Prisma to read as drift.
-import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED migrate-dev-drift.test.ts: Docker is not available. migrate dev after a hypertable conversion is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("migrate dev after a hypertable conversion is NOT verified.");
 
 /** Every migration.sql in the project, so a drift migration cannot hide in a new folder. */
 function migrationSql(h: Harness): string {

--- a/test/integration/multi-schema.test.ts
+++ b/test/integration/multi-schema.test.ts
@@ -1,25 +1,13 @@
 // End-to-end proof of @@schema (multiSchema): the hypertable + cagg live in a non-default
 // schema ("metrics"). Proves the generator schema-qualifies its SQL and the runtime resolves
 // schema-qualified relations against real TimescaleDB.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED: Docker is not available. The @@schema (multiSchema) checks are NOT verified.\n");
-}
+const DOCKER_OK = dockerAvailable("The @@schema (multiSchema) checks are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/non-public-search-path.test.ts
+++ b/test/integration/non-public-search-path.test.ts
@@ -11,30 +11,16 @@
 // retention, compression, chunk skipping, and a continuous aggregate whose view body calls
 // `time_bucket`. `test/integration/multi-schema.test.ts` is the sibling case that keeps
 // `?schema=public` and only moves the MODELS, which never exercised this.
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import pg from "pg";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 import { createHypertableSql } from "../../src/core/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED: Docker is not available. Migrations under a non-public search path (issue #129) are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Migrations under a non-public search path (issue #129) are NOT verified.");
 
 const SCHEMA = "data_collection";
 

--- a/test/integration/order-limit.test.ts
+++ b/test/integration/order-limit.test.ts
@@ -1,25 +1,13 @@
 // timeBucket orderBy + limit, end-to-end on real TimescaleDB: order by the bucket (asc/desc) or by
 // an aggregate, and cap rows with limit — i.e. "latest N buckets" and "top N buckets by value".
 // Three hourly buckets with distinct averages make the ordering unambiguous.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED order-limit.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's orderBy and limit are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/percentile.test.ts
+++ b/test/integration/percentile.test.ts
@@ -2,25 +2,13 @@
 // { percentile: col, p } -> approx_percentile(p, percentile_agg(col)). Requires the
 // timescaledb_toolkit extension, which the test harness's `-ha` image provides. Values 1..100 in one
 // bucket make p50/p95 predictable (approximate, so asserted within a tolerance).
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED percentile.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's approximate percentiles are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model SensorReading {

--- a/test/integration/relation-filters.test.ts
+++ b/test/integration/relation-filters.test.ts
@@ -1,27 +1,13 @@
 // Relation filters in timeBucket where, end-to-end on real TimescaleDB. The generator extracts
 // relation metadata (to-one `device`, composite-key to-many `tags`) into the registry, and the
 // runtime builds EXISTS subqueries. Counts mirror the research probe's Prisma results.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED relation-filters.test.ts: Docker is not available. Relation filters are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Relation filters are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {

--- a/test/integration/reset-safety.test.ts
+++ b/test/integration/reset-safety.test.ts
@@ -1,27 +1,13 @@
 // THE reset-safety proof (BUILD_PLAN M5): apply the GENERATED migrations through Prisma's
 // engine on a real TimescaleDB, then `migrate reset` twice and confirm the hypertable +
 // continuous aggregate + policy are reproduced with zero manual steps and zero errors.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED: Docker is not available. The reset-safety guarantee is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("The reset-safety guarantee is NOT verified.");
 
 async function counts(h: Harness) {
   const [hyper] = await h.query<{ n: number }>(

--- a/test/integration/retention.test.ts
+++ b/test/integration/retention.test.ts
@@ -1,27 +1,13 @@
 // Retention policies end-to-end on a real TimescaleDB: the generator emits a reset-safe
 // add_retention_policy from @timescale.retention, and the $timescale runtime helpers
 // add/remove a policy. Verified against timescaledb_information.jobs.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED retention.test.ts: Docker is not available. Retention policies are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Retention policies are NOT verified.");
 
 // Hypertable-only schema with a retention policy (matches the harness default CREATE TABLE).
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")

--- a/test/integration/runtime-search-path.test.ts
+++ b/test/integration/runtime-search-path.test.ts
@@ -9,27 +9,13 @@
 //
 // Prisma's own queries survive it, because the engine schema-qualifies the relations it
 // generates. This covers the raw SQL, which does not.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED runtime-search-path.test.ts: Docker is not available. Runtime queries under a narrowed search path are NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Runtime queries under a narrowed search path are NOT verified.");
 
 // The tables live in the service's own schema and the search path points at them, which is what
 // `?schema=data_collection` plus a matching role default gives you. Relations therefore still

--- a/test/integration/set-chunk-interval.test.ts
+++ b/test/integration/set-chunk-interval.test.ts
@@ -2,25 +2,13 @@
 // $timescale().setChunkInterval -> set_partitioning_interval. The default harness hypertable is
 // created with chunkInterval "1 day"; we resize it and confirm via timescaledb_information.dimensions.
 // Runtime-only feature (no migration emitted), so no migrate-reset assertion is needed.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED set-chunk-interval.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Setting the chunk interval at runtime is NOT verified.");
 
 /** The hypertable's current time-dimension chunk interval, in seconds (robust to interval display). */
 async function chunkIntervalSeconds(h: Harness): Promise<number> {

--- a/test/integration/space-partition.test.ts
+++ b/test/integration/space-partition.test.ts
@@ -1,22 +1,10 @@
 // Hash space partitioning end-to-end on real TimescaleDB: the generator emits a reset-safe
 // add_dimension(by_hash(...)) from partitionColumn / partitions, giving the hypertable a second
 // (space) dimension. Verified against timescaledb_information.dimensions, including migrate reset.
-import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness } from "./harness.js";
+import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED space-partition.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("Space partitioning is NOT verified.");
 
 // deviceId is in the @@id, so it's eligible as a partitioning column. Matches the harness default
 // CREATE TABLE (time / deviceId / temperature).

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -1,25 +1,13 @@
 // Toolkit stats_agg (1-D) in timeBucket, end-to-end on real TimescaleDB (the `-ha` image carries
 // timescaledb_toolkit). One op returns the 1-D statistical summary as a JS object per bucket
 // (jsonb_build_object over a single stats_agg(value)). Three values make the moments predictable.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED stats.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's stats_agg summaries are NOT verified.");
 
 const range = { start: new Date("2026-06-15T00:00:00Z"), end: new Date("2026-06-15T01:00:00Z") };
 

--- a/test/integration/timezone.test.ts
+++ b/test/integration/timezone.test.ts
@@ -1,25 +1,13 @@
 // timezone / offset for timeBucket, end-to-end on real TimescaleDB. Two rows straddling UTC
 // midnight bucket into ONE local day under a +2h timezone but TWO buckets under default UTC —
 // the DST-aware calendar behaviour. Requires a timestamptz column (@db.Timestamptz).
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn("\n[integration] SKIPPED timezone.test.ts: Docker is not available. Not verified.\n");
-}
+const DOCKER_OK = dockerAvailable("timeBucket's timezone and offset handling is NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {

--- a/test/integration/where-insensitive.test.ts
+++ b/test/integration/where-insensitive.test.ts
@@ -2,27 +2,13 @@
 // parity with Prisma's own engine (findMany count on the same filter), proving the LOWER(...)
 // translation matches what Prisma emits for insensitive equality, lists, comparisons, and
 // negation — including NULL exclusion.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED where-insensitive.test.ts: Docker is not available. Insensitive mode is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Insensitive mode is NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {

--- a/test/integration/where-not.test.ts
+++ b/test/integration/where-not.test.ts
@@ -1,27 +1,13 @@
 // Nested `not: { ... }` in timeBucket where, end-to-end on real TimescaleDB. Proves the SQL
 // executes and that negation excludes NULL rows — matching Prisma's findMany (verified by the
 // research probe). Uses a nullable column so the NULL-exclusion is observable.
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startHarness, type Harness, type TestPrismaClient } from "./harness.js";
+import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = (() => {
-  try {
-    execFileSync("docker", ["info"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-})();
-
-if (!DOCKER_OK) {
-  console.warn(
-    "\n[integration] SKIPPED where-not.test.ts: Docker is not available. Nested not is NOT verified.\n",
-  );
-}
+const DOCKER_OK = dockerAvailable("Nested not is NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {

--- a/test/integration/where-not.test.ts
+++ b/test/integration/where-not.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startHarness, type Harness, type TestPrismaClient, dockerAvailable } from "./harness.js";
 import { timescaledb } from "../../src/client/index.js";
 
-const DOCKER_OK = dockerAvailable("Nested not is NOT verified.");
+const DOCKER_OK = dockerAvailable("Nested NOT filters are NOT verified.");
 
 const MODELS = `/// @timescale.hypertable(column: "time", chunkInterval: "1 day")
 model Reading {


### PR DESCRIPTION
Closes #131

> **Base is `fix/non-public-search-path-129`, not `main`.** This touches all 33 integration files, five of which only exist on #130. Basing it on `main` would leave those five on the old pattern and conflict. Once #130 squash-merges, `git rebase --onto main` and retarget. Review after #130.

## The problem

Every integration file carried its own copy of this:

```ts
const DOCKER_OK = (() => {
  try {
    execFileSync("docker", ["info"], { stdio: "ignore" });
    return true;
  } catch {
    return false;
  }
})();
```

Thirty-three single-shot probes per run. One busy-daemon hiccup and that file skips itself, the run still reports green, and coverage is gone with nothing said.

CI is where it bites. The workflow comment already notes that ubuntu-latest runners ship Docker, so a skip there cannot mean "no Docker on this machine". It means something broke, the reset-safety proof did not run, and the branch ruleset was satisfied anyway.

## The second half was broken too

CLAUDE.md says "if Docker is unavailable, skip and say so loudly". The saying-so never worked. `console.warn` at module scope is buffered per test by vitest and dropped for a file whose tests are all skipped. With `docker` forced to fail, the old code printed nothing at all:

```
 Test Files  1 skipped (1)
      Tests  3 skipped (3)
```

## The change

`dockerAvailable()` in the harness replaces all 33 copies. It retries, it throws where Docker is expected, and it writes to stderr so the notice survives.

```ts
const DOCKER_OK = dockerAvailable("Retention policies are NOT verified.");
```

Fifteen files had drifted to a bare `"Not verified."`, the filename carrying whatever meaning there was. Each now names what it covers, since vitest already prints the filename.

The CI job sets `REQUIRE_DOCKER: "1"` explicitly rather than leaning on GitHub's `CI=true`, so the intent is visible where a reader looks for it.

## Verified both paths

With a `docker` on PATH that exits 1:

```
$ CI= REQUIRE_DOCKER= npx vitest run --config vitest.integration.config.ts test/integration/retention.test.ts

[integration] SKIPPED: Docker is not available. Retention policies are NOT verified.

 Test Files  1 skipped (1)
```

```
$ REQUIRE_DOCKER=1 npx vitest run --config vitest.integration.config.ts test/integration/retention.test.ts

Error: [integration] Docker is required here (CI, or REQUIRE_DOCKER=1) but `docker info` failed 3 times.
Failing instead of skipping: Retention policies are NOT verified.

 Test Files  1 failed (1)
```

With Docker present the suite is unchanged: 33 files, 96 tests.

## Second commit: the harness startup path

Research on #131 settled what the reported counters mean. `@vitest/runner` 4.1.11 catches a throwing `beforeAll`, calls `failTask` on the suite, then `markTasksAsSkipped` over its children: file failed, tests skipped, total unchanged. Exactly `1 failed | 32 passed (33)` with `95 passed | 1 skipped (96)`. An `afterAll` failure is excluded by those numbers, since it fails the file while its tests stay passed. So it was a `beforeAll` throw, in one of the nine files holding a single test.

It also corrected me. Measuring the readiness poll at one attempt out of thirty proved less than I claimed: the image declares no HEALTHCHECK (`docker inspect` returns `null`), so testcontainers falls back to `Wait.forListeningPorts()`, and a bound port does not mean Postgres will accept a connection.

Three changes follow:

- **Wait strategy**: the port check *and* the ready line seen twice, which is what separates the real server from the throwaway one the entrypoint runs init scripts against. Verified in the container logs; startup cost unchanged at roughly two seconds.
- **Retry `CREATE DATABASE shadow`**: it ran exactly once, unguarded, between container start and the first test. That is the shape of failure that surfaces as a `beforeAll` throw a few hundred container starts apart. "Already exists" counts as success rather than something to retry into.
- **Keep the evidence**: startup steps are wrapped so a failure names the step and carries the container log tail, where Postgres writes the reason it refused. Forcing the shadow step to fail now reports `[harness] failed while creating the shadow database: ...` followed by the log.

## What this does not do

It does not identify the original trigger, and does not claim to. Hammering `CREATE DATABASE` over ten container cycles produced no failure, but at roughly one event per few hundred starts ten samples has almost no power, so that is not evidence of absence. Research into known testcontainers-node and Docker Desktop churn failures produced nothing that survived adversarial verification, which at least suggests this is not a known upstream bug.

What it does is make a skipped file impossible to mistake for a passing run, and make the next occurrence leave something behind to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T17sEeg5h4mdqSSbeLM2k



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Standardized Docker availability checks across integration tests.
  - Integration tests now provide clearer skip diagnostics when Docker is unavailable.
  - Docker-dependent tests fail explicitly in CI or when Docker is required, rather than being silently skipped.
  - Improved container startup reliability with readiness checks, retries, and more detailed failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->