### PR TITLE
test(integration): turn TimescaleDB telemetry off on the shadow database

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,25 @@ export default defineConfig({
 
 Tiger Cloud rejects Prisma's auto-created shadow-database name, so a dedicated
 `shadowDatabaseUrl` is mandatory there; this package cannot paper over it.
+
+Turn TimescaleDB telemetry off on the shadow database once, after you create it:
+
+```sql
+ALTER DATABASE shadow SET timescaledb.telemetry_level = 'off';
+```
+
+Without it, `migrate dev` can fail intermittently with `P3016` and
+`cannot drop continuous aggregate using DROP VIEW` when the schema declares a
+continuous aggregate. Prisma resets the shadow with `DROP SCHEMA "public"
+CASCADE` before each use, which also drops the extension when it lives in
+`public`. Re-creating the extension restarts TimescaleDB's telemetry job, which
+holds locks on the extension catalog while it builds its report; a reset that
+arrives in that window deadlocks, Prisma silently falls back to a per-view
+`DROP VIEW`, and that fails on the aggregate. With telemetry off the job takes
+no locks. Dropping the aggregates from the shadow yourself before `migrate dev`
+does not cover this, because the migrations re-create them inside the command
+and the later resets of the same command still see them. In CI you can set it
+for the whole server instead with `-c timescaledb.telemetry_level=off`.
 Full details in
 [Setup → Shadow database](https://github.com/Krister-Johansson/prisma-extension-timescaledb/wiki/Setup#shadow-database).
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ export default defineConfig({
 Tiger Cloud rejects Prisma's auto-created shadow-database name, so a dedicated
 `shadowDatabaseUrl` is mandatory there; this package cannot paper over it.
 
-Turn TimescaleDB telemetry off on the shadow database once, after you create it:
+Turn TimescaleDB telemetry off on the shadow database once, after you create
+it. `shadow` here is the database name from your `shadowDatabaseUrl`; the
+repo's `docker/init-shadow-db.sql` already does this for the local setup:
 
 ```sql
 ALTER DATABASE shadow SET timescaledb.telemetry_level = 'off';

--- a/docker/init-shadow-db.sql
+++ b/docker/init-shadow-db.sql
@@ -10,3 +10,10 @@
 -- here as well can trigger the "extension already loaded with another version" clash.
 
 CREATE DATABASE shadow;
+
+-- Prisma resets the shadow with `DROP SCHEMA "public" CASCADE` before every use, which also
+-- drops the extension. Re-creating it restarts TimescaleDB's telemetry job, which holds locks on
+-- the extension catalog while it builds its report; a reset that arrives in that window
+-- deadlocks, Prisma falls back to `DROP VIEW`, and that fails on a continuous aggregate (P3016).
+-- With telemetry off the job takes no locks. See the README's "Shadow database" section.
+ALTER DATABASE shadow SET timescaledb.telemetry_level = 'off';

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -148,6 +148,20 @@ export async function startHarness(opts: HarnessOptions = {}): Promise<Harness> 
     await withContainerLogs(container, "creating the shadow database", () =>
       retry(() => runOnce(`${baseUrl}/postgres`, "CREATE DATABASE shadow")),
     );
+    // Prisma resets the shadow with `DROP SCHEMA "public" CASCADE` before each of the three shadow
+    // uses inside one `migrate dev`. The image installs the extension into `public`, so every
+    // reset drops it and kills the shadow's TimescaleDB scheduler; the first migration re-creates
+    // the extension, the scheduler restarts, and its first act is the "Telemetry Reporter" job,
+    // which builds its report in one transaction while holding AccessShareLocks on the extension
+    // catalog. A reset that lands in that window deadlocks on `_timescaledb_catalog.bgw_job`,
+    // Prisma swallows the error and falls back to `best_effort_reset`, and THAT issues `DROP VIEW`
+    // on the continuous aggregate: the intermittent P3016 of issue #135. With telemetry off the
+    // job returns before opening a transaction and never holds a lock. Verified with the
+    // interleaving pinned: 20/20 failures with telemetry on, 0/20 with it off. Database-level
+    // settings are honoured by the background worker, so the app database keeps its defaults.
+    await withContainerLogs(container, "disabling TimescaleDB telemetry on the shadow database", () =>
+      retry(() => runOnce(`${baseUrl}/postgres`, "ALTER DATABASE shadow SET timescaledb.telemetry_level = 'off'")),
+    );
 
     const dir = mkdtempSync(join(REPO_ROOT, ".tmp-int-"));
     try {

--- a/test/integration/migrate-dev-drift.test.ts
+++ b/test/integration/migrate-dev-drift.test.ts
@@ -14,6 +14,7 @@
 // only thing that creates indexes on the table, so there is nothing for Prisma to read as drift.
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startHarness, type Harness, dockerAvailable } from "./harness.js";
 
@@ -53,6 +54,24 @@ describe.skipIf(!DOCKER_OK)("migrate dev after a hypertable conversion", () => {
 
   it("creates only the indexes the Prisma schema declares", async () => {
     expect(await indexes(h)).toEqual(["SensorReading_deviceId_time_idx", "SensorReading_pkey"]);
+  });
+
+  // Both `migrate dev` calls below reset the shadow three times each, and every reset drops and
+  // re-creates the extension. That restarts TimescaleDB's telemetry job, whose catalog locks can
+  // deadlock the next reset and send Prisma down `best_effort_reset`, which drops the continuous
+  // aggregate with `DROP VIEW` and fails with P3016 (issue #135). The harness turns telemetry off
+  // on the shadow database for that reason; this pins it, so the flake cannot return unnoticed.
+  it("runs migrate dev against a shadow database with TimescaleDB telemetry off", async () => {
+    const client = new pg.Client({ connectionString: h.shadowUrl });
+    await client.connect();
+    try {
+      const { rows } = await client.query<{ level: string }>(
+        "SELECT current_setting('timescaledb.telemetry_level') AS level",
+      );
+      expect(rows[0]?.level).toBe("off");
+    } finally {
+      await client.end();
+    }
   });
 
   it("writes no drift migration on migrate dev --create-only (the documented flow)", () => {


### PR DESCRIPTION
Closes #135

## What changed

The integration harness runs `ALTER DATABASE shadow SET timescaledb.telemetry_level = 'off'` right after it creates the shadow database. The migrate-dev-drift test asserts that a session on the shadow sees the setting, so the mitigation cannot be removed without a red test. The README's shadow database section tells users with a dedicated shadow database to do the same and explains why.

## Why

The P3016 in #135 is a deadlock between Prisma's shadow reset and TimescaleDB's telemetry job, established against Prisma 7.10.0 engine source and real TimescaleDB 2.27.2 containers:

1. With `shadowDatabaseUrl` set, Prisma resets the shadow with `DROP SCHEMA "public" CASCADE` before each of the three shadow uses inside one `migrate dev` (DevDiagnostic twice, EvaluateDataLoss once). Only if that statement fails does it fall back to `best_effort_reset`, and it discards the failure reason.
2. The timescaledb-ha image installs the extension into `public`, so the reset drops the extension and kills the shadow's TimescaleDB scheduler. The first migration re-creates the extension, the scheduler restarts, and its first act is the Telemetry Reporter job.
3. That job builds its report in one transaction while holding AccessShareLocks on the extension catalog. If the next reset arrives in that window, the DROP blocks on `_timescaledb_catalog.bgw_job`, the job then asks for a relation the DROP holds, and Postgres picks the DROP as the deadlock victim. Prisma swallows the deadlock, `best_effort_reset` issues `DROP VIEW` on the continuous aggregate, and that is the P3016 the issue reports.
4. Both CI traces in the issue (EvaluateDataLoss, and validate_migrations under DevDiagnostic) are this path at two of the three shadow uses of one command.

With telemetry off the job returns before opening a transaction and holds no locks. In a standalone repro with the interleaving pinned, the sequence failed 20 of 20 times with telemetry on and 0 of 20 with it off, and the Postgres log showed `deadlock detected` for the DROP followed by `cannot drop continuous aggregate using DROP VIEW`.

Dropping the aggregate from the shadow before `migrate dev` does not cover this. It only removes the aggregate left by the previous command; the migrations re-create it inside the command, and the second and third resets of that same command still find it.

## What this does not do

It avoids the trigger rather than fixing the root cause, which is that Prisma's reset drops the extension at all and hides the hard reset's error. Any other TimescaleDB background job that reads the catalog at the wrong moment could form the same cycle; the refresh policy job never did in over 200 local sequences. Two upstream items remain: ask Prisma to surface the hard reset error in the engine log, and consider installing the extension outside `public` in the shadow database. The wiki Setup page should get the same paragraph as the README.

## Verification

- migrate-dev-drift ran 5 of 5 green locally with the new assertion.
- Unit suite: 336 passed. Full integration suite: 97 passed across 33 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shadow database resets to avoid intermittent migration failures caused by TimescaleDB telemetry jobs.
  - TimescaleDB telemetry is now disabled on shadow databases while remaining enabled on application databases.

- **Documentation**
  - Added setup guidance for disabling shadow database telemetry, including a SQL command and a server-wide CI configuration alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->